### PR TITLE
chore: deploy prerelease packages by CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,12 +75,14 @@ jobs:
               circleci step halt
             fi
       - checkout
+      - init-dependencies
       - run: npm install lerna
       - run:
           name: Setup npmjs
           command: bash .circleci/setup-npmjs.sh
-      - init-dependencies
-      - run: make nightly
+      - run:
+          name: Build & Deploy nightly version
+          command: bash .circleci/deploy-nightly-version.sh
 
 workflows:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,8 +61,26 @@ jobs:
           command: yarn run coverage:send
       - store_artifacts:
           path: ./packages/core/coverage
-      # - store_artifacts:
-      #     path: ./packages/core/.nyc_output
+
+  deploy-preview:
+    parameters:
+    docker:
+      - image: circleci/node:12
+    steps:
+      - run:
+          name: Early return if this build is from a forked repository
+          command: |
+            if [[ $CIRCLE_PROJECT_USERNAME != "influxdata" ]]; then
+              echo "Nothing to do for forked repositories, so marking this step successful"
+              circleci step halt
+            fi
+      - checkout
+      - run: npm install lerna
+      - run:
+          name: Setup npmjs
+          command: bash .circleci/setup-npmjs.sh
+      - init-dependencies
+      - run: make nightly
 
 workflows:
   build:
@@ -70,3 +88,10 @@ workflows:
       - unit-tests:
           version: '12'
       - coverage
+      - deploy-preview:
+          requires:
+            - unit-tests
+            - coverage
+          filters:
+            branches:
+              only: master

--- a/.circleci/deploy-nightly-version.sh
+++ b/.circleci/deploy-nightly-version.sh
@@ -1,0 +1,7 @@
+VERSION=$(cat packages/core/src/impl/version.ts | sed 's/[^0-9.]*//g' | awk -F. '{$2+=1; OFS="."; print $1"."$2"."$3}')
+sed -i -e "s/CLIENT_LIB_VERSION = '.*'/CLIENT_LIB_VERSION = '${VERSION}.nightly'/" packages/core/src/impl/version.ts
+git config user.name "CircleCI Builder"
+git config user.email "noreply@influxdata.com"
+git commit -am "chore(release): prepare to release influxdb-client-js-${VERSION}.nightly"
+yarn run build
+yarn lerna publish --canary preminor --no-git-tag-version --force-publish --preid nightly --yes

--- a/.circleci/setup-npmjs.sh
+++ b/.circleci/setup-npmjs.sh
@@ -1,0 +1,2 @@
+echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+chmod 0600 ~/.npmrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ### Security
 1. [#157](https://github.com/influxdata/influxdb-client-js/issues/157): [ESLint dependencies are vulnerable (ReDoS and Prototype Pollution)](https://github.com/advisories/GHSA-7fhm-mqm4-2wp7)
 
+### CI
+1. [#167](https://github.com/influxdata/influxdb-client-js/pull/167): The CircleCI publish prerelease packages
+
 ## 1.1.0 [2020-03-13]
 
 ### Features

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo ""
 	@echo "  publish    to publish packages to specified version by VERSION property. make publish VERSION=1.1.0"
+	@echo "  nightly    to publish nightly build"
 	@echo ""
 
 publish:
@@ -21,5 +22,10 @@ publish:
 	@echo ""
 	@echo "Next steps:"
 	@echo " - add new version to CHANGELOG.md"
-	@echo " - push changes to repository by : \"git commit -am 'prepare to next development iteration' && git push\""
+	@echo " - push changes to repository by : \"git commit -am 'chore(release): prepare to next development iteration [skip CI]' && git push\""
 	@echo ""
+
+nightly:
+	yarn install --frozen-lockfile
+	yarn run build
+	yarn lerna publish --canary preminor --no-git-tag-version --force-publish --yes

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ publish:
 	yarn run build
 	yarn run test
 	@echo "Publishing $(VERSION)..."
-	git commit -am "prepare to release influxdb-client-js-$(VERSION)"
+	git commit -am "chore(release): prepare to release influxdb-client-js-$(VERSION)"
 	lerna publish $(VERSION)
 	@echo "Publish successful"
 	@echo ""
@@ -27,5 +27,8 @@ publish:
 
 nightly:
 	yarn install --frozen-lockfile
+	$(eval VERSION=$(shell cat packages/core/src/impl/version.ts | sed 's/[^0-9.]*//g' | awk -F. '{$$2+=1; OFS="."; print $0}'))
+	sed -i '' -e "s/CLIENT_LIB_VERSION = '.*'/CLIENT_LIB_VERSION = '$(VERSION).nightly'/" packages/core/src/impl/version.ts
+	git commit -am "chore(release): prepare to release influxdb-client-js-$(VERSION).nightly"
 	yarn run build
-	yarn lerna publish --canary preminor --no-git-tag-version --force-publish --yes
+	yarn lerna publish --canary preminor --no-git-tag-version --force-publish --preid nightly --yes

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo ""
 	@echo "  publish    to publish packages to specified version by VERSION property. make publish VERSION=1.1.0"
-	@echo "  nightly    to publish nightly build"
 	@echo ""
 
 publish:
@@ -24,11 +23,3 @@ publish:
 	@echo " - add new version to CHANGELOG.md"
 	@echo " - push changes to repository by : \"git commit -am 'chore(release): prepare to next development iteration [skip CI]' && git push\""
 	@echo ""
-
-nightly:
-	yarn install --frozen-lockfile
-	$(eval VERSION=$(shell cat packages/core/src/impl/version.ts | sed 's/[^0-9.]*//g' | awk -F. '{$$2+=1; OFS="."; print $0}'))
-	sed -i '' -e "s/CLIENT_LIB_VERSION = '.*'/CLIENT_LIB_VERSION = '$(VERSION).nightly'/" packages/core/src/impl/version.ts
-	git commit -am "chore(release): prepare to release influxdb-client-js-$(VERSION).nightly"
-	yarn run build
-	yarn lerna publish --canary preminor --no-git-tag-version --force-publish --preid nightly --yes

--- a/lerna.json
+++ b/lerna.json
@@ -6,7 +6,7 @@
   ],
   "command": {
     "version": {
-      "message": "chore(release): publish %s"
+      "message": "chore(release): publish %s [skip CI]"
     }
   }
 }


### PR DESCRIPTION
Fixes #164

## Proposed Changes

The CircleCI publish prerelease packages. Package versions looks like:

```
Found 2 packages to publish:
 - @influxdata/influxdb-client-apis => 1.2.0-alpha.6+a9851da
 - @influxdata/influxdb-client => 1.2.0-alpha.6+a9851da
```

## Checklist

  - [x] CHANGELOG.md updated
  - [x] A test has been added if appropriate
  - [x] `yarn test` completes successfully
  - [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
