### PR TITLE
fix(docs): use better links in code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,20 @@
 ## 1.2.0 [unreleased]
 
-### Bug
-1. [#160](https://github.com/influxdata/influxdb-client-js/issues/160): Disabled using credentials for CORS 
+### Features
+
+### Bug Fixes
+
+1. [#160](https://github.com/influxdata/influxdb-client-js/issues/160): Disabled using credentials for CORS
+1. [#173](https://github.com/influxdata/influxdb-client-js/pull/173): use links that are clickable in VSCode
 
 ### Security
+
 1. [#157](https://github.com/influxdata/influxdb-client-js/issues/157): [ESLint dependencies are vulnerable (ReDoS and Prototype Pollution)](https://github.com/advisories/GHSA-7fhm-mqm4-2wp7)
 
 ## 1.1.0 [2020-03-13]
 
 ### Features
+
 1. [#152](https://github.com/influxdata/influxdb-client-js/issues/152): Set User-Agent to influxdb-client-js/VERSION for all requests
 
 ## 1.0.0 [2020-03-09]

--- a/packages/apis/generator/generateApi.ts
+++ b/packages/apis/generator/generateApi.ts
@@ -94,9 +94,9 @@ function generateClass(
   apiName: string,
   operations: Operation[]
 ): string {
-  let classDef = '/**\n'
+  let classDef = '/**\n * See\n'
   for (const operation of operations) {
-    classDef += ` * See https://v2.docs.influxdata.com/v2.0/api/#operation/${getOperationId(
+    classDef += ` * * https://v2.docs.influxdata.com/v2.0/api/#operation/${getOperationId(
       operation
     )}\n`
   }

--- a/packages/apis/generator/generateApi.ts
+++ b/packages/apis/generator/generateApi.ts
@@ -96,7 +96,7 @@ function generateClass(
 ): string {
   let classDef = '/**\n'
   for (const operation of operations) {
-    classDef += ` * @see https://v2.docs.influxdata.com/v2.0/api/#operation/${getOperationId(
+    classDef += ` * See https://v2.docs.influxdata.com/v2.0/api/#operation/${getOperationId(
       operation
     )}\n`
   }
@@ -124,9 +124,9 @@ export class ${apiName} extends APIBase {
       classDef += '\n  /**'
     }
     classDef += `
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/${opId}
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/${opId}
    */
   ${decapitalize1(opId)}(request${
       requestRequired(operation) ? '' : '?'

--- a/packages/apis/src/generated/AuthorizationsAPI.ts
+++ b/packages/apis/src/generated/AuthorizationsAPI.ts
@@ -34,11 +34,12 @@ export interface DeleteAuthorizationsIDRequest {
   authID: string
 }
 /**
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetAuthorizations
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostAuthorizations
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetAuthorizationsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchAuthorizationsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteAuthorizationsID
+ * See
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetAuthorizations
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostAuthorizations
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetAuthorizationsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PatchAuthorizationsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteAuthorizationsID
  */
 export class AuthorizationsAPI extends APIBase {
   /**

--- a/packages/apis/src/generated/AuthorizationsAPI.ts
+++ b/packages/apis/src/generated/AuthorizationsAPI.ts
@@ -34,11 +34,11 @@ export interface DeleteAuthorizationsIDRequest {
   authID: string
 }
 /**
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetAuthorizations
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostAuthorizations
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetAuthorizationsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchAuthorizationsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteAuthorizationsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetAuthorizations
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostAuthorizations
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetAuthorizationsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchAuthorizationsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteAuthorizationsID
  */
 export class AuthorizationsAPI extends APIBase {
   /**
@@ -49,9 +49,9 @@ export class AuthorizationsAPI extends APIBase {
   }
   /**
    * List all authorizations.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetAuthorizations
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetAuthorizations
    */
   getAuthorizations(
     request?: GetAuthorizationsRequest,
@@ -71,9 +71,9 @@ export class AuthorizationsAPI extends APIBase {
   }
   /**
    * Create an authorization.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostAuthorizations
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostAuthorizations
    */
   postAuthorizations(
     request: PostAuthorizationsRequest,
@@ -89,9 +89,9 @@ export class AuthorizationsAPI extends APIBase {
   }
   /**
    * Retrieve an authorization.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetAuthorizationsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetAuthorizationsID
    */
   getAuthorizationsID(
     request: GetAuthorizationsIDRequest,
@@ -106,9 +106,9 @@ export class AuthorizationsAPI extends APIBase {
   }
   /**
    * Update an authorization to be active or inactive.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchAuthorizationsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchAuthorizationsID
    */
   patchAuthorizationsID(
     request: PatchAuthorizationsIDRequest,
@@ -124,9 +124,9 @@ export class AuthorizationsAPI extends APIBase {
   }
   /**
    * Delete a authorization.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteAuthorizationsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteAuthorizationsID
    */
   deleteAuthorizationsID(
     request: DeleteAuthorizationsIDRequest,

--- a/packages/apis/src/generated/BucketsAPI.ts
+++ b/packages/apis/src/generated/BucketsAPI.ts
@@ -97,21 +97,22 @@ export interface GetBucketsIDLogsRequest {
   limit?: number
 }
 /**
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetBuckets
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostBuckets
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchBucketsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteBucketsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsIDLabels
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostBucketsIDLabels
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteBucketsIDLabelsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsIDMembers
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostBucketsIDMembers
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteBucketsIDMembersID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsIDOwners
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostBucketsIDOwners
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteBucketsIDOwnersID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsIDLogs
+ * See
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetBuckets
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostBuckets
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PatchBucketsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteBucketsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsIDLabels
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostBucketsIDLabels
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteBucketsIDLabelsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsIDMembers
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostBucketsIDMembers
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteBucketsIDMembersID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsIDOwners
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostBucketsIDOwners
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteBucketsIDOwnersID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsIDLogs
  */
 export class BucketsAPI extends APIBase {
   /**

--- a/packages/apis/src/generated/BucketsAPI.ts
+++ b/packages/apis/src/generated/BucketsAPI.ts
@@ -97,21 +97,21 @@ export interface GetBucketsIDLogsRequest {
   limit?: number
 }
 /**
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetBuckets
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostBuckets
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchBucketsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteBucketsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsIDLabels
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostBucketsIDLabels
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteBucketsIDLabelsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsIDMembers
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostBucketsIDMembers
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteBucketsIDMembersID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsIDOwners
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostBucketsIDOwners
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteBucketsIDOwnersID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsIDLogs
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetBuckets
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostBuckets
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchBucketsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteBucketsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsIDLabels
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostBucketsIDLabels
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteBucketsIDLabelsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsIDMembers
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostBucketsIDMembers
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteBucketsIDMembersID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsIDOwners
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostBucketsIDOwners
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteBucketsIDOwnersID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsIDLogs
  */
 export class BucketsAPI extends APIBase {
   /**
@@ -122,9 +122,9 @@ export class BucketsAPI extends APIBase {
   }
   /**
    * List all buckets.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetBuckets
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetBuckets
    */
   getBuckets(
     request?: GetBucketsRequest,
@@ -145,9 +145,9 @@ export class BucketsAPI extends APIBase {
   }
   /**
    * Create a bucket.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostBuckets
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostBuckets
    */
   postBuckets(
     request: PostBucketsRequest,
@@ -163,9 +163,9 @@ export class BucketsAPI extends APIBase {
   }
   /**
    * Retrieve a bucket.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsID
    */
   getBucketsID(
     request: GetBucketsIDRequest,
@@ -180,9 +180,9 @@ export class BucketsAPI extends APIBase {
   }
   /**
    * Update a bucket.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchBucketsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchBucketsID
    */
   patchBucketsID(
     request: PatchBucketsIDRequest,
@@ -198,9 +198,9 @@ export class BucketsAPI extends APIBase {
   }
   /**
    * Delete a bucket.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteBucketsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteBucketsID
    */
   deleteBucketsID(
     request: DeleteBucketsIDRequest,
@@ -215,9 +215,9 @@ export class BucketsAPI extends APIBase {
   }
   /**
    * List all labels for a bucket.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsIDLabels
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsIDLabels
    */
   getBucketsIDLabels(
     request: GetBucketsIDLabelsRequest,
@@ -232,9 +232,9 @@ export class BucketsAPI extends APIBase {
   }
   /**
    * Add a label to a bucket.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostBucketsIDLabels
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostBucketsIDLabels
    */
   postBucketsIDLabels(
     request: PostBucketsIDLabelsRequest,
@@ -250,9 +250,9 @@ export class BucketsAPI extends APIBase {
   }
   /**
    * delete a label from a bucket.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteBucketsIDLabelsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteBucketsIDLabelsID
    */
   deleteBucketsIDLabelsID(
     request: DeleteBucketsIDLabelsIDRequest,
@@ -267,9 +267,9 @@ export class BucketsAPI extends APIBase {
   }
   /**
    * List all users with member privileges for a bucket.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsIDMembers
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsIDMembers
    */
   getBucketsIDMembers(
     request: GetBucketsIDMembersRequest,
@@ -284,9 +284,9 @@ export class BucketsAPI extends APIBase {
   }
   /**
    * Add a member to a bucket.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostBucketsIDMembers
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostBucketsIDMembers
    */
   postBucketsIDMembers(
     request: PostBucketsIDMembersRequest,
@@ -302,9 +302,9 @@ export class BucketsAPI extends APIBase {
   }
   /**
    * Remove a member from a bucket.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteBucketsIDMembersID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteBucketsIDMembersID
    */
   deleteBucketsIDMembersID(
     request: DeleteBucketsIDMembersIDRequest,
@@ -319,9 +319,9 @@ export class BucketsAPI extends APIBase {
   }
   /**
    * List all owners of a bucket.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsIDOwners
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsIDOwners
    */
   getBucketsIDOwners(
     request: GetBucketsIDOwnersRequest,
@@ -336,9 +336,9 @@ export class BucketsAPI extends APIBase {
   }
   /**
    * Add an owner to a bucket.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostBucketsIDOwners
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostBucketsIDOwners
    */
   postBucketsIDOwners(
     request: PostBucketsIDOwnersRequest,
@@ -354,9 +354,9 @@ export class BucketsAPI extends APIBase {
   }
   /**
    * Remove an owner from a bucket.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteBucketsIDOwnersID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteBucketsIDOwnersID
    */
   deleteBucketsIDOwnersID(
     request: DeleteBucketsIDOwnersIDRequest,
@@ -371,9 +371,9 @@ export class BucketsAPI extends APIBase {
   }
   /**
    * Retrieve operation logs for a bucket.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsIDLogs
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetBucketsIDLogs
    */
   getBucketsIDLogs(
     request: GetBucketsIDLogsRequest,

--- a/packages/apis/src/generated/ChecksAPI.ts
+++ b/packages/apis/src/generated/ChecksAPI.ts
@@ -61,16 +61,16 @@ export interface GetChecksIDQueryRequest {
   checkID: string
 }
 /**
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetChecks
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/CreateCheck
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetChecksID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PutChecksID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchChecksID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteChecksID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetChecksIDLabels
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostChecksIDLabels
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteChecksIDLabelsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetChecksIDQuery
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetChecks
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/CreateCheck
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetChecksID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PutChecksID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchChecksID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteChecksID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetChecksIDLabels
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostChecksIDLabels
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteChecksIDLabelsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetChecksIDQuery
  */
 export class ChecksAPI extends APIBase {
   /**
@@ -81,9 +81,9 @@ export class ChecksAPI extends APIBase {
   }
   /**
    * Get all checks.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetChecks
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetChecks
    */
   getChecks(
     request: GetChecksRequest,
@@ -102,9 +102,9 @@ export class ChecksAPI extends APIBase {
   }
   /**
    * Add new check.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/CreateCheck
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/CreateCheck
    */
   createCheck(
     request: CreateCheckRequest,
@@ -120,9 +120,9 @@ export class ChecksAPI extends APIBase {
   }
   /**
    * Get a check.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetChecksID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetChecksID
    */
   getChecksID(
     request: GetChecksIDRequest,
@@ -137,9 +137,9 @@ export class ChecksAPI extends APIBase {
   }
   /**
    * Update a check.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PutChecksID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PutChecksID
    */
   putChecksID(
     request: PutChecksIDRequest,
@@ -155,9 +155,9 @@ export class ChecksAPI extends APIBase {
   }
   /**
    * Update a check.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchChecksID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchChecksID
    */
   patchChecksID(
     request: PatchChecksIDRequest,
@@ -173,9 +173,9 @@ export class ChecksAPI extends APIBase {
   }
   /**
    * Delete a check.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteChecksID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteChecksID
    */
   deleteChecksID(
     request: DeleteChecksIDRequest,
@@ -190,9 +190,9 @@ export class ChecksAPI extends APIBase {
   }
   /**
    * List all labels for a check.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetChecksIDLabels
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetChecksIDLabels
    */
   getChecksIDLabels(
     request: GetChecksIDLabelsRequest,
@@ -207,9 +207,9 @@ export class ChecksAPI extends APIBase {
   }
   /**
    * Add a label to a check.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostChecksIDLabels
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostChecksIDLabels
    */
   postChecksIDLabels(
     request: PostChecksIDLabelsRequest,
@@ -225,9 +225,9 @@ export class ChecksAPI extends APIBase {
   }
   /**
    * Delete label from a check.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteChecksIDLabelsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteChecksIDLabelsID
    */
   deleteChecksIDLabelsID(
     request: DeleteChecksIDLabelsIDRequest,
@@ -242,9 +242,9 @@ export class ChecksAPI extends APIBase {
   }
   /**
    * Get a check query.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetChecksIDQuery
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetChecksIDQuery
    */
   getChecksIDQuery(
     request: GetChecksIDQueryRequest,

--- a/packages/apis/src/generated/ChecksAPI.ts
+++ b/packages/apis/src/generated/ChecksAPI.ts
@@ -61,16 +61,17 @@ export interface GetChecksIDQueryRequest {
   checkID: string
 }
 /**
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetChecks
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/CreateCheck
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetChecksID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PutChecksID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchChecksID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteChecksID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetChecksIDLabels
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostChecksIDLabels
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteChecksIDLabelsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetChecksIDQuery
+ * See
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetChecks
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/CreateCheck
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetChecksID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PutChecksID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PatchChecksID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteChecksID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetChecksIDLabels
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostChecksIDLabels
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteChecksIDLabelsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetChecksIDQuery
  */
 export class ChecksAPI extends APIBase {
   /**

--- a/packages/apis/src/generated/DashboardsAPI.ts
+++ b/packages/apis/src/generated/DashboardsAPI.ts
@@ -144,27 +144,28 @@ export interface GetDashboardsIDLogsRequest {
   limit?: number
 }
 /**
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboards
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboards
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchDashboardsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboardsIDCells
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PutDashboardsIDCells
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchDashboardsIDCellsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsIDCellsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDCellsIDView
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchDashboardsIDCellsIDView
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDLabels
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboardsIDLabels
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsIDLabelsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDMembers
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboardsIDMembers
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsIDMembersID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDOwners
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboardsIDOwners
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsIDOwnersID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDLogs
+ * See
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboards
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboards
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PatchDashboardsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboardsIDCells
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PutDashboardsIDCells
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PatchDashboardsIDCellsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsIDCellsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDCellsIDView
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PatchDashboardsIDCellsIDView
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDLabels
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboardsIDLabels
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsIDLabelsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDMembers
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboardsIDMembers
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsIDMembersID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDOwners
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboardsIDOwners
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsIDOwnersID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDLogs
  */
 export class DashboardsAPI extends APIBase {
   /**

--- a/packages/apis/src/generated/DashboardsAPI.ts
+++ b/packages/apis/src/generated/DashboardsAPI.ts
@@ -144,27 +144,27 @@ export interface GetDashboardsIDLogsRequest {
   limit?: number
 }
 /**
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboards
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboards
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchDashboardsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboardsIDCells
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PutDashboardsIDCells
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchDashboardsIDCellsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsIDCellsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDCellsIDView
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchDashboardsIDCellsIDView
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDLabels
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboardsIDLabels
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsIDLabelsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDMembers
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboardsIDMembers
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsIDMembersID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDOwners
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboardsIDOwners
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsIDOwnersID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDLogs
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboards
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboards
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchDashboardsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboardsIDCells
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PutDashboardsIDCells
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchDashboardsIDCellsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsIDCellsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDCellsIDView
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchDashboardsIDCellsIDView
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDLabels
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboardsIDLabels
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsIDLabelsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDMembers
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboardsIDMembers
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsIDMembersID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDOwners
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboardsIDOwners
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsIDOwnersID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDLogs
  */
 export class DashboardsAPI extends APIBase {
   /**
@@ -175,9 +175,9 @@ export class DashboardsAPI extends APIBase {
   }
   /**
    * Get all dashboards.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboards
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboards
    */
   getDashboards(
     request?: GetDashboardsRequest,
@@ -198,9 +198,9 @@ export class DashboardsAPI extends APIBase {
   }
   /**
    * Create a dashboard.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboards
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboards
    */
   postDashboards(
     request: PostDashboardsRequest,
@@ -216,9 +216,9 @@ export class DashboardsAPI extends APIBase {
   }
   /**
    * Get a Dashboard.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsID
    */
   getDashboardsID(
     request: GetDashboardsIDRequest,
@@ -235,9 +235,9 @@ export class DashboardsAPI extends APIBase {
   }
   /**
    * Update a dashboard.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchDashboardsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchDashboardsID
    */
   patchDashboardsID(
     request: PatchDashboardsIDRequest,
@@ -253,9 +253,9 @@ export class DashboardsAPI extends APIBase {
   }
   /**
    * Delete a dashboard.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsID
    */
   deleteDashboardsID(
     request: DeleteDashboardsIDRequest,
@@ -270,9 +270,9 @@ export class DashboardsAPI extends APIBase {
   }
   /**
    * Create a dashboard cell.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboardsIDCells
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboardsIDCells
    */
   postDashboardsIDCells(
     request: PostDashboardsIDCellsRequest,
@@ -288,9 +288,9 @@ export class DashboardsAPI extends APIBase {
   }
   /**
    * Replace cells in a dashboard.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PutDashboardsIDCells
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PutDashboardsIDCells
    */
   putDashboardsIDCells(
     request: PutDashboardsIDCellsRequest,
@@ -306,9 +306,9 @@ export class DashboardsAPI extends APIBase {
   }
   /**
    * Update the non-positional information related to a cell.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchDashboardsIDCellsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchDashboardsIDCellsID
    */
   patchDashboardsIDCellsID(
     request: PatchDashboardsIDCellsIDRequest,
@@ -324,9 +324,9 @@ export class DashboardsAPI extends APIBase {
   }
   /**
    * Delete a dashboard cell.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsIDCellsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsIDCellsID
    */
   deleteDashboardsIDCellsID(
     request: DeleteDashboardsIDCellsIDRequest,
@@ -341,9 +341,9 @@ export class DashboardsAPI extends APIBase {
   }
   /**
    * Retrieve the view for a cell.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDCellsIDView
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDCellsIDView
    */
   getDashboardsIDCellsIDView(
     request: GetDashboardsIDCellsIDViewRequest,
@@ -358,9 +358,9 @@ export class DashboardsAPI extends APIBase {
   }
   /**
    * Update the view for a cell.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchDashboardsIDCellsIDView
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchDashboardsIDCellsIDView
    */
   patchDashboardsIDCellsIDView(
     request: PatchDashboardsIDCellsIDViewRequest,
@@ -376,9 +376,9 @@ export class DashboardsAPI extends APIBase {
   }
   /**
    * list all labels for a dashboard.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDLabels
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDLabels
    */
   getDashboardsIDLabels(
     request: GetDashboardsIDLabelsRequest,
@@ -393,9 +393,9 @@ export class DashboardsAPI extends APIBase {
   }
   /**
    * Add a label to a dashboard.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboardsIDLabels
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboardsIDLabels
    */
   postDashboardsIDLabels(
     request: PostDashboardsIDLabelsRequest,
@@ -411,9 +411,9 @@ export class DashboardsAPI extends APIBase {
   }
   /**
    * Delete a label from a dashboard.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsIDLabelsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsIDLabelsID
    */
   deleteDashboardsIDLabelsID(
     request: DeleteDashboardsIDLabelsIDRequest,
@@ -428,9 +428,9 @@ export class DashboardsAPI extends APIBase {
   }
   /**
    * List all dashboard members.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDMembers
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDMembers
    */
   getDashboardsIDMembers(
     request: GetDashboardsIDMembersRequest,
@@ -445,9 +445,9 @@ export class DashboardsAPI extends APIBase {
   }
   /**
    * Add a member to a dashboard.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboardsIDMembers
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboardsIDMembers
    */
   postDashboardsIDMembers(
     request: PostDashboardsIDMembersRequest,
@@ -463,9 +463,9 @@ export class DashboardsAPI extends APIBase {
   }
   /**
    * Remove a member from a dashboard.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsIDMembersID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsIDMembersID
    */
   deleteDashboardsIDMembersID(
     request: DeleteDashboardsIDMembersIDRequest,
@@ -480,9 +480,9 @@ export class DashboardsAPI extends APIBase {
   }
   /**
    * List all dashboard owners.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDOwners
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDOwners
    */
   getDashboardsIDOwners(
     request: GetDashboardsIDOwnersRequest,
@@ -497,9 +497,9 @@ export class DashboardsAPI extends APIBase {
   }
   /**
    * Add an owner to a dashboard.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboardsIDOwners
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostDashboardsIDOwners
    */
   postDashboardsIDOwners(
     request: PostDashboardsIDOwnersRequest,
@@ -515,9 +515,9 @@ export class DashboardsAPI extends APIBase {
   }
   /**
    * Remove an owner from a dashboard.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsIDOwnersID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDashboardsIDOwnersID
    */
   deleteDashboardsIDOwnersID(
     request: DeleteDashboardsIDOwnersIDRequest,
@@ -532,9 +532,9 @@ export class DashboardsAPI extends APIBase {
   }
   /**
    * Retrieve operation logs for a dashboard.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDLogs
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDLogs
    */
   getDashboardsIDLogs(
     request: GetDashboardsIDLogsRequest,

--- a/packages/apis/src/generated/DeleteAPI.ts
+++ b/packages/apis/src/generated/DeleteAPI.ts
@@ -14,7 +14,7 @@ export interface PostDeleteRequest {
   bucketID?: string
 }
 /**
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostDelete
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostDelete
  */
 export class DeleteAPI extends APIBase {
   /**
@@ -25,9 +25,9 @@ export class DeleteAPI extends APIBase {
   }
   /**
    * Delete time series data from InfluxDB.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostDelete
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostDelete
    */
   postDelete(
     request: PostDeleteRequest,

--- a/packages/apis/src/generated/DeleteAPI.ts
+++ b/packages/apis/src/generated/DeleteAPI.ts
@@ -14,7 +14,8 @@ export interface PostDeleteRequest {
   bucketID?: string
 }
 /**
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostDelete
+ * See
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostDelete
  */
 export class DeleteAPI extends APIBase {
   /**

--- a/packages/apis/src/generated/DocumentsAPI.ts
+++ b/packages/apis/src/generated/DocumentsAPI.ts
@@ -50,14 +50,15 @@ export interface DeleteDocumentsTemplatesIDLabelsIDRequest {
   labelID: string
 }
 /**
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDocumentsTemplates
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostDocumentsTemplates
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDocumentsTemplatesID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PutDocumentsTemplatesID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDocumentsTemplatesID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDocumentsTemplatesIDLabels
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostDocumentsTemplatesIDLabels
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDocumentsTemplatesIDLabelsID
+ * See
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetDocumentsTemplates
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostDocumentsTemplates
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetDocumentsTemplatesID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PutDocumentsTemplatesID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDocumentsTemplatesID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetDocumentsTemplatesIDLabels
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostDocumentsTemplatesIDLabels
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDocumentsTemplatesIDLabelsID
  */
 export class DocumentsAPI extends APIBase {
   /**

--- a/packages/apis/src/generated/DocumentsAPI.ts
+++ b/packages/apis/src/generated/DocumentsAPI.ts
@@ -50,14 +50,14 @@ export interface DeleteDocumentsTemplatesIDLabelsIDRequest {
   labelID: string
 }
 /**
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetDocumentsTemplates
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostDocumentsTemplates
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetDocumentsTemplatesID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PutDocumentsTemplatesID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDocumentsTemplatesID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetDocumentsTemplatesIDLabels
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostDocumentsTemplatesIDLabels
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDocumentsTemplatesIDLabelsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDocumentsTemplates
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostDocumentsTemplates
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDocumentsTemplatesID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PutDocumentsTemplatesID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDocumentsTemplatesID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDocumentsTemplatesIDLabels
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostDocumentsTemplatesIDLabels
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDocumentsTemplatesIDLabelsID
  */
 export class DocumentsAPI extends APIBase {
   /**
@@ -67,9 +67,9 @@ export class DocumentsAPI extends APIBase {
     super(influxDB)
   }
   /**
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDocumentsTemplates
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetDocumentsTemplates
    */
   getDocumentsTemplates(
     request?: GetDocumentsTemplatesRequest,
@@ -87,9 +87,9 @@ export class DocumentsAPI extends APIBase {
   }
   /**
    * Create a template.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostDocumentsTemplates
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostDocumentsTemplates
    */
   postDocumentsTemplates(
     request: PostDocumentsTemplatesRequest,
@@ -104,9 +104,9 @@ export class DocumentsAPI extends APIBase {
     )
   }
   /**
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDocumentsTemplatesID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetDocumentsTemplatesID
    */
   getDocumentsTemplatesID(
     request: GetDocumentsTemplatesIDRequest,
@@ -120,9 +120,9 @@ export class DocumentsAPI extends APIBase {
     )
   }
   /**
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PutDocumentsTemplatesID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PutDocumentsTemplatesID
    */
   putDocumentsTemplatesID(
     request: PutDocumentsTemplatesIDRequest,
@@ -138,9 +138,9 @@ export class DocumentsAPI extends APIBase {
   }
   /**
    * Delete a template.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDocumentsTemplatesID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDocumentsTemplatesID
    */
   deleteDocumentsTemplatesID(
     request: DeleteDocumentsTemplatesIDRequest,
@@ -155,9 +155,9 @@ export class DocumentsAPI extends APIBase {
   }
   /**
    * List all labels for a template.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetDocumentsTemplatesIDLabels
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetDocumentsTemplatesIDLabels
    */
   getDocumentsTemplatesIDLabels(
     request: GetDocumentsTemplatesIDLabelsRequest,
@@ -172,9 +172,9 @@ export class DocumentsAPI extends APIBase {
   }
   /**
    * Add a label to a template.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostDocumentsTemplatesIDLabels
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostDocumentsTemplatesIDLabels
    */
   postDocumentsTemplatesIDLabels(
     request: PostDocumentsTemplatesIDLabelsRequest,
@@ -190,9 +190,9 @@ export class DocumentsAPI extends APIBase {
   }
   /**
    * Delete a label from a template.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDocumentsTemplatesIDLabelsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteDocumentsTemplatesIDLabelsID
    */
   deleteDocumentsTemplatesIDLabelsID(
     request: DeleteDocumentsTemplatesIDLabelsIDRequest,

--- a/packages/apis/src/generated/HealthAPI.ts
+++ b/packages/apis/src/generated/HealthAPI.ts
@@ -3,7 +3,8 @@ import {HealthCheck} from './types'
 
 export interface GetHealthRequest {}
 /**
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetHealth
+ * See
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetHealth
  */
 export class HealthAPI extends APIBase {
   /**

--- a/packages/apis/src/generated/HealthAPI.ts
+++ b/packages/apis/src/generated/HealthAPI.ts
@@ -3,7 +3,7 @@ import {HealthCheck} from './types'
 
 export interface GetHealthRequest {}
 /**
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetHealth
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetHealth
  */
 export class HealthAPI extends APIBase {
   /**
@@ -14,9 +14,9 @@ export class HealthAPI extends APIBase {
   }
   /**
    * Get the health of an instance.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetHealth
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetHealth
    */
   getHealth(
     request?: GetHealthRequest,

--- a/packages/apis/src/generated/LabelsAPI.ts
+++ b/packages/apis/src/generated/LabelsAPI.ts
@@ -29,11 +29,11 @@ export interface DeleteLabelsIDRequest {
   labelID: string
 }
 /**
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetLabels
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostLabels
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetLabelsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchLabelsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteLabelsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetLabels
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostLabels
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetLabelsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchLabelsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteLabelsID
  */
 export class LabelsAPI extends APIBase {
   /**
@@ -44,9 +44,9 @@ export class LabelsAPI extends APIBase {
   }
   /**
    * Get all labels.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetLabels
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetLabels
    */
   getLabels(
     request?: GetLabelsRequest,
@@ -61,9 +61,9 @@ export class LabelsAPI extends APIBase {
   }
   /**
    * Create a label.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostLabels
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostLabels
    */
   postLabels(
     request: PostLabelsRequest,
@@ -79,9 +79,9 @@ export class LabelsAPI extends APIBase {
   }
   /**
    * Get a label.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetLabelsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetLabelsID
    */
   getLabelsID(
     request: GetLabelsIDRequest,
@@ -96,9 +96,9 @@ export class LabelsAPI extends APIBase {
   }
   /**
    * Update a label.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchLabelsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchLabelsID
    */
   patchLabelsID(
     request: PatchLabelsIDRequest,
@@ -114,9 +114,9 @@ export class LabelsAPI extends APIBase {
   }
   /**
    * Delete a label.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteLabelsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteLabelsID
    */
   deleteLabelsID(
     request: DeleteLabelsIDRequest,

--- a/packages/apis/src/generated/LabelsAPI.ts
+++ b/packages/apis/src/generated/LabelsAPI.ts
@@ -29,11 +29,12 @@ export interface DeleteLabelsIDRequest {
   labelID: string
 }
 /**
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetLabels
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostLabels
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetLabelsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchLabelsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteLabelsID
+ * See
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetLabels
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostLabels
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetLabelsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PatchLabelsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteLabelsID
  */
 export class LabelsAPI extends APIBase {
   /**

--- a/packages/apis/src/generated/MeAPI.ts
+++ b/packages/apis/src/generated/MeAPI.ts
@@ -8,8 +8,8 @@ export interface PutMePasswordRequest {
   body: PasswordResetBody
 }
 /**
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetMe
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PutMePassword
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetMe
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PutMePassword
  */
 export class MeAPI extends APIBase {
   /**
@@ -20,9 +20,9 @@ export class MeAPI extends APIBase {
   }
   /**
    * Return the current authenticated user.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetMe
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetMe
    */
   getMe(
     request?: GetMeRequest,
@@ -32,9 +32,9 @@ export class MeAPI extends APIBase {
   }
   /**
    * Update a password.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PutMePassword
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PutMePassword
    */
   putMePassword(
     request: PutMePasswordRequest,

--- a/packages/apis/src/generated/MeAPI.ts
+++ b/packages/apis/src/generated/MeAPI.ts
@@ -8,8 +8,9 @@ export interface PutMePasswordRequest {
   body: PasswordResetBody
 }
 /**
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetMe
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PutMePassword
+ * See
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetMe
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PutMePassword
  */
 export class MeAPI extends APIBase {
   /**

--- a/packages/apis/src/generated/NotificationEndpointsAPI.ts
+++ b/packages/apis/src/generated/NotificationEndpointsAPI.ts
@@ -56,15 +56,16 @@ export interface DeleteNotificationEndpointsIDLabelsIDRequest {
   labelID: string
 }
 /**
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationEndpoints
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/CreateNotificationEndpoint
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationEndpointsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PutNotificationEndpointsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchNotificationEndpointsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteNotificationEndpointsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationEndpointsIDLabels
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostNotificationEndpointIDLabels
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteNotificationEndpointsIDLabelsID
+ * See
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationEndpoints
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/CreateNotificationEndpoint
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationEndpointsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PutNotificationEndpointsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PatchNotificationEndpointsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteNotificationEndpointsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationEndpointsIDLabels
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostNotificationEndpointIDLabels
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteNotificationEndpointsIDLabelsID
  */
 export class NotificationEndpointsAPI extends APIBase {
   /**

--- a/packages/apis/src/generated/NotificationEndpointsAPI.ts
+++ b/packages/apis/src/generated/NotificationEndpointsAPI.ts
@@ -56,15 +56,15 @@ export interface DeleteNotificationEndpointsIDLabelsIDRequest {
   labelID: string
 }
 /**
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationEndpoints
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/CreateNotificationEndpoint
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationEndpointsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PutNotificationEndpointsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchNotificationEndpointsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteNotificationEndpointsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationEndpointsIDLabels
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostNotificationEndpointIDLabels
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteNotificationEndpointsIDLabelsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationEndpoints
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/CreateNotificationEndpoint
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationEndpointsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PutNotificationEndpointsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchNotificationEndpointsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteNotificationEndpointsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationEndpointsIDLabels
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostNotificationEndpointIDLabels
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteNotificationEndpointsIDLabelsID
  */
 export class NotificationEndpointsAPI extends APIBase {
   /**
@@ -75,9 +75,9 @@ export class NotificationEndpointsAPI extends APIBase {
   }
   /**
    * Get all notification endpoints.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationEndpoints
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationEndpoints
    */
   getNotificationEndpoints(
     request: GetNotificationEndpointsRequest,
@@ -96,9 +96,9 @@ export class NotificationEndpointsAPI extends APIBase {
   }
   /**
    * Add a notification endpoint.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/CreateNotificationEndpoint
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/CreateNotificationEndpoint
    */
   createNotificationEndpoint(
     request: CreateNotificationEndpointRequest,
@@ -114,9 +114,9 @@ export class NotificationEndpointsAPI extends APIBase {
   }
   /**
    * Get a notification endpoint.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationEndpointsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationEndpointsID
    */
   getNotificationEndpointsID(
     request: GetNotificationEndpointsIDRequest,
@@ -131,9 +131,9 @@ export class NotificationEndpointsAPI extends APIBase {
   }
   /**
    * Update a notification endpoint.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PutNotificationEndpointsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PutNotificationEndpointsID
    */
   putNotificationEndpointsID(
     request: PutNotificationEndpointsIDRequest,
@@ -149,9 +149,9 @@ export class NotificationEndpointsAPI extends APIBase {
   }
   /**
    * Update a notification endpoint.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchNotificationEndpointsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchNotificationEndpointsID
    */
   patchNotificationEndpointsID(
     request: PatchNotificationEndpointsIDRequest,
@@ -167,9 +167,9 @@ export class NotificationEndpointsAPI extends APIBase {
   }
   /**
    * Delete a notification endpoint.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteNotificationEndpointsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteNotificationEndpointsID
    */
   deleteNotificationEndpointsID(
     request: DeleteNotificationEndpointsIDRequest,
@@ -184,9 +184,9 @@ export class NotificationEndpointsAPI extends APIBase {
   }
   /**
    * List all labels for a notification endpoint.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationEndpointsIDLabels
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationEndpointsIDLabels
    */
   getNotificationEndpointsIDLabels(
     request: GetNotificationEndpointsIDLabelsRequest,
@@ -201,9 +201,9 @@ export class NotificationEndpointsAPI extends APIBase {
   }
   /**
    * Add a label to a notification endpoint.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostNotificationEndpointIDLabels
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostNotificationEndpointIDLabels
    */
   postNotificationEndpointIDLabels(
     request: PostNotificationEndpointIDLabelsRequest,
@@ -219,9 +219,9 @@ export class NotificationEndpointsAPI extends APIBase {
   }
   /**
    * Delete a label from a notification endpoint.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteNotificationEndpointsIDLabelsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteNotificationEndpointsIDLabelsID
    */
   deleteNotificationEndpointsIDLabelsID(
     request: DeleteNotificationEndpointsIDLabelsIDRequest,

--- a/packages/apis/src/generated/NotificationRulesAPI.ts
+++ b/packages/apis/src/generated/NotificationRulesAPI.ts
@@ -65,16 +65,17 @@ export interface GetNotificationRulesIDQueryRequest {
   ruleID: string
 }
 /**
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationRules
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/CreateNotificationRule
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationRulesID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PutNotificationRulesID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchNotificationRulesID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteNotificationRulesID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationRulesIDLabels
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostNotificationRuleIDLabels
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteNotificationRulesIDLabelsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationRulesIDQuery
+ * See
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationRules
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/CreateNotificationRule
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationRulesID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PutNotificationRulesID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PatchNotificationRulesID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteNotificationRulesID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationRulesIDLabels
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostNotificationRuleIDLabels
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteNotificationRulesIDLabelsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationRulesIDQuery
  */
 export class NotificationRulesAPI extends APIBase {
   /**

--- a/packages/apis/src/generated/NotificationRulesAPI.ts
+++ b/packages/apis/src/generated/NotificationRulesAPI.ts
@@ -65,16 +65,16 @@ export interface GetNotificationRulesIDQueryRequest {
   ruleID: string
 }
 /**
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationRules
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/CreateNotificationRule
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationRulesID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PutNotificationRulesID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchNotificationRulesID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteNotificationRulesID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationRulesIDLabels
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostNotificationRuleIDLabels
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteNotificationRulesIDLabelsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationRulesIDQuery
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationRules
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/CreateNotificationRule
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationRulesID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PutNotificationRulesID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchNotificationRulesID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteNotificationRulesID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationRulesIDLabels
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostNotificationRuleIDLabels
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteNotificationRulesIDLabelsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationRulesIDQuery
  */
 export class NotificationRulesAPI extends APIBase {
   /**
@@ -85,9 +85,9 @@ export class NotificationRulesAPI extends APIBase {
   }
   /**
    * Get all notification rules.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationRules
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationRules
    */
   getNotificationRules(
     request: GetNotificationRulesRequest,
@@ -108,9 +108,9 @@ export class NotificationRulesAPI extends APIBase {
   }
   /**
    * Add a notification rule.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/CreateNotificationRule
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/CreateNotificationRule
    */
   createNotificationRule(
     request: CreateNotificationRuleRequest,
@@ -126,9 +126,9 @@ export class NotificationRulesAPI extends APIBase {
   }
   /**
    * Get a notification rule.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationRulesID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationRulesID
    */
   getNotificationRulesID(
     request: GetNotificationRulesIDRequest,
@@ -143,9 +143,9 @@ export class NotificationRulesAPI extends APIBase {
   }
   /**
    * Update a notification rule.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PutNotificationRulesID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PutNotificationRulesID
    */
   putNotificationRulesID(
     request: PutNotificationRulesIDRequest,
@@ -161,9 +161,9 @@ export class NotificationRulesAPI extends APIBase {
   }
   /**
    * Update a notification rule.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchNotificationRulesID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchNotificationRulesID
    */
   patchNotificationRulesID(
     request: PatchNotificationRulesIDRequest,
@@ -179,9 +179,9 @@ export class NotificationRulesAPI extends APIBase {
   }
   /**
    * Delete a notification rule.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteNotificationRulesID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteNotificationRulesID
    */
   deleteNotificationRulesID(
     request: DeleteNotificationRulesIDRequest,
@@ -196,9 +196,9 @@ export class NotificationRulesAPI extends APIBase {
   }
   /**
    * List all labels for a notification rule.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationRulesIDLabels
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationRulesIDLabels
    */
   getNotificationRulesIDLabels(
     request: GetNotificationRulesIDLabelsRequest,
@@ -213,9 +213,9 @@ export class NotificationRulesAPI extends APIBase {
   }
   /**
    * Add a label to a notification rule.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostNotificationRuleIDLabels
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostNotificationRuleIDLabels
    */
   postNotificationRuleIDLabels(
     request: PostNotificationRuleIDLabelsRequest,
@@ -231,9 +231,9 @@ export class NotificationRulesAPI extends APIBase {
   }
   /**
    * Delete label from a notification rule.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteNotificationRulesIDLabelsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteNotificationRulesIDLabelsID
    */
   deleteNotificationRulesIDLabelsID(
     request: DeleteNotificationRulesIDLabelsIDRequest,
@@ -248,9 +248,9 @@ export class NotificationRulesAPI extends APIBase {
   }
   /**
    * Get a notification rule query.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationRulesIDQuery
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetNotificationRulesIDQuery
    */
   getNotificationRulesIDQuery(
     request: GetNotificationRulesIDQueryRequest,

--- a/packages/apis/src/generated/OrgsAPI.ts
+++ b/packages/apis/src/generated/OrgsAPI.ts
@@ -111,24 +111,25 @@ export interface GetOrgsIDLogsRequest {
   limit?: number
 }
 /**
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgs
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgs
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchOrgsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteOrgsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDLabels
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgsIDLabels
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteOrgsIDLabelsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDSecrets
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchOrgsIDSecrets
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgsIDSecrets
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDMembers
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgsIDMembers
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteOrgsIDMembersID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDOwners
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgsIDOwners
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteOrgsIDOwnersID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDLogs
+ * See
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgs
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgs
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PatchOrgsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteOrgsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDLabels
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgsIDLabels
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteOrgsIDLabelsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDSecrets
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PatchOrgsIDSecrets
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgsIDSecrets
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDMembers
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgsIDMembers
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteOrgsIDMembersID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDOwners
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgsIDOwners
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteOrgsIDOwnersID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDLogs
  */
 export class OrgsAPI extends APIBase {
   /**

--- a/packages/apis/src/generated/OrgsAPI.ts
+++ b/packages/apis/src/generated/OrgsAPI.ts
@@ -111,24 +111,24 @@ export interface GetOrgsIDLogsRequest {
   limit?: number
 }
 /**
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgs
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgs
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchOrgsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteOrgsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDLabels
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgsIDLabels
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteOrgsIDLabelsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDSecrets
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchOrgsIDSecrets
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgsIDSecrets
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDMembers
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgsIDMembers
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteOrgsIDMembersID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDOwners
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgsIDOwners
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteOrgsIDOwnersID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDLogs
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgs
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgs
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchOrgsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteOrgsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDLabels
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgsIDLabels
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteOrgsIDLabelsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDSecrets
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchOrgsIDSecrets
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgsIDSecrets
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDMembers
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgsIDMembers
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteOrgsIDMembersID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDOwners
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgsIDOwners
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteOrgsIDOwnersID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDLogs
  */
 export class OrgsAPI extends APIBase {
   /**
@@ -139,9 +139,9 @@ export class OrgsAPI extends APIBase {
   }
   /**
    * List all organizations.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgs
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgs
    */
   getOrgs(
     request?: GetOrgsRequest,
@@ -156,9 +156,9 @@ export class OrgsAPI extends APIBase {
   }
   /**
    * Create an organization.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgs
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgs
    */
   postOrgs(
     request: PostOrgsRequest,
@@ -174,9 +174,9 @@ export class OrgsAPI extends APIBase {
   }
   /**
    * Retrieve an organization.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsID
    */
   getOrgsID(
     request: GetOrgsIDRequest,
@@ -191,9 +191,9 @@ export class OrgsAPI extends APIBase {
   }
   /**
    * Update an organization.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchOrgsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchOrgsID
    */
   patchOrgsID(
     request: PatchOrgsIDRequest,
@@ -209,9 +209,9 @@ export class OrgsAPI extends APIBase {
   }
   /**
    * Delete an organization.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteOrgsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteOrgsID
    */
   deleteOrgsID(
     request: DeleteOrgsIDRequest,
@@ -226,9 +226,9 @@ export class OrgsAPI extends APIBase {
   }
   /**
    * List all labels for a organization.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDLabels
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDLabels
    */
   getOrgsIDLabels(
     request: GetOrgsIDLabelsRequest,
@@ -243,9 +243,9 @@ export class OrgsAPI extends APIBase {
   }
   /**
    * Add a label to an organization.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgsIDLabels
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgsIDLabels
    */
   postOrgsIDLabels(
     request: PostOrgsIDLabelsRequest,
@@ -261,9 +261,9 @@ export class OrgsAPI extends APIBase {
   }
   /**
    * Delete a label from an organization.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteOrgsIDLabelsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteOrgsIDLabelsID
    */
   deleteOrgsIDLabelsID(
     request: DeleteOrgsIDLabelsIDRequest,
@@ -278,9 +278,9 @@ export class OrgsAPI extends APIBase {
   }
   /**
    * List all secret keys for an organization.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDSecrets
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDSecrets
    */
   getOrgsIDSecrets(
     request: GetOrgsIDSecretsRequest,
@@ -295,9 +295,9 @@ export class OrgsAPI extends APIBase {
   }
   /**
    * Update secrets in an organization.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchOrgsIDSecrets
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchOrgsIDSecrets
    */
   patchOrgsIDSecrets(
     request: PatchOrgsIDSecretsRequest,
@@ -313,9 +313,9 @@ export class OrgsAPI extends APIBase {
   }
   /**
    * Delete secrets from an organization.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgsIDSecrets
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgsIDSecrets
    */
   postOrgsIDSecrets(
     request: PostOrgsIDSecretsRequest,
@@ -331,9 +331,9 @@ export class OrgsAPI extends APIBase {
   }
   /**
    * List all members of an organization.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDMembers
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDMembers
    */
   getOrgsIDMembers(
     request: GetOrgsIDMembersRequest,
@@ -348,9 +348,9 @@ export class OrgsAPI extends APIBase {
   }
   /**
    * Add a member to an organization.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgsIDMembers
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgsIDMembers
    */
   postOrgsIDMembers(
     request: PostOrgsIDMembersRequest,
@@ -366,9 +366,9 @@ export class OrgsAPI extends APIBase {
   }
   /**
    * Remove a member from an organization.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteOrgsIDMembersID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteOrgsIDMembersID
    */
   deleteOrgsIDMembersID(
     request: DeleteOrgsIDMembersIDRequest,
@@ -383,9 +383,9 @@ export class OrgsAPI extends APIBase {
   }
   /**
    * List all owners of an organization.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDOwners
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDOwners
    */
   getOrgsIDOwners(
     request: GetOrgsIDOwnersRequest,
@@ -400,9 +400,9 @@ export class OrgsAPI extends APIBase {
   }
   /**
    * Add an owner to an organization.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgsIDOwners
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostOrgsIDOwners
    */
   postOrgsIDOwners(
     request: PostOrgsIDOwnersRequest,
@@ -418,9 +418,9 @@ export class OrgsAPI extends APIBase {
   }
   /**
    * Remove an owner from an organization.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteOrgsIDOwnersID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteOrgsIDOwnersID
    */
   deleteOrgsIDOwnersID(
     request: DeleteOrgsIDOwnersIDRequest,
@@ -435,9 +435,9 @@ export class OrgsAPI extends APIBase {
   }
   /**
    * Retrieve operation logs for an organization.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDLogs
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetOrgsIDLogs
    */
   getOrgsIDLogs(
     request: GetOrgsIDLogsRequest,

--- a/packages/apis/src/generated/PackagesAPI.ts
+++ b/packages/apis/src/generated/PackagesAPI.ts
@@ -9,8 +9,8 @@ export interface ApplyPkgRequest {
   body: PkgApply
 }
 /**
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/CreatePkg
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/ApplyPkg
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/CreatePkg
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/ApplyPkg
  */
 export class PackagesAPI extends APIBase {
   /**
@@ -21,9 +21,9 @@ export class PackagesAPI extends APIBase {
   }
   /**
    * Create a new Influx package.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/CreatePkg
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/CreatePkg
    */
   createPkg(
     request: CreatePkgRequest,
@@ -39,9 +39,9 @@ export class PackagesAPI extends APIBase {
   }
   /**
    * Apply or dry-run an Influx package.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/ApplyPkg
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/ApplyPkg
    */
   applyPkg(
     request: ApplyPkgRequest,

--- a/packages/apis/src/generated/PackagesAPI.ts
+++ b/packages/apis/src/generated/PackagesAPI.ts
@@ -9,8 +9,9 @@ export interface ApplyPkgRequest {
   body: PkgApply
 }
 /**
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/CreatePkg
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/ApplyPkg
+ * See
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/CreatePkg
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/ApplyPkg
  */
 export class PackagesAPI extends APIBase {
   /**

--- a/packages/apis/src/generated/QueryAPI.ts
+++ b/packages/apis/src/generated/QueryAPI.ts
@@ -31,11 +31,12 @@ export interface PostQueryRequest {
   orgID?: string
 }
 /**
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostQueryAst
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetQuerySuggestions
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetQuerySuggestionsName
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostQueryAnalyze
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostQuery
+ * See
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostQueryAst
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetQuerySuggestions
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetQuerySuggestionsName
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostQueryAnalyze
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostQuery
  */
 export class QueryAPI extends APIBase {
   /**

--- a/packages/apis/src/generated/QueryAPI.ts
+++ b/packages/apis/src/generated/QueryAPI.ts
@@ -31,11 +31,11 @@ export interface PostQueryRequest {
   orgID?: string
 }
 /**
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostQueryAst
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetQuerySuggestions
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetQuerySuggestionsName
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostQueryAnalyze
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostQuery
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostQueryAst
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetQuerySuggestions
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetQuerySuggestionsName
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostQueryAnalyze
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostQuery
  */
 export class QueryAPI extends APIBase {
   /**
@@ -45,9 +45,9 @@ export class QueryAPI extends APIBase {
     super(influxDB)
   }
   /**
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostQueryAst
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostQueryAst
    */
   postQueryAst(
     request: PostQueryAstRequest,
@@ -62,9 +62,9 @@ export class QueryAPI extends APIBase {
     )
   }
   /**
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetQuerySuggestions
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetQuerySuggestions
    */
   getQuerySuggestions(
     request?: GetQuerySuggestionsRequest,
@@ -78,9 +78,9 @@ export class QueryAPI extends APIBase {
     )
   }
   /**
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetQuerySuggestionsName
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetQuerySuggestionsName
    */
   getQuerySuggestionsName(
     request: GetQuerySuggestionsNameRequest,
@@ -95,9 +95,9 @@ export class QueryAPI extends APIBase {
   }
   /**
    * Analyze an InfluxQL or Flux query.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostQueryAnalyze
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostQueryAnalyze
    */
   postQueryAnalyze(
     request: PostQueryAnalyzeRequest,
@@ -113,9 +113,9 @@ export class QueryAPI extends APIBase {
   }
   /**
    * Query InfluxDB.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostQuery
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostQuery
    */
   postQuery(
     request: PostQueryRequest,

--- a/packages/apis/src/generated/ReadyAPI.ts
+++ b/packages/apis/src/generated/ReadyAPI.ts
@@ -3,7 +3,8 @@ import {Ready} from './types'
 
 export interface GetReadyRequest {}
 /**
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetReady
+ * See
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetReady
  */
 export class ReadyAPI extends APIBase {
   /**

--- a/packages/apis/src/generated/ReadyAPI.ts
+++ b/packages/apis/src/generated/ReadyAPI.ts
@@ -3,7 +3,7 @@ import {Ready} from './types'
 
 export interface GetReadyRequest {}
 /**
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetReady
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetReady
  */
 export class ReadyAPI extends APIBase {
   /**
@@ -14,9 +14,9 @@ export class ReadyAPI extends APIBase {
   }
   /**
    * Get the readiness of an instance at startup.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetReady
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetReady
    */
   getReady(
     request?: GetReadyRequest,

--- a/packages/apis/src/generated/RootAPI.ts
+++ b/packages/apis/src/generated/RootAPI.ts
@@ -3,7 +3,7 @@ import {Routes} from './types'
 
 export interface GetRoutesRequest {}
 /**
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetRoutes
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetRoutes
  */
 export class RootAPI extends APIBase {
   /**
@@ -14,9 +14,9 @@ export class RootAPI extends APIBase {
   }
   /**
    * Map of all top level routes available.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetRoutes
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetRoutes
    */
   getRoutes(
     request?: GetRoutesRequest,

--- a/packages/apis/src/generated/RootAPI.ts
+++ b/packages/apis/src/generated/RootAPI.ts
@@ -3,7 +3,8 @@ import {Routes} from './types'
 
 export interface GetRoutesRequest {}
 /**
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetRoutes
+ * See
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetRoutes
  */
 export class RootAPI extends APIBase {
   /**

--- a/packages/apis/src/generated/ScrapersAPI.ts
+++ b/packages/apis/src/generated/ScrapersAPI.ts
@@ -99,21 +99,21 @@ export interface DeleteScrapersIDOwnersIDRequest {
   scraperTargetID: string
 }
 /**
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapers
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostScrapers
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapersID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchScrapersID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteScrapersID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapersIDLabels
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostScrapersIDLabels
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchScrapersIDLabelsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteScrapersIDLabelsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapersIDMembers
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostScrapersIDMembers
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteScrapersIDMembersID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapersIDOwners
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostScrapersIDOwners
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteScrapersIDOwnersID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapers
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostScrapers
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapersID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchScrapersID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteScrapersID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapersIDLabels
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostScrapersIDLabels
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchScrapersIDLabelsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteScrapersIDLabelsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapersIDMembers
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostScrapersIDMembers
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteScrapersIDMembersID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapersIDOwners
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostScrapersIDOwners
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteScrapersIDOwnersID
  */
 export class ScrapersAPI extends APIBase {
   /**
@@ -124,9 +124,9 @@ export class ScrapersAPI extends APIBase {
   }
   /**
    * Get all scraper targets.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapers
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapers
    */
   getScrapers(
     request?: GetScrapersRequest,
@@ -146,9 +146,9 @@ export class ScrapersAPI extends APIBase {
   }
   /**
    * Create a scraper target.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostScrapers
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostScrapers
    */
   postScrapers(
     request: PostScrapersRequest,
@@ -164,9 +164,9 @@ export class ScrapersAPI extends APIBase {
   }
   /**
    * Get a scraper target by ID.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapersID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapersID
    */
   getScrapersID(
     request: GetScrapersIDRequest,
@@ -181,9 +181,9 @@ export class ScrapersAPI extends APIBase {
   }
   /**
    * Update a scraper target.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchScrapersID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchScrapersID
    */
   patchScrapersID(
     request: PatchScrapersIDRequest,
@@ -199,9 +199,9 @@ export class ScrapersAPI extends APIBase {
   }
   /**
    * Delete a scraper target.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteScrapersID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteScrapersID
    */
   deleteScrapersID(
     request: DeleteScrapersIDRequest,
@@ -216,9 +216,9 @@ export class ScrapersAPI extends APIBase {
   }
   /**
    * List all labels for a scraper target.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapersIDLabels
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapersIDLabels
    */
   getScrapersIDLabels(
     request: GetScrapersIDLabelsRequest,
@@ -233,9 +233,9 @@ export class ScrapersAPI extends APIBase {
   }
   /**
    * Add a label to a scraper target.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostScrapersIDLabels
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostScrapersIDLabels
    */
   postScrapersIDLabels(
     request: PostScrapersIDLabelsRequest,
@@ -251,9 +251,9 @@ export class ScrapersAPI extends APIBase {
   }
   /**
    * Update a label on a scraper target.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchScrapersIDLabelsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchScrapersIDLabelsID
    */
   patchScrapersIDLabelsID(
     request: PatchScrapersIDLabelsIDRequest,
@@ -269,9 +269,9 @@ export class ScrapersAPI extends APIBase {
   }
   /**
    * Delete a label from a scraper target.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteScrapersIDLabelsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteScrapersIDLabelsID
    */
   deleteScrapersIDLabelsID(
     request: DeleteScrapersIDLabelsIDRequest,
@@ -286,9 +286,9 @@ export class ScrapersAPI extends APIBase {
   }
   /**
    * List all users with member privileges for a scraper target.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapersIDMembers
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapersIDMembers
    */
   getScrapersIDMembers(
     request: GetScrapersIDMembersRequest,
@@ -303,9 +303,9 @@ export class ScrapersAPI extends APIBase {
   }
   /**
    * Add a member to a scraper target.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostScrapersIDMembers
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostScrapersIDMembers
    */
   postScrapersIDMembers(
     request: PostScrapersIDMembersRequest,
@@ -321,9 +321,9 @@ export class ScrapersAPI extends APIBase {
   }
   /**
    * Remove a member from a scraper target.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteScrapersIDMembersID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteScrapersIDMembersID
    */
   deleteScrapersIDMembersID(
     request: DeleteScrapersIDMembersIDRequest,
@@ -338,9 +338,9 @@ export class ScrapersAPI extends APIBase {
   }
   /**
    * List all owners of a scraper target.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapersIDOwners
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapersIDOwners
    */
   getScrapersIDOwners(
     request: GetScrapersIDOwnersRequest,
@@ -355,9 +355,9 @@ export class ScrapersAPI extends APIBase {
   }
   /**
    * Add an owner to a scraper target.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostScrapersIDOwners
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostScrapersIDOwners
    */
   postScrapersIDOwners(
     request: PostScrapersIDOwnersRequest,
@@ -373,9 +373,9 @@ export class ScrapersAPI extends APIBase {
   }
   /**
    * Remove an owner from a scraper target.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteScrapersIDOwnersID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteScrapersIDOwnersID
    */
   deleteScrapersIDOwnersID(
     request: DeleteScrapersIDOwnersIDRequest,

--- a/packages/apis/src/generated/ScrapersAPI.ts
+++ b/packages/apis/src/generated/ScrapersAPI.ts
@@ -99,21 +99,22 @@ export interface DeleteScrapersIDOwnersIDRequest {
   scraperTargetID: string
 }
 /**
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapers
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostScrapers
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapersID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchScrapersID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteScrapersID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapersIDLabels
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostScrapersIDLabels
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchScrapersIDLabelsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteScrapersIDLabelsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapersIDMembers
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostScrapersIDMembers
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteScrapersIDMembersID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapersIDOwners
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostScrapersIDOwners
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteScrapersIDOwnersID
+ * See
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapers
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostScrapers
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapersID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PatchScrapersID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteScrapersID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapersIDLabels
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostScrapersIDLabels
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PatchScrapersIDLabelsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteScrapersIDLabelsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapersIDMembers
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostScrapersIDMembers
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteScrapersIDMembersID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetScrapersIDOwners
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostScrapersIDOwners
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteScrapersIDOwnersID
  */
 export class ScrapersAPI extends APIBase {
   /**

--- a/packages/apis/src/generated/SetupAPI.ts
+++ b/packages/apis/src/generated/SetupAPI.ts
@@ -7,8 +7,9 @@ export interface PostSetupRequest {
   body: OnboardingRequest
 }
 /**
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetSetup
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostSetup
+ * See
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetSetup
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostSetup
  */
 export class SetupAPI extends APIBase {
   /**

--- a/packages/apis/src/generated/SetupAPI.ts
+++ b/packages/apis/src/generated/SetupAPI.ts
@@ -7,8 +7,8 @@ export interface PostSetupRequest {
   body: OnboardingRequest
 }
 /**
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetSetup
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostSetup
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetSetup
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostSetup
  */
 export class SetupAPI extends APIBase {
   /**
@@ -19,9 +19,9 @@ export class SetupAPI extends APIBase {
   }
   /**
    * Check if database has default user, org, bucket.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetSetup
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetSetup
    */
   getSetup(
     request?: GetSetupRequest,
@@ -31,9 +31,9 @@ export class SetupAPI extends APIBase {
   }
   /**
    * Set up initial user, org and bucket.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostSetup
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostSetup
    */
   postSetup(
     request: PostSetupRequest,

--- a/packages/apis/src/generated/SigninAPI.ts
+++ b/packages/apis/src/generated/SigninAPI.ts
@@ -4,7 +4,7 @@ export interface PostSigninRequest {
   auth: {user: string; password: string}
 }
 /**
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostSignin
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostSignin
  */
 export class SigninAPI extends APIBase {
   /**
@@ -15,9 +15,9 @@ export class SigninAPI extends APIBase {
   }
   /**
    * Exchange basic auth credentials for session.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostSignin
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostSignin
    */
   postSignin(
     request: PostSigninRequest,

--- a/packages/apis/src/generated/SigninAPI.ts
+++ b/packages/apis/src/generated/SigninAPI.ts
@@ -4,7 +4,8 @@ export interface PostSigninRequest {
   auth: {user: string; password: string}
 }
 /**
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostSignin
+ * See
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostSignin
  */
 export class SigninAPI extends APIBase {
   /**

--- a/packages/apis/src/generated/SignoutAPI.ts
+++ b/packages/apis/src/generated/SignoutAPI.ts
@@ -2,7 +2,8 @@ import {APIBase, RequestOptions} from '../APIBase'
 
 export interface PostSignoutRequest {}
 /**
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostSignout
+ * See
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostSignout
  */
 export class SignoutAPI extends APIBase {
   /**

--- a/packages/apis/src/generated/SignoutAPI.ts
+++ b/packages/apis/src/generated/SignoutAPI.ts
@@ -2,7 +2,7 @@ import {APIBase, RequestOptions} from '../APIBase'
 
 export interface PostSignoutRequest {}
 /**
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostSignout
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostSignout
  */
 export class SignoutAPI extends APIBase {
   /**
@@ -13,9 +13,9 @@ export class SignoutAPI extends APIBase {
   }
   /**
    * Expire the current session.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostSignout
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostSignout
    */
   postSignout(
     request?: PostSignoutRequest,

--- a/packages/apis/src/generated/SourcesAPI.ts
+++ b/packages/apis/src/generated/SourcesAPI.ts
@@ -34,13 +34,13 @@ export interface GetSourcesIDBucketsRequest {
   org?: string
 }
 /**
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetSources
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostSources
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetSourcesID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchSourcesID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteSourcesID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetSourcesIDHealth
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetSourcesIDBuckets
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetSources
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostSources
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetSourcesID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchSourcesID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteSourcesID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetSourcesIDHealth
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetSourcesIDBuckets
  */
 export class SourcesAPI extends APIBase {
   /**
@@ -51,9 +51,9 @@ export class SourcesAPI extends APIBase {
   }
   /**
    * Get all sources.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetSources
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetSources
    */
   getSources(
     request?: GetSourcesRequest,
@@ -68,9 +68,9 @@ export class SourcesAPI extends APIBase {
   }
   /**
    * Creates a source.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostSources
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostSources
    */
   postSources(
     request: PostSourcesRequest,
@@ -86,9 +86,9 @@ export class SourcesAPI extends APIBase {
   }
   /**
    * Get a source.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetSourcesID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetSourcesID
    */
   getSourcesID(
     request: GetSourcesIDRequest,
@@ -103,9 +103,9 @@ export class SourcesAPI extends APIBase {
   }
   /**
    * Update a Source.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchSourcesID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchSourcesID
    */
   patchSourcesID(
     request: PatchSourcesIDRequest,
@@ -121,9 +121,9 @@ export class SourcesAPI extends APIBase {
   }
   /**
    * Delete a source.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteSourcesID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteSourcesID
    */
   deleteSourcesID(
     request: DeleteSourcesIDRequest,
@@ -138,9 +138,9 @@ export class SourcesAPI extends APIBase {
   }
   /**
    * Get the health of a source.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetSourcesIDHealth
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetSourcesIDHealth
    */
   getSourcesIDHealth(
     request: GetSourcesIDHealthRequest,
@@ -155,9 +155,9 @@ export class SourcesAPI extends APIBase {
   }
   /**
    * Get buckets in a source.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetSourcesIDBuckets
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetSourcesIDBuckets
    */
   getSourcesIDBuckets(
     request: GetSourcesIDBucketsRequest,

--- a/packages/apis/src/generated/SourcesAPI.ts
+++ b/packages/apis/src/generated/SourcesAPI.ts
@@ -34,13 +34,14 @@ export interface GetSourcesIDBucketsRequest {
   org?: string
 }
 /**
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetSources
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostSources
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetSourcesID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchSourcesID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteSourcesID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetSourcesIDHealth
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetSourcesIDBuckets
+ * See
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetSources
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostSources
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetSourcesID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PatchSourcesID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteSourcesID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetSourcesIDHealth
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetSourcesIDBuckets
  */
 export class SourcesAPI extends APIBase {
   /**

--- a/packages/apis/src/generated/TasksAPI.ts
+++ b/packages/apis/src/generated/TasksAPI.ts
@@ -145,27 +145,28 @@ export interface DeleteTasksIDOwnersIDRequest {
   taskID: string
 }
 /**
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasks
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasks
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchTasksID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDRuns
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDRuns
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDRunsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksIDRunsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDRunsIDRetry
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDLogs
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDRunsIDLogs
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDLabels
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDLabels
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksIDLabelsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDMembers
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDMembers
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksIDMembersID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDOwners
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDOwners
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksIDOwnersID
+ * See
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasks
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasks
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PatchTasksID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDRuns
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDRuns
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDRunsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksIDRunsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDRunsIDRetry
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDLogs
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDRunsIDLogs
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDLabels
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDLabels
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksIDLabelsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDMembers
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDMembers
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksIDMembersID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDOwners
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDOwners
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksIDOwnersID
  */
 export class TasksAPI extends APIBase {
   /**

--- a/packages/apis/src/generated/TasksAPI.ts
+++ b/packages/apis/src/generated/TasksAPI.ts
@@ -145,27 +145,27 @@ export interface DeleteTasksIDOwnersIDRequest {
   taskID: string
 }
 /**
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasks
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasks
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchTasksID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDRuns
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDRuns
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDRunsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksIDRunsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDRunsIDRetry
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDLogs
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDRunsIDLogs
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDLabels
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDLabels
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksIDLabelsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDMembers
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDMembers
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksIDMembersID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDOwners
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDOwners
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksIDOwnersID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasks
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasks
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchTasksID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDRuns
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDRuns
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDRunsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksIDRunsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDRunsIDRetry
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDLogs
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDRunsIDLogs
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDLabels
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDLabels
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksIDLabelsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDMembers
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDMembers
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksIDMembersID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDOwners
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDOwners
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksIDOwnersID
  */
 export class TasksAPI extends APIBase {
   /**
@@ -176,9 +176,9 @@ export class TasksAPI extends APIBase {
   }
   /**
    * List all tasks.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasks
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasks
    */
   getTasks(
     request?: GetTasksRequest,
@@ -201,9 +201,9 @@ export class TasksAPI extends APIBase {
   }
   /**
    * Create a new task.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasks
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasks
    */
   postTasks(
     request: PostTasksRequest,
@@ -219,9 +219,9 @@ export class TasksAPI extends APIBase {
   }
   /**
    * Retrieve a task.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksID
    */
   getTasksID(
     request: GetTasksIDRequest,
@@ -236,9 +236,9 @@ export class TasksAPI extends APIBase {
   }
   /**
    * Update a task.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchTasksID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchTasksID
    */
   patchTasksID(
     request: PatchTasksIDRequest,
@@ -254,9 +254,9 @@ export class TasksAPI extends APIBase {
   }
   /**
    * Delete a task.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksID
    */
   deleteTasksID(
     request: DeleteTasksIDRequest,
@@ -271,9 +271,9 @@ export class TasksAPI extends APIBase {
   }
   /**
    * List runs for a task.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDRuns
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDRuns
    */
   getTasksIDRuns(
     request: GetTasksIDRunsRequest,
@@ -293,9 +293,9 @@ export class TasksAPI extends APIBase {
   }
   /**
    * Manually start a task run, overriding the current schedule.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDRuns
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDRuns
    */
   postTasksIDRuns(
     request: PostTasksIDRunsRequest,
@@ -311,9 +311,9 @@ export class TasksAPI extends APIBase {
   }
   /**
    * Retrieve a single run for a task.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDRunsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDRunsID
    */
   getTasksIDRunsID(
     request: GetTasksIDRunsIDRequest,
@@ -328,9 +328,9 @@ export class TasksAPI extends APIBase {
   }
   /**
    * Cancel a running task.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksIDRunsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksIDRunsID
    */
   deleteTasksIDRunsID(
     request: DeleteTasksIDRunsIDRequest,
@@ -345,9 +345,9 @@ export class TasksAPI extends APIBase {
   }
   /**
    * Retry a task run.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDRunsIDRetry
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDRunsIDRetry
    */
   postTasksIDRunsIDRetry(
     request: PostTasksIDRunsIDRetryRequest,
@@ -362,9 +362,9 @@ export class TasksAPI extends APIBase {
   }
   /**
    * Retrieve all logs for a task.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDLogs
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDLogs
    */
   getTasksIDLogs(
     request: GetTasksIDLogsRequest,
@@ -379,9 +379,9 @@ export class TasksAPI extends APIBase {
   }
   /**
    * Retrieve all logs for a run.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDRunsIDLogs
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDRunsIDLogs
    */
   getTasksIDRunsIDLogs(
     request: GetTasksIDRunsIDLogsRequest,
@@ -396,9 +396,9 @@ export class TasksAPI extends APIBase {
   }
   /**
    * List all labels for a task.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDLabels
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDLabels
    */
   getTasksIDLabels(
     request: GetTasksIDLabelsRequest,
@@ -413,9 +413,9 @@ export class TasksAPI extends APIBase {
   }
   /**
    * Add a label to a task.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDLabels
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDLabels
    */
   postTasksIDLabels(
     request: PostTasksIDLabelsRequest,
@@ -431,9 +431,9 @@ export class TasksAPI extends APIBase {
   }
   /**
    * Delete a label from a task.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksIDLabelsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksIDLabelsID
    */
   deleteTasksIDLabelsID(
     request: DeleteTasksIDLabelsIDRequest,
@@ -448,9 +448,9 @@ export class TasksAPI extends APIBase {
   }
   /**
    * List all task members.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDMembers
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDMembers
    */
   getTasksIDMembers(
     request: GetTasksIDMembersRequest,
@@ -465,9 +465,9 @@ export class TasksAPI extends APIBase {
   }
   /**
    * Add a member to a task.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDMembers
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDMembers
    */
   postTasksIDMembers(
     request: PostTasksIDMembersRequest,
@@ -483,9 +483,9 @@ export class TasksAPI extends APIBase {
   }
   /**
    * Remove a member from a task.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksIDMembersID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksIDMembersID
    */
   deleteTasksIDMembersID(
     request: DeleteTasksIDMembersIDRequest,
@@ -500,9 +500,9 @@ export class TasksAPI extends APIBase {
   }
   /**
    * List all owners of a task.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDOwners
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTasksIDOwners
    */
   getTasksIDOwners(
     request: GetTasksIDOwnersRequest,
@@ -517,9 +517,9 @@ export class TasksAPI extends APIBase {
   }
   /**
    * Add an owner to a task.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDOwners
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostTasksIDOwners
    */
   postTasksIDOwners(
     request: PostTasksIDOwnersRequest,
@@ -535,9 +535,9 @@ export class TasksAPI extends APIBase {
   }
   /**
    * Remove an owner from a task.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksIDOwnersID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTasksIDOwnersID
    */
   deleteTasksIDOwnersID(
     request: DeleteTasksIDOwnersIDRequest,

--- a/packages/apis/src/generated/TelegrafAPI.ts
+++ b/packages/apis/src/generated/TelegrafAPI.ts
@@ -6,7 +6,7 @@ export interface GetTelegrafPluginsRequest {
   type?: string
 }
 /**
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafPlugins
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafPlugins
  */
 export class TelegrafAPI extends APIBase {
   /**
@@ -16,9 +16,9 @@ export class TelegrafAPI extends APIBase {
     super(influxDB)
   }
   /**
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafPlugins
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafPlugins
    */
   getTelegrafPlugins(
     request?: GetTelegrafPluginsRequest,

--- a/packages/apis/src/generated/TelegrafAPI.ts
+++ b/packages/apis/src/generated/TelegrafAPI.ts
@@ -6,7 +6,8 @@ export interface GetTelegrafPluginsRequest {
   type?: string
 }
 /**
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafPlugins
+ * See
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafPlugins
  */
 export class TelegrafAPI extends APIBase {
   /**

--- a/packages/apis/src/generated/TelegrafsAPI.ts
+++ b/packages/apis/src/generated/TelegrafsAPI.ts
@@ -84,20 +84,21 @@ export interface DeleteTelegrafsIDOwnersIDRequest {
   telegrafID: string
 }
 /**
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafs
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTelegrafs
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PutTelegrafsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTelegrafsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafsIDLabels
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTelegrafsIDLabels
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTelegrafsIDLabelsID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafsIDMembers
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTelegrafsIDMembers
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTelegrafsIDMembersID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafsIDOwners
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTelegrafsIDOwners
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTelegrafsIDOwnersID
+ * See
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafs
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostTelegrafs
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PutTelegrafsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTelegrafsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafsIDLabels
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostTelegrafsIDLabels
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTelegrafsIDLabelsID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafsIDMembers
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostTelegrafsIDMembers
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTelegrafsIDMembersID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafsIDOwners
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostTelegrafsIDOwners
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTelegrafsIDOwnersID
  */
 export class TelegrafsAPI extends APIBase {
   /**

--- a/packages/apis/src/generated/TelegrafsAPI.ts
+++ b/packages/apis/src/generated/TelegrafsAPI.ts
@@ -84,20 +84,20 @@ export interface DeleteTelegrafsIDOwnersIDRequest {
   telegrafID: string
 }
 /**
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafs
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostTelegrafs
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PutTelegrafsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTelegrafsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafsIDLabels
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostTelegrafsIDLabels
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTelegrafsIDLabelsID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafsIDMembers
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostTelegrafsIDMembers
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTelegrafsIDMembersID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafsIDOwners
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostTelegrafsIDOwners
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTelegrafsIDOwnersID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafs
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTelegrafs
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PutTelegrafsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTelegrafsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafsIDLabels
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTelegrafsIDLabels
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTelegrafsIDLabelsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafsIDMembers
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTelegrafsIDMembers
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTelegrafsIDMembersID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafsIDOwners
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTelegrafsIDOwners
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTelegrafsIDOwnersID
  */
 export class TelegrafsAPI extends APIBase {
   /**
@@ -107,9 +107,9 @@ export class TelegrafsAPI extends APIBase {
     super(influxDB)
   }
   /**
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafs
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafs
    */
   getTelegrafs(
     request?: GetTelegrafsRequest,
@@ -124,9 +124,9 @@ export class TelegrafsAPI extends APIBase {
   }
   /**
    * Create a Telegraf config.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTelegrafs
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostTelegrafs
    */
   postTelegrafs(
     request: PostTelegrafsRequest,
@@ -142,9 +142,9 @@ export class TelegrafsAPI extends APIBase {
   }
   /**
    * Retrieve a Telegraf config.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafsID
    */
   getTelegrafsID(
     request: GetTelegrafsIDRequest,
@@ -159,9 +159,9 @@ export class TelegrafsAPI extends APIBase {
   }
   /**
    * Update a Telegraf config.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PutTelegrafsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PutTelegrafsID
    */
   putTelegrafsID(
     request: PutTelegrafsIDRequest,
@@ -177,9 +177,9 @@ export class TelegrafsAPI extends APIBase {
   }
   /**
    * Delete a Telegraf config.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTelegrafsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTelegrafsID
    */
   deleteTelegrafsID(
     request: DeleteTelegrafsIDRequest,
@@ -194,9 +194,9 @@ export class TelegrafsAPI extends APIBase {
   }
   /**
    * List all labels for a Telegraf config.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafsIDLabels
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafsIDLabels
    */
   getTelegrafsIDLabels(
     request: GetTelegrafsIDLabelsRequest,
@@ -211,9 +211,9 @@ export class TelegrafsAPI extends APIBase {
   }
   /**
    * Add a label to a Telegraf config.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTelegrafsIDLabels
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostTelegrafsIDLabels
    */
   postTelegrafsIDLabels(
     request: PostTelegrafsIDLabelsRequest,
@@ -229,9 +229,9 @@ export class TelegrafsAPI extends APIBase {
   }
   /**
    * Delete a label from a Telegraf config.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTelegrafsIDLabelsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTelegrafsIDLabelsID
    */
   deleteTelegrafsIDLabelsID(
     request: DeleteTelegrafsIDLabelsIDRequest,
@@ -246,9 +246,9 @@ export class TelegrafsAPI extends APIBase {
   }
   /**
    * List all users with member privileges for a Telegraf config.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafsIDMembers
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafsIDMembers
    */
   getTelegrafsIDMembers(
     request: GetTelegrafsIDMembersRequest,
@@ -263,9 +263,9 @@ export class TelegrafsAPI extends APIBase {
   }
   /**
    * Add a member to a Telegraf config.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTelegrafsIDMembers
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostTelegrafsIDMembers
    */
   postTelegrafsIDMembers(
     request: PostTelegrafsIDMembersRequest,
@@ -281,9 +281,9 @@ export class TelegrafsAPI extends APIBase {
   }
   /**
    * Remove a member from a Telegraf config.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTelegrafsIDMembersID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTelegrafsIDMembersID
    */
   deleteTelegrafsIDMembersID(
     request: DeleteTelegrafsIDMembersIDRequest,
@@ -298,9 +298,9 @@ export class TelegrafsAPI extends APIBase {
   }
   /**
    * List all owners of a Telegraf config.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafsIDOwners
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetTelegrafsIDOwners
    */
   getTelegrafsIDOwners(
     request: GetTelegrafsIDOwnersRequest,
@@ -315,9 +315,9 @@ export class TelegrafsAPI extends APIBase {
   }
   /**
    * Add an owner to a Telegraf config.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostTelegrafsIDOwners
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostTelegrafsIDOwners
    */
   postTelegrafsIDOwners(
     request: PostTelegrafsIDOwnersRequest,
@@ -333,9 +333,9 @@ export class TelegrafsAPI extends APIBase {
   }
   /**
    * Remove an owner from a Telegraf config.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTelegrafsIDOwnersID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteTelegrafsIDOwnersID
    */
   deleteTelegrafsIDOwnersID(
     request: DeleteTelegrafsIDOwnersIDRequest,

--- a/packages/apis/src/generated/UsersAPI.ts
+++ b/packages/apis/src/generated/UsersAPI.ts
@@ -34,13 +34,13 @@ export interface GetUsersIDLogsRequest {
   limit?: number
 }
 /**
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetUsers
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostUsers
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetUsersID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchUsersID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteUsersID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PutUsersIDPassword
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetUsersIDLogs
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetUsers
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostUsers
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetUsersID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchUsersID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteUsersID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PutUsersIDPassword
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetUsersIDLogs
  */
 export class UsersAPI extends APIBase {
   /**
@@ -51,9 +51,9 @@ export class UsersAPI extends APIBase {
   }
   /**
    * List all users.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetUsers
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetUsers
    */
   getUsers(
     request?: GetUsersRequest,
@@ -63,9 +63,9 @@ export class UsersAPI extends APIBase {
   }
   /**
    * Create a user.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostUsers
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostUsers
    */
   postUsers(
     request: PostUsersRequest,
@@ -81,9 +81,9 @@ export class UsersAPI extends APIBase {
   }
   /**
    * Retrieve a user.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetUsersID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetUsersID
    */
   getUsersID(
     request: GetUsersIDRequest,
@@ -98,9 +98,9 @@ export class UsersAPI extends APIBase {
   }
   /**
    * Update a user.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchUsersID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchUsersID
    */
   patchUsersID(
     request: PatchUsersIDRequest,
@@ -116,9 +116,9 @@ export class UsersAPI extends APIBase {
   }
   /**
    * Delete a user.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteUsersID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteUsersID
    */
   deleteUsersID(
     request: DeleteUsersIDRequest,
@@ -133,9 +133,9 @@ export class UsersAPI extends APIBase {
   }
   /**
    * Update a password.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PutUsersIDPassword
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PutUsersIDPassword
    */
   putUsersIDPassword(
     request: PutUsersIDPasswordRequest,
@@ -151,9 +151,9 @@ export class UsersAPI extends APIBase {
   }
   /**
    * Retrieve operation logs for a user.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetUsersIDLogs
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetUsersIDLogs
    */
   getUsersIDLogs(
     request: GetUsersIDLogsRequest,

--- a/packages/apis/src/generated/UsersAPI.ts
+++ b/packages/apis/src/generated/UsersAPI.ts
@@ -34,13 +34,14 @@ export interface GetUsersIDLogsRequest {
   limit?: number
 }
 /**
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetUsers
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostUsers
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetUsersID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchUsersID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteUsersID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PutUsersIDPassword
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetUsersIDLogs
+ * See
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetUsers
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostUsers
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetUsersID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PatchUsersID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteUsersID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PutUsersIDPassword
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetUsersIDLogs
  */
 export class UsersAPI extends APIBase {
   /**

--- a/packages/apis/src/generated/VariablesAPI.ts
+++ b/packages/apis/src/generated/VariablesAPI.ts
@@ -54,15 +54,16 @@ export interface DeleteVariablesIDLabelsIDRequest {
   labelID: string
 }
 /**
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetVariables
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostVariables
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetVariablesID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PutVariablesID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchVariablesID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteVariablesID
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetVariablesIDLabels
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostVariablesIDLabels
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteVariablesIDLabelsID
+ * See
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetVariables
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostVariables
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetVariablesID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PutVariablesID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PatchVariablesID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteVariablesID
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/GetVariablesIDLabels
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostVariablesIDLabels
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteVariablesIDLabelsID
  */
 export class VariablesAPI extends APIBase {
   /**

--- a/packages/apis/src/generated/VariablesAPI.ts
+++ b/packages/apis/src/generated/VariablesAPI.ts
@@ -54,15 +54,15 @@ export interface DeleteVariablesIDLabelsIDRequest {
   labelID: string
 }
 /**
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetVariables
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostVariables
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetVariablesID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PutVariablesID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchVariablesID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteVariablesID
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetVariablesIDLabels
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostVariablesIDLabels
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteVariablesIDLabelsID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetVariables
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostVariables
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetVariablesID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PutVariablesID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchVariablesID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteVariablesID
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetVariablesIDLabels
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostVariablesIDLabels
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteVariablesIDLabelsID
  */
 export class VariablesAPI extends APIBase {
   /**
@@ -73,9 +73,9 @@ export class VariablesAPI extends APIBase {
   }
   /**
    * Get all variables.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetVariables
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetVariables
    */
   getVariables(
     request?: GetVariablesRequest,
@@ -90,9 +90,9 @@ export class VariablesAPI extends APIBase {
   }
   /**
    * Create a variable.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostVariables
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostVariables
    */
   postVariables(
     request: PostVariablesRequest,
@@ -108,9 +108,9 @@ export class VariablesAPI extends APIBase {
   }
   /**
    * Get a variable.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetVariablesID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetVariablesID
    */
   getVariablesID(
     request: GetVariablesIDRequest,
@@ -125,9 +125,9 @@ export class VariablesAPI extends APIBase {
   }
   /**
    * Replace a variable.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PutVariablesID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PutVariablesID
    */
   putVariablesID(
     request: PutVariablesIDRequest,
@@ -143,9 +143,9 @@ export class VariablesAPI extends APIBase {
   }
   /**
    * Update a variable.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PatchVariablesID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PatchVariablesID
    */
   patchVariablesID(
     request: PatchVariablesIDRequest,
@@ -161,9 +161,9 @@ export class VariablesAPI extends APIBase {
   }
   /**
    * Delete a variable.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteVariablesID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteVariablesID
    */
   deleteVariablesID(
     request: DeleteVariablesIDRequest,
@@ -178,9 +178,9 @@ export class VariablesAPI extends APIBase {
   }
   /**
    * List all labels for a variable.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/GetVariablesIDLabels
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/GetVariablesIDLabels
    */
   getVariablesIDLabels(
     request: GetVariablesIDLabelsRequest,
@@ -195,9 +195,9 @@ export class VariablesAPI extends APIBase {
   }
   /**
    * Add a label to a variable.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostVariablesIDLabels
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostVariablesIDLabels
    */
   postVariablesIDLabels(
     request: PostVariablesIDLabelsRequest,
@@ -213,9 +213,9 @@ export class VariablesAPI extends APIBase {
   }
   /**
    * Delete a label from a variable.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteVariablesIDLabelsID
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteVariablesIDLabelsID
    */
   deleteVariablesIDLabelsID(
     request: DeleteVariablesIDLabelsIDRequest,

--- a/packages/apis/src/generated/WriteAPI.ts
+++ b/packages/apis/src/generated/WriteAPI.ts
@@ -13,7 +13,7 @@ export interface PostWriteRequest {
   precision?: any
 }
 /**
- * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostWrite
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostWrite
  */
 export class WriteAPI extends APIBase {
   /**
@@ -24,9 +24,9 @@ export class WriteAPI extends APIBase {
   }
   /**
    * Write time series data into InfluxDB.
+   * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostWrite
    * @param request
    * @return promise of response
-   * @see https://v2.docs.influxdata.com/v2.0/api/#operation/PostWrite
    */
   postWrite(
     request: PostWriteRequest,

--- a/packages/apis/src/generated/WriteAPI.ts
+++ b/packages/apis/src/generated/WriteAPI.ts
@@ -13,7 +13,8 @@ export interface PostWriteRequest {
   precision?: any
 }
 /**
- * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostWrite
+ * See
+ * * https://v2.docs.influxdata.com/v2.0/api/#operation/PostWrite
  */
 export class WriteAPI extends APIBase {
   /**

--- a/packages/core/src/Point.ts
+++ b/packages/core/src/Point.ts
@@ -2,7 +2,7 @@ import {escape} from './util/escape'
 import {PointSettings} from './options'
 /**
  * Point defines the values that will be written to the database.
- * <a href="http://bit.ly/influxdata-point">See Go Implementation</a>.
+ * See [Go Implementation](http://bit.ly/influxdata-point)
  */
 export default class Point {
   private name: string

--- a/packages/core/src/QueryApi.ts
+++ b/packages/core/src/QueryApi.ts
@@ -30,7 +30,7 @@ export interface QueryOptions {
 
 /**
  * Query InfluxDB 2.0. Provides methods that notify abouts result lines of the executed query.
- * @see <a href="https://v2.docs.influxdata.com/v2.0/api/#operation/PostQuery">https://v2.docs.influxdata.com/v2.0/api/#operation/PostQuery</a>.
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostQuery
  */
 export default interface QueryApi {
   /**
@@ -42,7 +42,7 @@ export default interface QueryApi {
 
   /**
    * Executes the query and receives result lines (including empty and annotation lines)
-   * through the supplied consumer. See <a href="https://v2.docs.influxdata.com/v2.0/reference/syntax/annotated-csv/">annotated-csv</a>.
+   * through the supplied consumer. See [annotated-csv](https://v2.docs.influxdata.com/v2.0/reference/syntax/annotated-csv/).
    *
    * @param record single line in the query result
    * @param consumer data/error consumer

--- a/packages/core/src/WriteApi.ts
+++ b/packages/core/src/WriteApi.ts
@@ -3,7 +3,7 @@ import Point from './Point'
 /**
  * The asynchronous buffering API to Write time-series data into InfluxDB 2.0.
  * <p>
- * The data are formatted in <a href="https://bit.ly/2QL99fu">Line Protocol</a>.
+ * The data are formatted in [Line Protocol](https://bit.ly/2QL99fu).
  * <p>
  */
 export default interface WriteApi {
@@ -15,14 +15,14 @@ export default interface WriteApi {
   useDefaultTags(tags: {[key: string]: string}): WriteApi
 
   /**
-   * Write a line of <a href="https://bit.ly/2QL99fu">Line Protocol</a>.
+   * Write a line of [Line Protocol](https://bit.ly/2QL99fu).
    *
    * @param record line in InfluxDB Line Protocol.
    */
   writeRecord(record: string): void
 
   /**
-   * Write lines of <a href="https://bit.ly/2QL99fu">Line Protocol</a>.
+   * Write lines of [Line Protocol](https://bit.ly/2QL99fu).
    *
    * @param records lines in InfluxDB Line Protocol
    */

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -79,7 +79,7 @@ export interface ClientOptions extends ConnectionOptions {
 
 /**
  * Precission for write operations.
- * @see <a href="https://v2.docs.influxdata.com/v2.0/api/#operation/PostWrite">https://v2.docs.influxdata.com/v2.0/api/#operation/PostWrite</a>
+ * See https://v2.docs.influxdata.com/v2.0/api/#operation/PostWrite
  */
 export const enum WritePrecision {
   /** nanosecond */

--- a/packages/core/src/query/FluxTableColumn.ts
+++ b/packages/core/src/query/FluxTableColumn.ts
@@ -33,7 +33,7 @@ export interface FluxTableColumnLike {
   defaultValue?: string
 }
 /**
- * Column metadata of a flux [table](http://bit.ly/flux-spec#table).
+ * Column metadata of a [flux table](http://bit.ly/flux-spec#table).
  */
 export default class FluxTableColumn {
   /**

--- a/packages/core/src/query/FluxTableColumn.ts
+++ b/packages/core/src/query/FluxTableColumn.ts
@@ -33,7 +33,7 @@ export interface FluxTableColumnLike {
   defaultValue?: string
 }
 /**
- * Column metadata of a flux <a href="http://bit.ly/flux-spec#table">table</a>.
+ * Column metadata of a flux [table](http://bit.ly/flux-spec#table).
  */
 export default class FluxTableColumn {
   /**

--- a/packages/core/src/query/FluxTableMetaData.ts
+++ b/packages/core/src/query/FluxTableMetaData.ts
@@ -4,7 +4,7 @@ import {IllegalArgumentError} from '../errors'
 const identity = (x: string): any => x
 /**
  * A dictionary of serializers of particular types returned by a flux query
- * @see https://v2.docs.influxdata.com/v2.0/reference/syntax/annotated-csv/#valid-data-types
+ * See https://v2.docs.influxdata.com/v2.0/reference/syntax/annotated-csv/#valid-data-types
  */
 export const typeSerializers: {[key: string]: (val: string) => any} = {
   boolean: (x: string): any => x === 'true',
@@ -17,7 +17,7 @@ export const typeSerializers: {[key: string]: (val: string) => any} = {
   duration: identity,
 }
 /**
- * Represents metadata of a flux <a href="http://bit.ly/flux-spec#table">table</a>.
+ * Represents metadata of a flux [table](http://bit.ly/flux-spec#table).
  */
 export default class FluxTableMetaData {
   /**

--- a/packages/core/src/query/FluxTableMetaData.ts
+++ b/packages/core/src/query/FluxTableMetaData.ts
@@ -3,7 +3,7 @@ import {IllegalArgumentError} from '../errors'
 
 const identity = (x: string): any => x
 /**
- * A dictionary of serializers of particular types returned by a flux query
+ * A dictionary of serializers of particular types returned by a flux query.
  * See https://v2.docs.influxdata.com/v2.0/reference/syntax/annotated-csv/#valid-data-types
  */
 export const typeSerializers: {[key: string]: (val: string) => any} = {

--- a/packages/core/src/query/FluxTableMetaData.ts
+++ b/packages/core/src/query/FluxTableMetaData.ts
@@ -17,7 +17,7 @@ export const typeSerializers: {[key: string]: (val: string) => any} = {
   duration: identity,
 }
 /**
- * Represents metadata of a flux [table](http://bit.ly/flux-spec#table).
+ * Represents metadata of a [flux table](http://bit.ly/flux-spec#table).
  */
 export default class FluxTableMetaData {
   /**


### PR DESCRIPTION
Fixes #172 

## Proposed Changes
Remove all @see doc comments and replace them with  plain links or Markdown https://typedoc.org/guides/doccomments/

## Checklist

  - [x] CHANGELOG.md updated
  - [x] `yarn test` completes successfully
  - [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
