### PR TITLE
feat: allow to set Point's timestamp using Date or number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ### Features
 
+1. [#174](https://github.com/influxdata/influxdb-client-js/pull/174): Allow to set Point's timestamp using Date or number
+
 ### Bug Fixes
 
 1. [#160](https://github.com/influxdata/influxdb-client-js/issues/160): Disabled using credentials for CORS
-1. [#173](https://github.com/influxdata/influxdb-client-js/pull/173): use links that are clickable in VSCode
+1. [#173](https://github.com/influxdata/influxdb-client-js/pull/173): Use links that are clickable in VSCode
 
 ### Security
 

--- a/packages/core/src/Point.ts
+++ b/packages/core/src/Point.ts
@@ -113,7 +113,12 @@ export default class Point {
   }
 
   /**
-   * Sets point time.
+   * Sets point time. A string or number value is used
+   * to carry an int64 value of a precision that depends
+   * on WriteApi, nanoseconds by default. An undefined value
+   * generates a local timestamp using the client's clock.
+   * An empty string can be used to let the server assign
+   * the timestamp.
    *
    * @param value point time
    * @return this

--- a/packages/core/src/Point.ts
+++ b/packages/core/src/Point.ts
@@ -8,7 +8,7 @@ export default class Point {
   private name: string
   private tags: {[key: string]: string} = {}
   private fields: {[key: string]: string} = {}
-  private time: string | undefined
+  private time: string | number | Date | undefined
 
   /**
    * Create a new Point with specified a measurement name.
@@ -118,7 +118,7 @@ export default class Point {
    * @param value point time
    * @return this
    */
-  public timestamp(value: string | undefined): Point {
+  public timestamp(value: string | number | Date | undefined): Point {
     this.time = value
     return this
   }

--- a/packages/core/src/impl/WriteApiImpl.ts
+++ b/packages/core/src/impl/WriteApiImpl.ts
@@ -224,14 +224,14 @@ export default class WriteApiImpl implements WriteApi, PointSettings {
   convertTime(value: string | number | Date | undefined): string | undefined {
     if (value === undefined) {
       return this.currentTime()
-    } else if (value instanceof Date) {
-      return this.dateToProtocolTimestamp(value)
     } else if (typeof value === 'string') {
       return value.length > 0 ? value : undefined
+    } else if (value instanceof Date) {
+      return this.dateToProtocolTimestamp(value)
     } else if (typeof value === 'number') {
-      return String(value)
+      return String(Math.floor(value))
     } else {
-      Logger.error(`unsupported timestamp value: ${value}`)
+      // Logger.warn(`unsupported timestamp value: ${value}`)
       return String(value)
     }
   }

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -98,5 +98,7 @@ export const enum WritePrecision {
  */
 export interface PointSettings {
   defaultTags?: {[key: string]: string}
-  convertTime?: (value: string | undefined) => string | undefined
+  convertTime?: (
+    value: string | number | Date | undefined
+  ) => string | undefined
 }

--- a/packages/core/src/util/currentTime.ts
+++ b/packages/core/src/util/currentTime.ts
@@ -86,3 +86,11 @@ export const currentTime = Object.freeze({
   micros,
   nanos,
 })
+
+export const dateToProtocolTimestamp = {
+  [String(WritePrecision.s)]: (d: Date): string =>
+    `${Math.floor(d.getTime() / 1000)}`,
+  [String(WritePrecision.ms)]: (d: Date): string => `${d.getTime()}`,
+  [String(WritePrecision.us)]: (d: Date): string => `${d.getTime()}000`,
+  [String(WritePrecision.ns)]: (d: Date): string => `${d.getTime()}000000`,
+}

--- a/packages/core/test/unit/WriteApi.test.ts
+++ b/packages/core/test/unit/WriteApi.test.ts
@@ -209,18 +209,18 @@ describe('WriteApi', () => {
       expect(logs.error).to.length(0)
       expect(logs.warn).to.length(1)
       subject.writePoints([
-        new Point('test'), // will be ignored
+        new Point('test'), // will be ignored + warning
         new Point('test').floatField('value', 2),
         new Point('test').floatField('value', 3),
         new Point('test').floatField('value', 4).timestamp('1'),
-        new Point('test').floatField('value', 5).timestamp(2),
+        new Point('test').floatField('value', 5).timestamp(2.1),
         new Point('test').floatField('value', 6).timestamp(new Date(3)),
         new Point('test')
           .floatField('value', 7)
-          .timestamp((false as any) as string), // wrong type from js
+          .timestamp((false as any) as string), // server decides what to do with such values
       ])
       await new Promise(resolve => setTimeout(resolve, 10)) // wait for background flush and HTTP to finish
-      expect(logs.error).to.length(1) // true value is not a supported value
+      expect(logs.error).to.length(0)
       expect(logs.warn).to.length(2)
       expect(messages).to.have.length(2)
       expect(messages[0]).to.equal('test,t=\\ ,xtra=1 value=1')

--- a/packages/core/test/unit/WriteApi.test.ts
+++ b/packages/core/test/unit/WriteApi.test.ts
@@ -213,17 +213,19 @@ describe('WriteApi', () => {
         new Point('test').floatField('value', 2),
         new Point('test').floatField('value', 3),
         new Point('test').floatField('value', 4).timestamp('1'),
+        new Point('test').floatField('value', 5).timestamp(2),
+        new Point('test').floatField('value', 6).timestamp(new Date(3)),
+        new Point('test')
+          .floatField('value', 7)
+          .timestamp((false as any) as string), // wrong type from js
       ])
       await new Promise(resolve => setTimeout(resolve, 10)) // wait for background flush and HTTP to finish
-      expect(logs.error).to.length(0)
-      expect(logs.warn).to.length(2)
-      await new Promise(resolve => setTimeout(resolve, 10)) // wait for background flush
-      expect(logs.error).to.length(0)
+      expect(logs.error).to.length(1) // true value is not a supported value
       expect(logs.warn).to.length(2)
       expect(messages).to.have.length(2)
       expect(messages[0]).to.equal('test,t=\\ ,xtra=1 value=1')
       const lines = messages[1].split('\n')
-      expect(lines).has.length(3)
+      expect(lines).has.length(6)
       expect(lines[0]).to.satisfy((line: string) =>
         line.startsWith('test,xtra=1 value=2')
       )
@@ -237,10 +239,9 @@ describe('WriteApi', () => {
         String(Date.now()).length + 6 // nanosecond precision
       )
       expect(lines[2]).to.be.equal('test,xtra=1 value=4 1')
-      lines.forEach(_line => {})
-      await subject.flush().then(() => {
-        expect(logs.error).to.length(0)
-      })
+      expect(lines[3]).to.be.equal('test,xtra=1 value=5 2')
+      expect(lines[4]).to.be.equal('test,xtra=1 value=6 3000000')
+      expect(lines[5]).to.be.equal('test,xtra=1 value=7 false')
     })
   })
 })

--- a/packages/core/test/unit/util/currentTime.test.ts
+++ b/packages/core/test/unit/util/currentTime.test.ts
@@ -1,4 +1,8 @@
-import {currentTime, useProcessHrtime} from '../../../src'
+import {
+  currentTime,
+  useProcessHrtime,
+  dateToProtocolTimestamp,
+} from '../../../src'
 import {expect} from 'chai'
 
 describe('currentTime', () => {
@@ -74,4 +78,14 @@ describe('currentTime', () => {
       }
     )
   })
+})
+
+describe('dateToProtocolTimestamp', () => {
+  const subject = new Date(1584294154693)
+  expect(dateToProtocolTimestamp['s'](subject)).to.be.equal('1584294154')
+  expect(dateToProtocolTimestamp['ms'](subject)).to.be.equal('1584294154693')
+  expect(dateToProtocolTimestamp['us'](subject)).to.be.equal('1584294154693000')
+  expect(dateToProtocolTimestamp['ns'](subject)).to.be.equal(
+    '1584294154693000000'
+  )
 })


### PR DESCRIPTION
Fixes #171 

## Proposed Changes

Currently, when a Point is written via the WriteAPI, it can include timestamp as a string. A non-string value will silently generate the time stamp on the client. This is not handy from a user perspective, it should be possible to also set a number or Date.

## Checklist

  - [x] CHANGELOG.md updated
  - [x] A test has been added if appropriate
  - [x] `yarn test` completes successfully
  - [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
