### PR TITLE
feat(query): add now to query options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 1. [#177](https://github.com/influxdata/influxdb-client-js/pull/177): Allow to receive query results as [Observable](https://github.com/tc39/proposal-observable)
 1. [#181](https://github.com/influxdata/influxdb-client-js/pull/181): Update APIs from swagger as of 2020-04-30
+1. [#182](https://github.com/influxdata/influxdb-client-js/pull/182): Allow setting the time that should be reported as "now" in the query
 
 ## 1.2.0 [2020-04-17]
 

--- a/packages/core/src/QueryApi.ts
+++ b/packages/core/src/QueryApi.ts
@@ -27,6 +27,11 @@ export interface QueryOptions {
    * Requests gzip encoded response.
    */
   gzip?: boolean
+  /**
+   * Specifies the time that should be reported as "now" in the query. RFC3339 value must be returned,
+   * for example `new Date().toISOString()`.
+   */
+  now?: () => string
 }
 
 /** Wraps values and associated metadata of a query result row */

--- a/packages/core/src/impl/QueryApiImpl.ts
+++ b/packages/core/src/impl/QueryApiImpl.ts
@@ -60,11 +60,13 @@ export class QueryApiImpl implements QueryApi {
     return (consumer): void => {
       this.transport.send(
         `/api/v2/query?org=${encodeURIComponent(org)}`,
-        JSON.stringify({
-          query,
-          dialect: DEFAULT_dialect,
-          type,
-        }),
+        JSON.stringify(
+          this.decorateRequest({
+            query,
+            dialect: DEFAULT_dialect,
+            type,
+          })
+        ),
         {
           method: 'POST',
           headers: {
@@ -75,6 +77,14 @@ export class QueryApiImpl implements QueryApi {
         new ChunksToLines(consumer, this.transport.chunkCombiner)
       )
     }
+  }
+  private decorateRequest(request: any): any {
+    if (typeof this.options.now === 'function') {
+      request.now = this.options.now()
+    }
+    // https://v2.docs.influxdata.com/v2.0/api/#operation/PostQuery requires type
+    request.type = this.options.type || 'flux'
+    return request
   }
 }
 

--- a/packages/core/src/query/FluxTableMetaData.ts
+++ b/packages/core/src/query/FluxTableMetaData.ts
@@ -1,4 +1,4 @@
-import FluxTableColumn from './FluxTableColumn'
+import FluxTableColumn, {ColumnType} from './FluxTableColumn'
 import {IllegalArgumentError} from '../errors'
 
 const identity = (x: string): any => x
@@ -6,7 +6,7 @@ const identity = (x: string): any => x
  * A dictionary of serializers of particular types returned by a flux query.
  * See https://v2.docs.influxdata.com/v2.0/reference/syntax/annotated-csv/#valid-data-types
  */
-export const typeSerializers: {[key: string]: (val: string) => any} = {
+export const typeSerializers: Record<ColumnType, (val: string) => any> = {
   boolean: (x: string): any => x === 'true',
   unsignedLong: identity,
   long: identity,
@@ -51,9 +51,7 @@ export default class FluxTableMetaData {
       if (val === '' && column.defaultValue) {
         val = column.defaultValue
       }
-      acc[column.label] = (
-        typeSerializers[column.dataType as string] || identity
-      )(val)
+      acc[column.label] = (typeSerializers[column.dataType] || identity)(val)
     }
     return acc
   }


### PR DESCRIPTION
Allow setting the time that should be reported as "now" in the query.

## Checklist

  - [x] CHANGELOG.md updated
  - [x] A test has been added if appropriate
  - [x] `yarn test` completes successfully
  - [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
