### PR TITLE
feat(core): allow to create write API with custom writeOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 1. [#181](https://github.com/influxdata/influxdb-client-js/pull/181): Update APIs from swagger as of 2020-04-30
 1. [#182](https://github.com/influxdata/influxdb-client-js/pull/182): Allow setting the time that should be reported as "now" in the query
 1. [#183](https://github.com/influxdata/influxdb-client-js/pull/183): Remove trailing slash from connection URL
+1. [#185](https://github.com/influxdata/influxdb-client-js/pull/185): Allow to create WriteApi with custom write options.
 
 ## 1.2.0 [2020-04-17]
 

--- a/packages/core/src/InfluxDB.ts
+++ b/packages/core/src/InfluxDB.ts
@@ -1,5 +1,5 @@
 import WriteApi from './WriteApi'
-import {ClientOptions, WritePrecision} from './options'
+import {ClientOptions, WritePrecision, WriteOptions} from './options'
 import WriteApiImpl from './impl/WriteApiImpl'
 import {IllegalArgumentError} from './errors'
 import {Transport} from './transport'
@@ -41,18 +41,20 @@ export default class InfluxDB {
    * @param org Specifies the destination organization for writes. Takes either the ID or Name interchangeably.
    * @param bucket The destination bucket for writes.
    * @param precision Timestamp precision for line items.
+   * @param options Custom write options.
    */
   getWriteApi(
     org: string,
     bucket: string,
-    precision: WritePrecision = WritePrecision.ns
+    precision: WritePrecision = WritePrecision.ns,
+    options?: Partial<WriteOptions>
   ): WriteApi {
     return new WriteApiImpl(
       this.transport,
       org,
       bucket,
       precision,
-      this._options.writeOptions
+      options || this._options.writeOptions
     )
   }
 

--- a/packages/core/src/InfluxDB.ts
+++ b/packages/core/src/InfluxDB.ts
@@ -41,20 +41,20 @@ export default class InfluxDB {
    * @param org Specifies the destination organization for writes. Takes either the ID or Name interchangeably.
    * @param bucket The destination bucket for writes.
    * @param precision Timestamp precision for line items.
-   * @param options Custom write options.
+   * @param writeOptions Custom write options.
    */
   getWriteApi(
     org: string,
     bucket: string,
     precision: WritePrecision = WritePrecision.ns,
-    options?: Partial<WriteOptions>
+    writeOptions?: Partial<WriteOptions>
   ): WriteApi {
     return new WriteApiImpl(
       this.transport,
       org,
       bucket,
       precision,
-      options || this._options.writeOptions
+      writeOptions || this._options.writeOptions
     )
   }
 

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -71,9 +71,9 @@ export const DEFAULT_WriteOptions: WriteOptions = Object.freeze({
  * Options used by [[InfluxDB]] .
  */
 export interface ClientOptions extends ConnectionOptions {
-  /** to override default writing options */
+  /** supplies and overrides default writing options */
   writeOptions?: Partial<WriteOptions>
-  /** to specify custom transport */
+  /** specifies custom transport */
   transport?: Transport
 }
 

--- a/packages/core/test/unit/WriteApi.test.ts
+++ b/packages/core/test/unit/WriteApi.test.ts
@@ -85,10 +85,9 @@ describe('WriteApi', () => {
     let subject: WriteApi
     let logs: CollectedLogs
     function useSubject(writeOptions: Partial<WriteOptions>): void {
-      subject = createApi(ORG, BUCKET, PRECISION, {
-        retryJitter: 0,
-        ...writeOptions,
-      })
+      subject = new InfluxDB({
+        ...clientOptions,
+      }).getWriteApi(ORG, BUCKET, PRECISION, writeOptions)
     }
     beforeEach(() => {
       // logs = collectLogging.decorate()


### PR DESCRIPTION
Fixes #184 

## Proposed Changes
Adds optional writeOptions to getWriteApi
```js
getWriteApi(
    org: string,
    bucket: string,
    precision: WritePrecision = WritePrecision.ns,
    writeOptions?: Partial<WriteOptions>
  ): WriteApi {
```

## Checklist

  - [x] CHANGELOG.md updated
  - [x] A test has been added if appropriate
  - [x] `yarn test` completes successfully
  - [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
