### PR TITLE
fix(example): add timestamp to write example

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -40,7 +40,7 @@
           .tag('example', 'index.html')
           .floatField('value', value)
         writeApi.writePoint(point1)
-        log(` ${point1}`)
+        log(` ${point1.toLineProtocol()}`)
 
         // flush pending writes and close writeApi
         writeApi

--- a/examples/write.js
+++ b/examples/write.js
@@ -8,20 +8,23 @@ const {url, token, org, bucket} = require('./env')
 const {hostname} = require('os')
 
 console.log('*** WRITE POINTS ***')
-const writeApi = new InfluxDB({url, token}).getWriteApi(org, bucket)
+const writeApi = new InfluxDB({url, token}).getWriteApi(org, bucket, 'ns')
 // setup default tags for all writes through this API
 writeApi.useDefaultTags({location: hostname()})
 
+// write point with the current (client-side) timestamp
 const point1 = new Point('temperature')
   .tag('example', 'write.ts')
   .floatField('value', 20 + Math.round(100 * Math.random()) / 10)
 writeApi.writePoint(point1)
 console.log(` ${point1}`)
+// write point with a custom timestamp
 const point2 = new Point('temperature')
   .tag('example', 'write.ts')
   .floatField('value', 10 + Math.round(100 * Math.random()) / 10)
+  .timestamp(new Date()) // can be also a number, but in writeApi's precision units (s, ms, us, ns)!
 writeApi.writePoint(point2)
-console.log(` ${point2}`)
+console.log(` ${point2.toLineProtocol(writeApi)}`)
 
 // flush pending writes and close writeApi
 writeApi

--- a/packages/core/src/Point.ts
+++ b/packages/core/src/Point.ts
@@ -113,7 +113,7 @@ export default class Point {
   }
 
   /**
-   * Sets point time. A string or number value is used
+   * Sets point time. A string or number value can be used
    * to carry an int64 value of a precision that depends
    * on WriteApi, nanoseconds by default. An undefined value
    * generates a local timestamp using the client's clock.
@@ -123,7 +123,7 @@ export default class Point {
    * @param value point time
    * @return this
    */
-  public timestamp(value: string | number | Date | undefined): Point {
+  public timestamp(value: Date | number | string | undefined): Point {
     this.time = value
     return this
   }


### PR DESCRIPTION
Fixes #188

## Proposed Changes

Show how to use point timestamp to write.js, change write examples to print points as protocol lines.

## Checklist

  - [ ] CHANGELOG.md updated
  - [x] `yarn test` completes successfully
  - [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
