### PR TITLE
fix(core/query): remove influxql support #195

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 1. [#186](https://github.com/influxdata/influxdb-client-js/pull/186): Allow to create parameterized queries using flux tagged template.
 1. [#191](https://github.com/influxdata/influxdb-client-js/pull/191): Update APIs from swagger as of 2020-05-27
+1. [#196](https://github.com/influxdata/influxdb-client-js/pull/196): Remove influxql option from Query API
 
 ### Documentation
 

--- a/packages/core/src/QueryApi.ts
+++ b/packages/core/src/QueryApi.ts
@@ -14,19 +14,7 @@ export interface QueryOptions {
   /**
    * Type of the query, default is "flux"
    */
-  type?: 'influxql' | 'flux'
-  /**
-   * Required only for "influxql" queries.
-   */
-  cluster?: string
-  /**
-   * Required only for "influxql" queries.
-   */
-  db?: string
-  /**
-   * Required only for "influxql" queries.
-   */
-  rp?: string
+  type?: 'flux'
   /**
    * Requests gzip encoded response.
    */


### PR DESCRIPTION
Fixes #195

This PR removes support for influxql queries in the query API, there are multiple reasons for doing this:
   * the state of support of influxql queries in InfluxDB 2.0 is unknown and not documented
   * the server returns json data to influxql query, such data is not parseable by this client that expect CSV data as the only option explained by the docs
   * even 1.x server does not support influxql in 2.0 compatibility API

## Checklist

  - [x] CHANGELOG.md updated
  - [x] A test has been added if appropriate
  - [x] `yarn test` completes successfully
  - [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
