### PR TITLE
feat(core/query): add collectRows and collectLines to query API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ### Features
 
 1. [#186](https://github.com/influxdata/influxdb-client-js/pull/186): Allow to create parameterized queries using flux tagged template.
-1. [#191](https://github.com/influxdata/influxdb-client-js/pull/191): Regenerate APIs from swagger
-1. [#196](https://github.com/influxdata/influxdb-client-js/pull/196): Remove influxql option from Query API
+1. [#191](https://github.com/influxdata/influxdb-client-js/pull/191): Regenerate APIs from swagger.
+1. [#196](https://github.com/influxdata/influxdb-client-js/pull/196): Remove influxql option from Query API.
+1. [#200](https://github.com/influxdata/influxdb-client-js/pull/200): Enhance Query API with collectRows and collectLines.
 
 ### Documentation
 

--- a/examples/query.ts
+++ b/examples/query.ts
@@ -3,7 +3,7 @@
 // Shows how to use InfluxDB query API. //
 //////////////////////////////////////////
 
-import {InfluxDB, FluxTableMetaData} from '@influxdata/influxdb-client'
+import {InfluxDB, FluxTableMetaData} from '../packages/core'
 import {url, token, org} from './env'
 
 const queryApi = new InfluxDB({url, token}).getQueryApi(org)
@@ -29,6 +29,19 @@ queryApi.queryRows(fluxQuery, {
     console.log('\nFinished SUCCESS')
   },
 })
+
+// // executes query and wait for all results in a Promise
+// // use with caution, it copies the whole stream of results into memory
+// queryApi
+//   .collectRows(fluxQuery /*, you can specify a row mapper as a second arg */)
+//   .then(data => {
+//     data.forEach(x => console.log(JSON.stringify(x)))
+//     console.log('\nCollect ROWS SUCCESS')
+//   })
+//   .catch(error => {
+//     console.error(error)
+//     console.log('\nCollect ROWS ERROR')
+//   })
 
 // performs query and receive line results in annotated csv format
 // https://v2.docs.influxdata.com/v2.0/reference/syntax/annotated-csv/

--- a/examples/query.ts
+++ b/examples/query.ts
@@ -3,7 +3,7 @@
 // Shows how to use InfluxDB query API. //
 //////////////////////////////////////////
 
-import {InfluxDB, FluxTableMetaData} from '../packages/core'
+import {InfluxDB, FluxTableMetaData} from '@influxdata/influxdb-client'
 import {url, token, org} from './env'
 
 const queryApi = new InfluxDB({url, token}).getQueryApi(org)
@@ -11,7 +11,7 @@ const fluxQuery =
   'from(bucket:"my-bucket") |> range(start: 0) |> filter(fn: (r) => r._measurement == "temperature")'
 
 console.log('*** QUERY ROWS ***')
-// performs query and receive line table metadata and rows
+// Execute query and receive table metadata and rows.
 // https://v2.docs.influxdata.com/v2.0/reference/syntax/annotated-csv/
 queryApi.queryRows(fluxQuery, {
   next(row: string[], tableMeta: FluxTableMetaData) {
@@ -30,8 +30,8 @@ queryApi.queryRows(fluxQuery, {
   },
 })
 
-// // executes query and wait for all results in a Promise
-// // use with caution, it copies the whole stream of results into memory
+// // Execute query and collect all results in a Promise.
+// // Use with caution, it copies the whole stream of results into memory.
 // queryApi
 //   .collectRows(fluxQuery /*, you can specify a row mapper as a second arg */)
 //   .then(data => {
@@ -43,8 +43,7 @@ queryApi.queryRows(fluxQuery, {
 //     console.log('\nCollect ROWS ERROR')
 //   })
 
-// performs query and receive line results in annotated csv format
-// https://v2.docs.influxdata.com/v2.0/reference/syntax/annotated-csv/
+// Execute query and receive result lines in annotated csv format
 // queryApi.queryLines(
 //   fluxQuery,
 //   {

--- a/packages/core/src/QueryApi.ts
+++ b/packages/core/src/QueryApi.ts
@@ -6,6 +6,13 @@ import {
 } from './query'
 import {CommunicationObserver} from './transport'
 
+export function defaultRowMapping(
+  values: string[],
+  tableMeta: FluxTableMetaData
+): Record<string, any> {
+  return tableMeta.toObject(values)
+}
+
 export interface QueryOptions {
   /**
    * Specifies the name of the organization executing the query. Takes either the ID or Name interchangeably.
@@ -47,14 +54,14 @@ export default interface QueryApi {
   /**
    * Creates a cold observable of the lines returned by the given query.
    *
-   * @param query the query text in the format specifed in `QueryOptions.type`
+   * @param query query
    */
   lines(query: string | ParameterizedQuery): Observable<string>
 
   /**
    * Creates a cold observable of the rows returned by the given query.
    *
-   * @param query the query text in the format specifed in `QueryOptions.type`
+   * @param query query
    */
   rows(query: string | ParameterizedQuery): Observable<Row>
 
@@ -62,7 +69,7 @@ export default interface QueryApi {
    * Executes the query and receives result lines (including empty and annotation lines)
    * through the supplied consumer. See [annotated-csv](https://v2.docs.influxdata.com/v2.0/reference/syntax/annotated-csv/).
    *
-   * @param record single line in the query result
+   * @param query query
    * @param consumer data/error consumer
    */
   queryLines(
@@ -73,11 +80,38 @@ export default interface QueryApi {
   /**
    * Executes the query and receives table metadata and rows through the supplied consumer.
    *
-   * @param record single line in the query result
+   * @param query query
    * @param consumer data/error consumer
    */
   queryRows(
     query: string | ParameterizedQuery,
     consumer: FluxResultObserver<string[]>
   ): void
+
+  /**
+   * CollectRows executes the query and collects all the results in the returned Promise.
+   * This method is suitable to collect simple results. Use with caution,
+   * a possibly huge stream of results is copied to memory.
+   *
+   * @param query query
+   * @param rowMapper maps the supplied row to an item that is then collected,
+   *  undefined return values are not collected. If no rowMapper is supplied,
+   *  `row => row.tableMeta.toObject(row.values)` is used.
+   */
+  collectRows<T>(
+    query: string | ParameterizedQuery,
+    rowMapper?: (
+      values: string[],
+      tableMeta: FluxTableMetaData
+    ) => T | undefined
+  ): Promise<Array<T>>
+
+  /**
+   * CollectLines executes the query and collects all result lines in the returned Promise.
+   * This method is suitable to collect simple results. Use with caution,
+   * a possibly huge stream of lines is copied to memory.
+   *
+   * @param query query
+   */
+  collectLines(query: string | ParameterizedQuery): Promise<Array<string>>
 }


### PR DESCRIPTION
There are use cases in which the users want to receive all the query results in a Promise, knowing that the size of the data is not that big. It can be already achieved on top of the existing query API, but it would be better to provide such utility functions directly in the query API + document a warning that the new `collect*` methods store all the streamed query results into memory.

## Proposed Changes

* add `collectLines` to QueryApi
* add `collectRows` to QueryApi
* enhance query example with collectRows

## Checklist

  - [x] CHANGELOG.md updated
  - [x] A test has been added if appropriate
  - [x] `yarn test` completes successfully
  - [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
