### PR TITLE
feat(core/write): allow to supply listener for write failures

### DIFF
--- a/packages/core/src/impl/WriteApiImpl.ts
+++ b/packages/core/src/impl/WriteApiImpl.ts
@@ -132,15 +132,14 @@ export default class WriteApiImpl implements WriteApi, PointSettings {
         this.transport.send(this.httpPath, lines.join('\n'), this.sendOptions, {
           error(error: Error): void {
             // call the writeFailed listener and check if we can retry
-            if (
-              self.writeOptions.writeFailed.call(
-                self,
-                error,
-                lines,
-                self.writeOptions.maxRetries + 2 - attempts
-              ) === true
-            ) {
-              resolve()
+            const onRetry = self.writeOptions.writeFailed.call(
+              self,
+              error,
+              lines,
+              self.writeOptions.maxRetries + 2 - attempts
+            )
+            if (onRetry) {
+              onRetry.then(resolve, reject)
               return
             }
             if (

--- a/packages/core/src/impl/WriteApiImpl.ts
+++ b/packages/core/src/impl/WriteApiImpl.ts
@@ -160,10 +160,9 @@ export default class WriteApiImpl implements WriteApi, PointSettings {
               )
               reject(error)
               return
-            } else {
-              Logger.error(`Write to influx DB failed.`, error)
-              reject(error)
             }
+            Logger.error(`Write to influx DB failed.`, error)
+            reject(error)
           },
           complete(): void {
             self.retryStrategy.success()

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -1,4 +1,5 @@
 import {Transport} from './transport'
+import WriteApi from './WriteApi'
 
 /**
  * Option for the communication with InfluxDB server.
@@ -35,6 +36,20 @@ export interface RetryDelayStrategyOptions {
  * Options that configure strategy for retrying failed InfluxDB write operations.
  */
 export interface WriteRetryOptions extends RetryDelayStrategyOptions {
+  /*
+   * writeFailed is called to inform about write error
+   * @param this the instance of the API that failed
+   * @param error write error
+   * @param lines failed lines
+   * @param attempts a number of failed attempts to write the lines
+   * @return `true` forces the API to not retry again
+   */
+  writeFailed(
+    this: WriteApi,
+    error: Error,
+    lines: Array<string>,
+    attempts: number
+  ): boolean | void
   /** max number of retries when write fails */
   maxRetries: number
   /** the maximum size of retry-buffer (in lines) */
@@ -62,6 +77,7 @@ export const DEFAULT_RetryDelayStrategyOptions = Object.freeze({
 export const DEFAULT_WriteOptions: WriteOptions = Object.freeze({
   batchSize: 1000,
   flushInterval: 60000,
+  writeFailed: function() {},
   maxRetries: 2,
   maxBufferLines: 32_000,
   ...DEFAULT_RetryDelayStrategyOptions,

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -42,14 +42,15 @@ export interface WriteRetryOptions extends RetryDelayStrategyOptions {
    * @param error write error
    * @param lines failed lines
    * @param attempts a number of failed attempts to write the lines
-   * @return `true` forces the API to not retry again
+   * @return a Promise to force the API to not retry again and use the promise as a result of the flush operation,
+   * void/undefined to continue with default retry mechanism
    */
   writeFailed(
     this: WriteApi,
     error: Error,
     lines: Array<string>,
     attempts: number
-  ): boolean | void
+  ): Promise<void> | void
   /** max number of retries when write fails */
   maxRetries: number
   /** the maximum size of retry-buffer (in lines) */

--- a/packages/core/test/unit/WriteApi.test.ts
+++ b/packages/core/test/unit/WriteApi.test.ts
@@ -125,7 +125,7 @@ describe('WriteApi', () => {
         expect(logs.warn).is.deep.equal([])
       })
     })
-    it('does not retry write when writeFailed handler returns true', async () => {
+    it('does not retry write when writeFailed handler returns a Promise', async () => {
       useSubject({
         maxRetries: 3,
         batchSize: 1,
@@ -134,7 +134,7 @@ describe('WriteApi', () => {
             `CUSTOMERRORHANDLING ${!!error} ${lines.length} ${attempts}`,
             undefined
           )
-          return true
+          return Promise.resolve()
         },
       })
       subject.writeRecord('test value=1')


### PR DESCRIPTION
Fixes #197

## Proposed Changes

The following property was added to `writeOptions`, so it is now possible to know/observe/react upon writing failures in a custom way.
 
```
  /**
   * writeFailed is called to inform about write error
   * @param source the instance of the API that failed
   * @param error write error
   * @param lines failed lines
   * @param attempts a number of failed attempts to write the lines
   * @return a Promise to force the API to not retry again and use the promise as a result of the flush operation,
   * void/undefined to continue with default retry mechanism   
   */
  writeFailed?: (
    source: WriteApi,
    error: Error,
    lines: Array<string>,
    attempts: number
  ) => boolean | void
```
## Checklist

  - [ ] CHANGELOG.md updated
  - [x] A test has been added if appropriate
  - [x] `yarn test` completes successfully
  - [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
