### PR TITLE
feat(write): allow to supply default tags in WriteOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.5.0 [unreleased]
 
+### Features
+
+1. [#204](https://github.com/influxdata/influxdb-client-js/pull/204): Allow to supply default tags in WriteOptions.
+
 ## 1.4.0 [2020-06-19]
 
 ### Features

--- a/packages/core/src/impl/WriteApiImpl.ts
+++ b/packages/core/src/impl/WriteApiImpl.ts
@@ -87,6 +87,9 @@ export default class WriteApiImpl implements WriteApi, PointSettings {
     }
     this.currentTime = currentTime[precision]
     this.dateToProtocolTimestamp = dateToProtocolTimestamp[precision]
+    if (this.writeOptions.defaultTags) {
+      this.useDefaultTags(this.writeOptions.defaultTags)
+    }
 
     const scheduleNextSend = (): void => {
       if (this.writeOptions.flushInterval > 0) {

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -65,6 +65,8 @@ export interface WriteOptions extends WriteRetryOptions {
   batchSize: number
   /** delay between data flushes in milliseconds, at most `batch size` records are sent during flush  */
   flushInterval: number
+  /** default tags, unescaped */
+  defaultTags?: Record<string, string>
 }
 
 /** default RetryDelayStrategyOptions */

--- a/packages/core/test/unit/WriteApi.test.ts
+++ b/packages/core/test/unit/WriteApi.test.ts
@@ -191,9 +191,9 @@ describe('WriteApi', () => {
     function useSubject(writeOptions: Partial<WriteOptions>): void {
       subject = createApi(ORG, BUCKET, WritePrecision.ns, {
         retryJitter: 0,
-
+        defaultTags: {xtra: '1'},
         ...writeOptions,
-      }).useDefaultTags({xtra: '1'})
+      })
     }
     beforeEach(() => {
       // logs = collectLogging.decorate()


### PR DESCRIPTION
## Proposed Changes
This PR allows supplying default tags in WriteOptions so that it can carry all write API configuration options.

* add `defaultTags` into WriteOptions
* use then in WriteApiImpl when set
* tests default tags in WriteOptions

## Checklist

  - [x] CHANGELOG.md updated
  - [x] A test has been added if appropriate
  - [x] `yarn test` completes successfully
  - [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
