### PR TITLE
fix: serialization of `\n`, `\r` and `\t` to Line Protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 1. [#207](https://github.com/influxdata/influxdb-client-js/pull/207): Explain the significance of the precision argument in write example.
 
+### Bug Fixes
+
+1. [#205](https://github.com/influxdata/influxdb-client-js/pull/205): Fixed serialization of `\n`, `\r` and `\t` to Line Protocol
+
 ## 1.4.0 [2020-06-19]
 
 ### Features

--- a/packages/core/src/util/escape.ts
+++ b/packages/core/src/util/escape.ts
@@ -36,7 +36,7 @@ class Escaper {
   private _re: RegExp
 
   constructor(
-    private config: {[p: string]: EscaperConfig} = {},
+    private config: {[p: string]: EscaperConfig},
     private wrap: string = ''
   ) {
     const patterns = Object.keys(config)

--- a/packages/core/test/fixture/escapeTables.json
+++ b/packages/core/test/fixture/escapeTables.json
@@ -21,7 +21,8 @@
     ["a b,c", "a\\ b\\,c"],
     ["new\nline", "new\\nline"],
     ["carriage\rreturn", "carriage\\rreturn"],
-    ["t\tab", "t\\tab"]
+    ["t\tab", "t\\tab"],
+    ["equ=al", "equ=al"]
   ],
   "quoted": [
     ["ab", "\"ab\""],

--- a/packages/core/test/fixture/escapeTables.json
+++ b/packages/core/test/fixture/escapeTables.json
@@ -8,14 +8,20 @@
     ["a=b", "a\\=b"],
     ["a b", "a\\ b"],
     ["a b=c", "a\\ b\\=c"],
-    ["'a' \\b=c\\,\\\\\"d\"", "'a'\\ \\b\\=c\\\\,\\\\\"d\""]
+    ["'a' \\b=c\\,\\\\\"d\"", "'a'\\ \\b\\=c\\\\,\\\\\"d\""],
+    ["new\nline", "new\\nline"],
+    ["carriage\rreturn", "carriage\\rreturn"],
+    ["t\tab", "t\\tab"]
   ],
   "measurement": [
     ["ab", "ab"],
     ["a,", "a\\,"],
     ["a,b", "a\\,b"],
     ["a b", "a\\ b"],
-    ["a b,c", "a\\ b\\,c"]
+    ["a b,c", "a\\ b\\,c"],
+    ["new\nline", "new\\nline"],
+    ["carriage\rreturn", "carriage\\rreturn"],
+    ["t\tab", "t\\tab"]
   ],
   "quoted": [
     ["ab", "\"ab\""],


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-java/issues/127

## Checklist

  - [x] CHANGELOG.md updated
  - [x] A test has been added if appropriate
  - [x] `yarn test` completes successfully
  - [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
