### PR TITLE
chore(docs): repair main typedoc script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "cd packages/core && yarn test && cd ../apis && yarn test",
     "coverage": "cd packages/core && yarn coverage",
     "coverage:send": "cd packages/core && yarn coverage:send",
-    "typedoc": "cd packages/core && yarn typedoc && cd ../apis && yarn typedoc"
+    "typedoc": "cd packages/core && yarn build && yarn typedoc && cd ../apis && yarn typedoc"
   },
   "homepage": "https://github.com/influxdata/influxdb-client-js",
   "repository": {


### PR DESCRIPTION
This PR repair the main typedoc task than now fails in a cleaned repo. The api package typedoc requires a build of the core module.

## Proposed Changes

BuildD the code module before running typedoc on apis

## Checklist

  - [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
