### PR TITLE
docs: add default documentation to body property in generated APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 1.6.0 [unreleased]
 
+### Documentation
+
+1. [#215](https://github.com/influxdata/influxdb-client-js/pull/215): Add createBucket.js example
+1. [#218](https://github.com/influxdata/influxdb-client-js/pull/218): Add default documentation to body property in generated APIs
+
 ## 1.5.0 [2020-07-17]
 
 ### Features

--- a/packages/apis/generator/generateApi.ts
+++ b/packages/apis/generator/generateApi.ts
@@ -57,6 +57,8 @@ function generateTypes(operation: Operation): string {
   if (operation.bodyParam) {
     if (operation.bodyParam.description) {
       retVal += `  /** ${operation.bodyParam.description} */\n`
+    } else {
+      retVal += `  /** entity body */\n`
     }
     const bodyType = getBodyType(operation)
     retVal += `  body: ${bodyType}\n`

--- a/packages/apis/src/generated/DashboardsAPI.ts
+++ b/packages/apis/src/generated/DashboardsAPI.ts
@@ -68,6 +68,7 @@ export interface PostDashboardsIDCellsRequest {
 export interface PutDashboardsIDCellsRequest {
   /** The ID of the dashboard to update. */
   dashboardID: string
+  /** entity body */
   body: Cells
 }
 export interface PatchDashboardsIDCellsIDRequest {
@@ -75,6 +76,7 @@ export interface PatchDashboardsIDCellsIDRequest {
   dashboardID: string
   /** The ID of the cell to update. */
   cellID: string
+  /** entity body */
   body: CellUpdate
 }
 export interface DeleteDashboardsIDCellsIDRequest {
@@ -94,6 +96,7 @@ export interface PatchDashboardsIDCellsIDViewRequest {
   dashboardID: string
   /** The ID of the cell to update. */
   cellID: string
+  /** entity body */
   body: View
 }
 export interface GetDashboardsIDLabelsRequest {

--- a/packages/apis/src/generated/PackagesAPI.ts
+++ b/packages/apis/src/generated/PackagesAPI.ts
@@ -6,6 +6,7 @@ export interface CreatePkgRequest {
   body: PkgCreate
 }
 export interface ApplyPkgRequest {
+  /** entity body */
   body: PkgApply
 }
 export interface ListStacksRequest {

--- a/packages/apis/src/generated/TasksAPI.ts
+++ b/packages/apis/src/generated/TasksAPI.ts
@@ -66,6 +66,7 @@ export interface GetTasksIDRunsRequest {
 }
 export interface PostTasksIDRunsRequest {
   taskID: string
+  /** entity body */
   body: RunManually
 }
 export interface GetTasksIDRunsIDRequest {


### PR DESCRIPTION
## Proposed Changes

This PR adds default documentation of a body property in generated APIs. See #211 

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
