### PR TITLE
feat(apis): generate API constructor with InfluxDB parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ### Documentation
 
-1. [#215](https://github.com/influxdata/influxdb-client-js/pull/215): Add createBucket.js example
-1. [#218](https://github.com/influxdata/influxdb-client-js/pull/218): Add default documentation to body property in generated APIs
+1. [#215](https://github.com/influxdata/influxdb-client-js/pull/215): Add createBucket.js example.
+1. [#218](https://github.com/influxdata/influxdb-client-js/pull/218): Add default documentation to body property in generated APIs.
+1. [#220](https://github.com/influxdata/influxdb-client-js/pull/220): Generate API constructor with InfluxDB parameter.
 
 ## 1.5.0 [2020-07-17]
 

--- a/packages/apis/generator/generateApi.ts
+++ b/packages/apis/generator/generateApi.ts
@@ -105,9 +105,10 @@ function generateClass(
   classDef += ` */
 export class ${apiName} extends APIBase {
   /**
-   * Creates ${apiName} from an influxDB object.
+   * Creates ${apiName}
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }`
 
@@ -164,7 +165,8 @@ export function generateApi(
   operations: Operation[]
 ): {apiName: string; code: string} {
   const apiName = (apiKey ? capitalize1(apiKey) : 'Root') + 'API'
-  let code = `import {APIBase, RequestOptions} from '../APIBase'\n`
+  let code = `import {InfluxDB} from '@influxdata/influxdb-client'\n`
+  code += `import {APIBase, RequestOptions} from '../APIBase'\n`
   const typesCollector = new TypesCollector()
   for (const operation of operations) {
     typesCollector.add(getReturnType(operation))

--- a/packages/apis/src/generated/AuthorizationsAPI.ts
+++ b/packages/apis/src/generated/AuthorizationsAPI.ts
@@ -1,3 +1,4 @@
+import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 import {
   Authorization,
@@ -43,9 +44,10 @@ export interface DeleteAuthorizationsIDRequest {
  */
 export class AuthorizationsAPI extends APIBase {
   /**
-   * Creates AuthorizationsAPI from an influxDB object.
+   * Creates AuthorizationsAPI
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }
   /**

--- a/packages/apis/src/generated/BucketsAPI.ts
+++ b/packages/apis/src/generated/BucketsAPI.ts
@@ -1,3 +1,4 @@
+import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 import {
   AddResourceMemberRequestBody,
@@ -108,9 +109,10 @@ export interface DeleteBucketsIDOwnersIDRequest {
  */
 export class BucketsAPI extends APIBase {
   /**
-   * Creates BucketsAPI from an influxDB object.
+   * Creates BucketsAPI
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }
   /**

--- a/packages/apis/src/generated/ChecksAPI.ts
+++ b/packages/apis/src/generated/ChecksAPI.ts
@@ -1,3 +1,4 @@
+import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 import {
   Check,
@@ -75,9 +76,10 @@ export interface GetChecksIDQueryRequest {
  */
 export class ChecksAPI extends APIBase {
   /**
-   * Creates ChecksAPI from an influxDB object.
+   * Creates ChecksAPI
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }
   /**

--- a/packages/apis/src/generated/DashboardsAPI.ts
+++ b/packages/apis/src/generated/DashboardsAPI.ts
@@ -1,3 +1,4 @@
+import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 import {
   AddResourceMemberRequestBody,
@@ -172,9 +173,10 @@ export interface DeleteDashboardsIDOwnersIDRequest {
  */
 export class DashboardsAPI extends APIBase {
   /**
-   * Creates DashboardsAPI from an influxDB object.
+   * Creates DashboardsAPI
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }
   /**

--- a/packages/apis/src/generated/DbrpsAPI.ts
+++ b/packages/apis/src/generated/DbrpsAPI.ts
@@ -1,3 +1,4 @@
+import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 import {DBRP, DBRPUpdate, DBRPs} from './types'
 
@@ -49,9 +50,10 @@ export interface DeleteDBRPIDRequest {
  */
 export class DbrpsAPI extends APIBase {
   /**
-   * Creates DbrpsAPI from an influxDB object.
+   * Creates DbrpsAPI
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }
   /**

--- a/packages/apis/src/generated/DeleteAPI.ts
+++ b/packages/apis/src/generated/DeleteAPI.ts
@@ -1,3 +1,4 @@
+import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 import {DeletePredicateRequest} from './types'
 
@@ -19,9 +20,10 @@ export interface PostDeleteRequest {
  */
 export class DeleteAPI extends APIBase {
   /**
-   * Creates DeleteAPI from an influxDB object.
+   * Creates DeleteAPI
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }
   /**

--- a/packages/apis/src/generated/DocumentsAPI.ts
+++ b/packages/apis/src/generated/DocumentsAPI.ts
@@ -1,3 +1,4 @@
+import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 import {
   Document,
@@ -62,9 +63,10 @@ export interface DeleteDocumentsTemplatesIDLabelsIDRequest {
  */
 export class DocumentsAPI extends APIBase {
   /**
-   * Creates DocumentsAPI from an influxDB object.
+   * Creates DocumentsAPI
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }
   /**

--- a/packages/apis/src/generated/FlagsAPI.ts
+++ b/packages/apis/src/generated/FlagsAPI.ts
@@ -1,3 +1,4 @@
+import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 import {Flags} from './types'
 
@@ -8,9 +9,10 @@ export interface GetFlagsRequest {}
  */
 export class FlagsAPI extends APIBase {
   /**
-   * Creates FlagsAPI from an influxDB object.
+   * Creates FlagsAPI
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }
   /**

--- a/packages/apis/src/generated/HealthAPI.ts
+++ b/packages/apis/src/generated/HealthAPI.ts
@@ -1,3 +1,4 @@
+import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 import {HealthCheck} from './types'
 
@@ -8,9 +9,10 @@ export interface GetHealthRequest {}
  */
 export class HealthAPI extends APIBase {
   /**
-   * Creates HealthAPI from an influxDB object.
+   * Creates HealthAPI
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }
   /**

--- a/packages/apis/src/generated/LabelsAPI.ts
+++ b/packages/apis/src/generated/LabelsAPI.ts
@@ -1,3 +1,4 @@
+import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 import {
   LabelCreateRequest,
@@ -38,9 +39,10 @@ export interface DeleteLabelsIDRequest {
  */
 export class LabelsAPI extends APIBase {
   /**
-   * Creates LabelsAPI from an influxDB object.
+   * Creates LabelsAPI
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }
   /**

--- a/packages/apis/src/generated/MeAPI.ts
+++ b/packages/apis/src/generated/MeAPI.ts
@@ -1,3 +1,4 @@
+import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 import {PasswordResetBody, User} from './types'
 
@@ -14,9 +15,10 @@ export interface PutMePasswordRequest {
  */
 export class MeAPI extends APIBase {
   /**
-   * Creates MeAPI from an influxDB object.
+   * Creates MeAPI
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }
   /**

--- a/packages/apis/src/generated/NotificationEndpointsAPI.ts
+++ b/packages/apis/src/generated/NotificationEndpointsAPI.ts
@@ -1,3 +1,4 @@
+import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 import {
   LabelMapping,
@@ -69,9 +70,10 @@ export interface DeleteNotificationEndpointsIDLabelsIDRequest {
  */
 export class NotificationEndpointsAPI extends APIBase {
   /**
-   * Creates NotificationEndpointsAPI from an influxDB object.
+   * Creates NotificationEndpointsAPI
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }
   /**

--- a/packages/apis/src/generated/NotificationRulesAPI.ts
+++ b/packages/apis/src/generated/NotificationRulesAPI.ts
@@ -1,3 +1,4 @@
+import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 import {
   FluxResponse,
@@ -79,9 +80,10 @@ export interface GetNotificationRulesIDQueryRequest {
  */
 export class NotificationRulesAPI extends APIBase {
   /**
-   * Creates NotificationRulesAPI from an influxDB object.
+   * Creates NotificationRulesAPI
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }
   /**

--- a/packages/apis/src/generated/OrgsAPI.ts
+++ b/packages/apis/src/generated/OrgsAPI.ts
@@ -1,3 +1,4 @@
+import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 import {
   AddResourceMemberRequestBody,
@@ -162,9 +163,10 @@ export interface DeleteOrgsIDOwnersIDRequest {
  */
 export class OrgsAPI extends APIBase {
   /**
-   * Creates OrgsAPI from an influxDB object.
+   * Creates OrgsAPI
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }
   /**

--- a/packages/apis/src/generated/PackagesAPI.ts
+++ b/packages/apis/src/generated/PackagesAPI.ts
@@ -1,3 +1,4 @@
+import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 import {Pkg, PkgApply, PkgCreate, PkgSummary, Stack} from './types'
 
@@ -65,9 +66,10 @@ export interface ExportStackRequest {
  */
 export class PackagesAPI extends APIBase {
   /**
-   * Creates PackagesAPI from an influxDB object.
+   * Creates PackagesAPI
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }
   /**

--- a/packages/apis/src/generated/QueryAPI.ts
+++ b/packages/apis/src/generated/QueryAPI.ts
@@ -1,3 +1,4 @@
+import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 import {
   ASTResponse,
@@ -40,9 +41,10 @@ export interface PostQueryRequest {
  */
 export class QueryAPI extends APIBase {
   /**
-   * Creates QueryAPI from an influxDB object.
+   * Creates QueryAPI
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }
   /**

--- a/packages/apis/src/generated/ReadyAPI.ts
+++ b/packages/apis/src/generated/ReadyAPI.ts
@@ -1,3 +1,4 @@
+import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 import {Ready} from './types'
 
@@ -8,9 +9,10 @@ export interface GetReadyRequest {}
  */
 export class ReadyAPI extends APIBase {
   /**
-   * Creates ReadyAPI from an influxDB object.
+   * Creates ReadyAPI
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }
   /**

--- a/packages/apis/src/generated/RootAPI.ts
+++ b/packages/apis/src/generated/RootAPI.ts
@@ -1,3 +1,4 @@
+import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 import {Routes} from './types'
 
@@ -8,9 +9,10 @@ export interface GetRoutesRequest {}
  */
 export class RootAPI extends APIBase {
   /**
-   * Creates RootAPI from an influxDB object.
+   * Creates RootAPI
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }
   /**

--- a/packages/apis/src/generated/ScrapersAPI.ts
+++ b/packages/apis/src/generated/ScrapersAPI.ts
@@ -1,3 +1,4 @@
+import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 import {
   AddResourceMemberRequestBody,
@@ -118,9 +119,10 @@ export interface DeleteScrapersIDOwnersIDRequest {
  */
 export class ScrapersAPI extends APIBase {
   /**
-   * Creates ScrapersAPI from an influxDB object.
+   * Creates ScrapersAPI
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }
   /**

--- a/packages/apis/src/generated/SetupAPI.ts
+++ b/packages/apis/src/generated/SetupAPI.ts
@@ -1,3 +1,4 @@
+import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 import {IsOnboarding, OnboardingRequest, OnboardingResponse} from './types'
 
@@ -18,9 +19,10 @@ export interface PostSetupUserRequest {
  */
 export class SetupAPI extends APIBase {
   /**
-   * Creates SetupAPI from an influxDB object.
+   * Creates SetupAPI
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }
   /**

--- a/packages/apis/src/generated/SigninAPI.ts
+++ b/packages/apis/src/generated/SigninAPI.ts
@@ -1,3 +1,4 @@
+import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 
 export interface PostSigninRequest {
@@ -9,9 +10,10 @@ export interface PostSigninRequest {
  */
 export class SigninAPI extends APIBase {
   /**
-   * Creates SigninAPI from an influxDB object.
+   * Creates SigninAPI
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }
   /**

--- a/packages/apis/src/generated/SignoutAPI.ts
+++ b/packages/apis/src/generated/SignoutAPI.ts
@@ -1,3 +1,4 @@
+import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 
 export interface PostSignoutRequest {}
@@ -7,9 +8,10 @@ export interface PostSignoutRequest {}
  */
 export class SignoutAPI extends APIBase {
   /**
-   * Creates SignoutAPI from an influxDB object.
+   * Creates SignoutAPI
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }
   /**

--- a/packages/apis/src/generated/SourcesAPI.ts
+++ b/packages/apis/src/generated/SourcesAPI.ts
@@ -1,3 +1,4 @@
+import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 import {Buckets, HealthCheck, Source, Sources} from './types'
 
@@ -45,9 +46,10 @@ export interface GetSourcesIDBucketsRequest {
  */
 export class SourcesAPI extends APIBase {
   /**
-   * Creates SourcesAPI from an influxDB object.
+   * Creates SourcesAPI
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }
   /**

--- a/packages/apis/src/generated/TasksAPI.ts
+++ b/packages/apis/src/generated/TasksAPI.ts
@@ -1,3 +1,4 @@
+import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 import {
   AddResourceMemberRequestBody,
@@ -171,9 +172,10 @@ export interface DeleteTasksIDOwnersIDRequest {
  */
 export class TasksAPI extends APIBase {
   /**
-   * Creates TasksAPI from an influxDB object.
+   * Creates TasksAPI
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }
   /**

--- a/packages/apis/src/generated/TelegrafAPI.ts
+++ b/packages/apis/src/generated/TelegrafAPI.ts
@@ -1,3 +1,4 @@
+import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 import {TelegrafPlugins} from './types'
 
@@ -11,9 +12,10 @@ export interface GetTelegrafPluginsRequest {
  */
 export class TelegrafAPI extends APIBase {
   /**
-   * Creates TelegrafAPI from an influxDB object.
+   * Creates TelegrafAPI
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }
   /**

--- a/packages/apis/src/generated/TelegrafsAPI.ts
+++ b/packages/apis/src/generated/TelegrafsAPI.ts
@@ -1,3 +1,4 @@
+import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 import {
   AddResourceMemberRequestBody,
@@ -102,9 +103,10 @@ export interface DeleteTelegrafsIDOwnersIDRequest {
  */
 export class TelegrafsAPI extends APIBase {
   /**
-   * Creates TelegrafsAPI from an influxDB object.
+   * Creates TelegrafsAPI
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }
   /**

--- a/packages/apis/src/generated/UsersAPI.ts
+++ b/packages/apis/src/generated/UsersAPI.ts
@@ -1,3 +1,4 @@
+import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 import {PasswordResetBody, User, Users} from './types'
 
@@ -38,9 +39,10 @@ export interface PostUsersIDPasswordRequest {
  */
 export class UsersAPI extends APIBase {
   /**
-   * Creates UsersAPI from an influxDB object.
+   * Creates UsersAPI
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }
   /**

--- a/packages/apis/src/generated/VariablesAPI.ts
+++ b/packages/apis/src/generated/VariablesAPI.ts
@@ -1,3 +1,4 @@
+import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 import {
   LabelMapping,
@@ -67,9 +68,10 @@ export interface DeleteVariablesIDLabelsIDRequest {
  */
 export class VariablesAPI extends APIBase {
   /**
-   * Creates VariablesAPI from an influxDB object.
+   * Creates VariablesAPI
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }
   /**

--- a/packages/apis/src/generated/WriteAPI.ts
+++ b/packages/apis/src/generated/WriteAPI.ts
@@ -1,3 +1,4 @@
+import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 
 export interface PostWriteRequest {
@@ -18,9 +19,10 @@ export interface PostWriteRequest {
  */
 export class WriteAPI extends APIBase {
   /**
-   * Creates WriteAPI from an influxDB object.
+   * Creates WriteAPI
+   * @param influxDB InfluxDB
    */
-  constructor(influxDB: any) {
+  constructor(influxDB: InfluxDB) {
     super(influxDB)
   }
   /**


### PR DESCRIPTION
This PR changes the type of constructor parameter in all APIs to InfluxDB. This helps to understand the API concepts when reading its  API documentation or relying on code completion suggestions. The change is supposed to have at most no effects on backward compatibility, the InfluxDB instances are already expected in existing code base. This PR is related to #211

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
