### PR TITLE
chore(core): improve retry strategy and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 1. [#219](https://github.com/influxdata/influxdb-client-js/pull/219): Sanitize arrays in parameterized flux queries.
+1. [#226](https://github.com/influxdata/influxdb-client-js/pull/226): Improve retry strategy.
 
 ### Documentation
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -5,9 +5,10 @@ export interface RetryDelayStrategy {
   /**
    * Returns delay for a next retry
    * @param error - reason for retrying
+   * @param failedAttempts - a count of already failed attempts, 1 being the first
    * @returns milliseconds to wait before retrying
    */
-  nextDelay(error?: Error): number
+  nextDelay(error?: Error, failedAttempts?: number): number
   /** Implementation should reset its state, this is mandatory to call upon success.  */
   success(): void
 }

--- a/packages/core/test/unit/impl/retryStrategy.test.ts
+++ b/packages/core/test/unit/impl/retryStrategy.test.ts
@@ -59,6 +59,26 @@ describe('RetryStrategyImpl', () => {
       expect(x).to.not.be.greaterThan(1000)
     })
   })
+  it('generates exponential delays with failedAttempts', () => {
+    const subject = new RetryStrategyImpl({
+      minRetryDelay: 100,
+      maxRetryDelay: 1000,
+      retryJitter: 10,
+    })
+    const values = [1, 2, 3, 4, 5, 6].reduce((acc, val) => {
+      acc.push(subject.nextDelay(new Error(), val))
+      return acc
+    }, [] as number[])
+    expect(values).to.have.length(6)
+    values.forEach((x, i) => {
+      if (i > 0) {
+        expect(Math.max(Math.trunc(x / 100), 10)).to.not.be.lessThan(
+          Math.max(Math.trunc(values[i - 1] / 100), 10)
+        )
+      }
+      expect(x).to.not.be.greaterThan(1000 + 10)
+    })
+  })
   it('generates default jittered delays', () => {
     const subject = new RetryStrategyImpl({
       minRetryDelay: 100,

--- a/packages/core/test/unit/query/flux.test.ts
+++ b/packages/core/test/unit/query/flux.test.ts
@@ -112,6 +112,9 @@ describe('Flux Values', () => {
       {value: 'abc${val}def', flux: '"abc\\${val}def"'},
       {value: 'abc$', flux: '"abc$"'},
       {value: 'a"$d', flux: '"a\\"$d"'},
+      {value: [], flux: '[]'},
+      {value: ['a"$d'], flux: '["a\\"$d"]'},
+      {value: Symbol('thisSym'), flux: `"${Symbol('thisSym').toString()}"`},
     ]
     pairs.forEach(pair => {
       it(`converts ${JSON.stringify(String(pair.value))} to '${


### PR DESCRIPTION
This PR improves
- retry strategy (internal) to count with the number of already failed attempts + add a better test for exponential backoff
- improve test for flux sanitized strings

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
