### PR TITLE
fix(core): change default number serializes to return null to represent emptiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 1. [#219](https://github.com/influxdata/influxdb-client-js/pull/219): Sanitize arrays in parameterized flux queries.
 
+### Breaking Changes
+
+1. [#227](https://github.com/influxdata/influxdb-client-js/pull/227): Change default number serializers to return null when no value is found.
+   This change affects the output of `tableMeta.toObject(row)`, see [#227](https://github.com/influxdata/influxdb-client-js/pull/227) for details and backward compatibility notes.
+
 ### Documentation
 
 1. [#215](https://github.com/influxdata/influxdb-client-js/pull/215): Add createBucket.js example.

--- a/packages/core/src/query/FluxTableMetaData.ts
+++ b/packages/core/src/query/FluxTableMetaData.ts
@@ -8,13 +8,13 @@ const identity = (x: string): any => x
  */
 export const typeSerializers: Record<ColumnType, (val: string) => any> = {
   boolean: (x: string): any => x === 'true',
-  unsignedLong: identity,
-  long: identity,
-  double: (x: string): any => +x,
+  unsignedLong: (x: string): any => (x === '' ? null : +x),
+  long: (x: string): any => (x === '' ? null : +x),
+  double: (x: string): any => (x === '' ? null : +x),
   string: identity,
   base64Binary: identity,
-  dateTime: identity,
-  duration: identity,
+  dateTime: (x: string): any => (x === '' ? null : x),
+  duration: (x: string): any => (x === '' ? null : x),
 }
 /**
  * Represents metadata of a {@link http://bit.ly/flux-spec#table | flux table}.

--- a/packages/core/test/unit/QueryApi.test.ts
+++ b/packages/core/test/unit/QueryApi.test.ts
@@ -148,7 +148,7 @@ describe('QueryApi', () => {
     expect(values).to.deep.equal([
       {
         result: '_result',
-        table: '0',
+        table: 0,
         id: 'GO506_20_6431',
         st_length: 25.463641400535032,
         st_linestring: '-73.68691 40.820317, -73.690054 40.815413',
@@ -156,7 +156,7 @@ describe('QueryApi', () => {
       },
       {
         result: '_result',
-        table: '1',
+        table: 1,
         id: 'GO506_20_6431',
         st_length: 25.463641400535032,
         st_linestring: '-73.68691 40.820317, -73.690054 40.815413',

--- a/packages/core/test/unit/query/FluxTableMetaData.test.ts
+++ b/packages/core/test/unit/query/FluxTableMetaData.test.ts
@@ -30,7 +30,7 @@ describe('FluxTableMetaData', () => {
     const columns: FluxTableColumn[] = [
       FluxTableColumn.from({
         label: 'a',
-        defaultValue: 'def',
+        defaultValue: '1',
         dataType: 'long',
         group: false,
       }),
@@ -39,17 +39,20 @@ describe('FluxTableMetaData', () => {
       }),
     ]
     const subject = new FluxTableMetaData(columns)
-    expect(subject.toObject(['', ''])).to.deep.equal({a: 'def', b: ''})
-    expect(subject.toObject(['x', 'y'])).to.deep.equal({a: 'x', b: 'y'})
-    expect(subject.toObject(['x', 'y', 'z'])).to.deep.equal({a: 'x', b: 'y'})
-    expect(subject.toObject(['x'])).to.deep.equal({a: 'x'})
+    expect(subject.toObject(['', ''])).to.deep.equal({a: 1, b: ''})
+    expect(subject.toObject(['2', 'y'])).to.deep.equal({a: 2, b: 'y'})
+    expect(subject.toObject(['3', 'y', 'z'])).to.deep.equal({a: 3, b: 'y'})
+    expect(subject.toObject(['4'])).to.deep.equal({a: 4})
   })
   const serializationTable: Array<[ColumnType | undefined, string, any]> = [
     ['boolean', 'false', false],
     ['boolean', 'true', true],
-    ['unsignedLong', '1', '1'],
-    ['long', '1', '1'],
+    ['unsignedLong', '1', 1],
+    ['unsignedLong', '', null],
+    ['long', '1', 1],
+    ['long', '', null],
     ['double', '1', 1],
+    ['double', '', null],
     ['string', '1', '1'],
     ['base64Binary', '1', '1'],
     ['dateTime', '1', '1'],


### PR DESCRIPTION
Closes #227

## Proposed Changes

`tableMeta.toObject(row)` in this PR newly returns object with `null` numbers if an associated row value is empty.  
. Before this PR, it contained 0 in columns with empty double values and an empty string for long and unsignedLong values. 

## Backward Compatibility
This PR changes the return value of `tableMeta.toObject(row)`, which now returns a different object. This returned object is not documented. If there would be complications with this chage, the following extra code can be added to take back the previous behavior:
```
import { typeSerializers } from '@influxdata/influxdb-client'

typeSerializers.double = (val) => +val
typeSerializers.long = (val) => val
typeSerializers.unsignedLong = (val) => val
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
