### PR TITLE
feat(core): Unify default retry strategy settings across all InfluxDB v2 clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 1. [#219](https://github.com/influxdata/influxdb-client-js/pull/219): Sanitize arrays in parameterized flux queries.
 1. [#226](https://github.com/influxdata/influxdb-client-js/pull/226): Improve retry strategy.
 1. [#231](https://github.com/influxdata/influxdb-client-js/pull/231): Regenerate APIs from swagger.
+1. [#233](https://github.com/influxdata/influxdb-client-js/pull/233): Unify default retry strategy settings across all InfluxDB v2 clients.
 1. [#234](https://github.com/influxdata/influxdb-client-js/pull/234): Upgrade dependencies.
 
 ### Breaking Changes

--- a/packages/core/src/impl/retryStrategy.ts
+++ b/packages/core/src/impl/retryStrategy.ts
@@ -20,10 +20,7 @@ export class RetryStrategyImpl implements RetryDelayStrategy {
   nextDelay(error?: Error, failedAttempts?: number): number {
     const delay = getRetryDelay(error)
     if (delay && delay > 0) {
-      return Math.min(
-        delay + Math.round(Math.random() * this.options.retryJitter),
-        this.options.maxRetryDelay
-      )
+      return delay + Math.round(Math.random() * this.options.retryJitter)
     } else {
       let delay = this.currentDelay
       if (failedAttempts && failedAttempts > 0) {

--- a/packages/core/src/impl/retryStrategy.ts
+++ b/packages/core/src/impl/retryStrategy.ts
@@ -30,7 +30,7 @@ export class RetryStrategyImpl implements RetryDelayStrategy {
         // compute delay
         delay = this.options.minRetryDelay
         for (let i = 1; i < failedAttempts; i++) {
-          delay = delay * 2
+          delay = delay * this.options.exponentialBase
           if (delay >= this.options.maxRetryDelay) {
             break
           }
@@ -41,7 +41,7 @@ export class RetryStrategyImpl implements RetryDelayStrategy {
         )
       } else if (this.currentDelay) {
         this.currentDelay = Math.min(
-          Math.max(this.currentDelay * 2, 1) +
+          Math.max(this.currentDelay * this.options.exponentialBase, 1) +
             Math.round(Math.random() * this.options.retryJitter),
           this.options.maxRetryDelay
         )

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -26,10 +26,12 @@ export const DEFAULT_ConnectionOptions: Partial<ConnectionOptions> = {
 export interface RetryDelayStrategyOptions {
   /** include random milliseconds when retrying HTTP calls */
   retryJitter: number
-  /** minimum delay when retrying write  */
+  /** minimum delay when retrying write (milliseconds) */
   minRetryDelay: number
-  /** maximum delay when retrying write  */
+  /** maximum delay when retrying write (milliseconds) */
   maxRetryDelay: number
+  /** base for the exponential retry delay, the next delay is computed as `minRetryDelay * exponentialBase^(attempts-1) + random(retryJitter)` */
+  exponentialBase: number
 }
 
 /**
@@ -74,6 +76,7 @@ export const DEFAULT_RetryDelayStrategyOptions = Object.freeze({
   retryJitter: 200,
   minRetryDelay: 5000,
   maxRetryDelay: 180000,
+  exponentialBase: 5,
 })
 
 /** default writeOptions */

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -81,7 +81,7 @@ export const DEFAULT_WriteOptions: WriteOptions = Object.freeze({
   batchSize: 1000,
   flushInterval: 60000,
   writeFailed: function() {},
-  maxRetries: 2,
+  maxRetries: 3,
   maxBufferLines: 32_000,
   ...DEFAULT_RetryDelayStrategyOptions,
 })

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -72,8 +72,8 @@ export interface WriteOptions extends WriteRetryOptions {
 /** default RetryDelayStrategyOptions */
 export const DEFAULT_RetryDelayStrategyOptions = Object.freeze({
   retryJitter: 200,
-  minRetryDelay: 1000,
-  maxRetryDelay: 15000,
+  minRetryDelay: 5000,
+  maxRetryDelay: 180000,
 })
 
 /** default writeOptions */

--- a/packages/core/test/unit/impl/retryStrategy.test.ts
+++ b/packages/core/test/unit/impl/retryStrategy.test.ts
@@ -22,6 +22,7 @@ describe('RetryStrategyImpl', () => {
       minRetryDelay: 100,
       maxRetryDelay: 1000,
       retryJitter: 0,
+      exponentialBase: 2,
     })
     const values = [1, 2, 3, 4, 5, 6].reduce((acc, _val) => {
       acc.push(subject.nextDelay())
@@ -30,6 +31,29 @@ describe('RetryStrategyImpl', () => {
     expect(values).to.be.deep.equal([100, 200, 400, 800, 1000, 1000])
     subject.success()
     expect(subject.nextDelay()).equals(100)
+  })
+  it('generates exponential data from min to max for unknown delays', () => {
+    const subject = new RetryStrategyImpl({
+      minRetryDelay: 100,
+      maxRetryDelay: 2000,
+      retryJitter: 20,
+      // exponentialBase: 5, 5 by default
+    })
+    const values = [1, 2, 3, 4, 5, 6].reduce((acc, _val, index) => {
+      acc.push(subject.nextDelay(undefined, index + 1))
+      return acc
+    }, [] as number[])
+    // truncate values to ignore jittering
+    expect(values.map(x => Math.trunc(x / 100) * 100)).to.be.deep.equal([
+      100,
+      500,
+      2000,
+      2000,
+      2000,
+      2000,
+    ])
+    subject.success()
+    expect(Math.trunc(subject.nextDelay() / 100) * 100).equals(100)
   })
   it('generates the delays according to errors', () => {
     const subject = new RetryStrategyImpl({

--- a/scripts/enhance-doc-index-md.js
+++ b/scripts/enhance-doc-index-md.js
@@ -26,7 +26,7 @@ function enhanceIndexMD(file) {
       if (line.startsWith('## API Reference')) {
         acc.push('')
         acc.push(
-          `Welcome to the API Reference Documentation of InfluxDB v2 JavaScript client version **${version}** _(${new Date().toISOString()})_.`
+          `Welcome to the API Reference Documentation of InfluxDB v2 JavaScript Client (version ${version} _${new Date().toISOString()}_).`
         )
         acc.push('Use this client library with InfluxDB 2.x and InfluxDB 1.8+.')
         acc.push(


### PR DESCRIPTION
This PR changes the **default** retry strategy options:
- initial/minimum retry delay is **5** seconds
- max retry delay is **180** seconds
- at most **3** retries 
- the base for the exponential backoff is set to **5** seconds, the default retry delays are now [5, 25, 125] seconds + jitter.


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
