### PR TITLE
fix(core/query): repair wrong quote detection in  chunks to lines transformation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.7.0 [unreleased]
 
+### Bug Fixes
+
+1. [#237](https://github.com/influxdata/influxdb-client-js/pull/237): Fixed line splitter of query results that might have produced wrong results for query responses with quoted data.
+
 ## 1.6.0 [2020-08-14]
 
 ### Features

--- a/packages/core/src/impl/ChunksToLines.ts
+++ b/packages/core/src/impl/ChunksToLines.ts
@@ -7,6 +7,7 @@ import Cancellable from '../util/Cancellable'
 export default class ChunksToLines implements CommunicationObserver<any> {
   previous?: Uint8Array
   finished = false
+  quoted = false
 
   constructor(
     private target: CommunicationObserver<string>,
@@ -51,18 +52,17 @@ export default class ChunksToLines implements CommunicationObserver<any> {
     } else {
       index = 0
     }
-    let quoted = false
     while (index < chunk.length) {
       const c = chunk[index]
       if (c === 10) {
-        if (!quoted) {
+        if (!this.quoted) {
           /* do not emit CR+LR or LF line ending */
           const end = index > 0 && chunk[index - 1] === 13 ? index - 1 : index
           this.target.next(this.chunks.toUtf8String(chunk, start, end))
           start = index + 1
         }
       } else if (c === 34 /* " */) {
-        quoted = !quoted
+        this.quoted = !this.quoted
       }
       index++
     }

--- a/packages/core/test/fixture/chunksToLinesTables.json
+++ b/packages/core/test/fixture/chunksToLinesTables.json
@@ -46,5 +46,15 @@
       ",result,table,id,st_length,st_linestring,trip_id",
       ",,0,GO506_20_6431,25.463641400535032,\"-73.68691 40.820317, -73.690054 40.815413\",GO506_20_6431"
     ]
+  },
+  {
+    "name": "2 chunks breaks quoted data, 1 line",
+    "chunks": ["ab\"\ncd\nef", "g\"h"],
+    "lines": ["ab\"\ncd\nefg\"h"]
+  },
+  {
+    "name": "2 chunks breaks quoted data, 2 lines",
+    "chunks": ["ab\"", "c\"\nd"],
+    "lines": ["ab\"c\"", "d"]
   }
 ]


### PR DESCRIPTION
Fixes #236

The transformation that creates query result lines out of HTTP response chunks did not properly detect quoting that could possibly ignore newline characters. If a first chunk ends with an open quote, the next chunks did not remember that the quote was opened in the previous chunk and then ignores newline characters. This is fixed in this PR, the opened quote is remembered as a state variable of the transformation.


_Briefly describe your proposed changes:_

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
