### PR TITLE
feat(core): keep url's context path in node transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.7.0 [unreleased]
 
+### Features
+
+1. [#238](https://github.com/influxdata/influxdb-client-js/pull/238): Respect context path in client's url option.
+
 ### Bug Fixes
 
 1. [#237](https://github.com/influxdata/influxdb-client-js/pull/237): Fixed line splitter of query results that might have produced wrong results for query responses with quoted data.

--- a/packages/core/src/impl/node/NodeHttpTransport.ts
+++ b/packages/core/src/impl/node/NodeHttpTransport.ts
@@ -45,6 +45,7 @@ export class NodeHttpTransport implements Transport {
     options: http.RequestOptions,
     callback: (res: http.IncomingMessage) => void
   ) => http.ClientRequest
+  private contextPath: string
   /**
    * Creates a node transport using for the client options supplied.
    * @param connectionOptions - connection options
@@ -58,6 +59,13 @@ export class NodeHttpTransport implements Transport {
       port: url.port,
       protocol: url.protocol,
       hostname: url.hostname,
+    }
+    this.contextPath = url.path ?? ''
+    if (this.contextPath.endsWith('/')) {
+      this.contextPath = this.contextPath.substring(
+        0,
+        this.contextPath.length - 1
+      )
     }
     if (url.protocol === 'http:') {
       this.requestApi = http.request
@@ -161,7 +169,7 @@ export class NodeHttpTransport implements Transport {
     }
     const options: {[key: string]: any} = {
       ...this.defaultOptions,
-      path,
+      path: this.contextPath + path,
       method: sendOptions.method,
       headers: {
         ...headers,

--- a/packages/core/test/unit/impl/node/NodeHttpTransport.test.ts
+++ b/packages/core/test/unit/impl/node/NodeHttpTransport.test.ts
@@ -67,6 +67,32 @@ describe('NodeHttpTransport', () => {
       })
       expect(transport.requestApi).to.equal(https.request)
     })
+    it('creates the transport with contextPath', () => {
+      const transport: any = new NodeHttpTransport({
+        url: 'http://test:9999/influx',
+      })
+      expect(transport.defaultOptions).to.deep.equal({
+        hostname: 'test',
+        port: '9999',
+        protocol: 'http:',
+        timeout: 10000,
+        url: 'http://test:9999/influx',
+      })
+      expect(transport.contextPath).equals('/influx')
+    })
+    it('creates the transport with contextPath/', () => {
+      const transport: any = new NodeHttpTransport({
+        url: 'http://test:9999/influx/',
+      })
+      expect(transport.defaultOptions).to.deep.equal({
+        hostname: 'test',
+        port: '9999',
+        protocol: 'http:',
+        timeout: 10000,
+        url: 'http://test:9999/influx/',
+      })
+      expect(transport.contextPath).equals('/influx')
+    })
     it('does not create the transport from other uri', () => {
       expect(
         () =>
@@ -100,6 +126,7 @@ describe('NodeHttpTransport', () => {
             'accept-encoding': 'gzip',
           },
         },
+        {contextPath: '/context'},
       ]
       for (let i = 0; i < extraOptions.length; i++) {
         const extras = extraOptions[i]
@@ -113,7 +140,7 @@ describe('NodeHttpTransport', () => {
             )
             let responseRead = false
             const context = nock(transportOptions.url)
-              .post('/test')
+              .post((extras.contextPath ?? '') + '/test')
               .reply((_uri, _requestBody) => [
                 200,
                 new Readable({
@@ -150,6 +177,7 @@ describe('NodeHttpTransport', () => {
             new NodeHttpTransport({
               ...extras,
               ...transportOptions,
+              url: transportOptions.url + (extras.contextPath ?? ''),
             }).send(
               '/test',
               '',


### PR DESCRIPTION
This PR changes the client's node transport to also include url's context path to every request:

```js
#!/usr/bin/env node
...
const influxDB = new InfluxDB({url:'http://my-proxy:1234/influx', token})
...
const writeApi = influxDB.getWriteApi(org, bucket, 'ns')
...
// every API call now includes url's path, the following API call 
// will do POST http://my-proxy:1234/influx/api/v2/write
//
// before this PR: POST http://my-proxy:1234/api/v2/write
writeApi.writePoint(point1)
```

The context path is already respected in the browser (fetch) transport.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
