### PR TITLE
feat(core): add helpers to let users choose how to deserialize dateTime:RFC3339 query response data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 1. [#238](https://github.com/influxdata/influxdb-client-js/pull/238): Respect context path in client's url option.
+1. [#240](https://github.com/influxdata/influxdb-client-js/pull/240): Add helpers to let users choose how to deserialize dateTime:RFC3339 query response data type
 
 ### Bug Fixes
 

--- a/packages/core/src/query/FluxTableColumn.ts
+++ b/packages/core/src/query/FluxTableColumn.ts
@@ -8,8 +8,9 @@ export type ColumnType =
   | 'double'
   | 'string'
   | 'base64Binary'
-  | 'dateTime'
+  | 'dateTime:RFC3339'
   | 'duration'
+  | string
 
 /**
  * FluxTableColumnLike provides metadata of a flux table column.

--- a/packages/core/src/query/FluxTableMetaData.ts
+++ b/packages/core/src/query/FluxTableMetaData.ts
@@ -13,9 +13,41 @@ export const typeSerializers: Record<ColumnType, (val: string) => any> = {
   double: (x: string): any => (x === '' ? null : +x),
   string: identity,
   base64Binary: identity,
-  dateTime: (x: string): any => (x === '' ? null : x),
   duration: (x: string): any => (x === '' ? null : x),
+  'dateTime:RFC3339': (x: string): any => (x === '' ? null : x),
 }
+
+/**
+ * serializeDateTimeAsDate changes type serializers to return JavaScript Date instances
+ * for 'dateTime:RFC3339' query result data type. Empty value is converted to null.
+ * @remarks
+ * Please note that the result has millisecond precision whereas InfluxDB returns dateTime
+ * in nanosecond precision.
+ */
+export function serializeDateTimeAsDate(): void {
+  typeSerializers['dateTime:RFC3339'] = (x: string): any =>
+    x === '' ? null : new Date(Date.parse(x))
+}
+/**
+ * serializeDateTimeAsNumber changes type serializers to return milliseconds since epoch
+ * for 'dateTime:RFC3339' query result data type. Empty value is converted to null.
+ * @remarks
+ * Please note that the result has millisecond precision whereas InfluxDB returns dateTime
+ * in nanosecond precision.
+ */
+export function serializeDateTimeAsNumber(): void {
+  typeSerializers['dateTime:RFC3339'] = (x: string): any =>
+    x === '' ? null : Date.parse(x)
+}
+/**
+ * serializeDateTimeAsString changes type serializers to return string values
+ * for `dateTime:RFC3339` query result data type.  Empty value is converted to null.
+ */
+export function serializeDateTimeAsString(): void {
+  typeSerializers['dateTime:RFC3339'] = (x: string): any =>
+    x === '' ? null : x
+}
+
 /**
  * Represents metadata of a {@link http://bit.ly/flux-spec#table | flux table}.
  */

--- a/packages/core/src/query/index.ts
+++ b/packages/core/src/query/index.ts
@@ -1,6 +1,9 @@
 export {
   default as FluxTableMetaData,
   typeSerializers,
+  serializeDateTimeAsDate,
+  serializeDateTimeAsNumber,
+  serializeDateTimeAsString,
 } from './FluxTableMetaData'
 export {default as FluxResultObserver} from './FluxResultObserver'
 export {


### PR DESCRIPTION
Fixes #239 and introduce functions that let users choose how to de-serialize `dateTime:RFC3339` type.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
