### PR TITLE
chore(examples): rename env vars

### DIFF
--- a/examples/env.js
+++ b/examples/env.js
@@ -1,9 +1,9 @@
 /** InfluxDB v2 URL */
-const url = process.env['INFLUXDB_URL'] || 'http://localhost:9999'
+const url = process.env['INFLUX_URL'] || 'http://localhost:9999'
 /** InfluxDB authorization token */
-const token = process.env['INFLUXDB_TOKEN'] || 'my-token'
-/** Organization within InfluxDB URL  */
-const org = process.env['INFLUXDB_ORG'] || 'my-org'
+const token = process.env['INFLUX_TOKEN'] || 'my-token'
+/** Organization within InfluxDB  */
+const org = process.env['INFLUX_ORG'] || 'my-org'
 /**InfluxDB bucket used in examples  */
 const bucket = 'my-bucket'
 // ONLY onboarding example


### PR DESCRIPTION
Fixes #243 

## Proposed Changes

Example environment variables renamed for the sake of consistency with InfluxDB v2 tools. `INFLUXDB_* is now INFLUX_*` 

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
