### PR TITLE
fix(core): throw exception when using closed writeApi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 1. [#237](https://github.com/influxdata/influxdb-client-js/pull/237): Fixed line splitter of query results that might have produced wrong results for query responses with quoted data.
 1. [#242](https://github.com/influxdata/influxdb-client-js/pull/242): Repair escaping of backslash in line protocol string field.
+1. [#246](https://github.com/influxdata/influxdb-client-js/pull/246): Throw error on attempt to write points using a closed WriteApi instance.
 
 ## 1.6.0 [2020-08-14]
 

--- a/packages/core/src/impl/WriteApiImpl.ts
+++ b/packages/core/src/impl/WriteApiImpl.ts
@@ -187,18 +187,30 @@ export default class WriteApiImpl implements WriteApi, PointSettings {
   }
 
   writeRecord(record: string): void {
+    if (this.closed) {
+      throw new Error('writeApi: already closed!')
+    }
     this.writeBuffer.add(record)
   }
   writeRecords(records: ArrayLike<string>): void {
+    if (this.closed) {
+      throw new Error('writeApi: already closed!')
+    }
     for (let i = 0; i < records.length; i++) {
       this.writeBuffer.add(records[i])
     }
   }
   writePoint(point: Point): void {
+    if (this.closed) {
+      throw new Error('writeApi: already closed!')
+    }
     const line = point.toLineProtocol(this)
     if (line) this.writeBuffer.add(line)
   }
   writePoints(points: ArrayLike<Point>): void {
+    if (this.closed) {
+      throw new Error('writeApi: already closed!')
+    }
     for (let i = 0; i < points.length; i++) {
       this.writePoint(points[i])
     }

--- a/packages/core/test/unit/WriteApi.test.ts
+++ b/packages/core/test/unit/WriteApi.test.ts
@@ -81,6 +81,21 @@ describe('WriteApi', () => {
           expect(e).to.be.ok
         })
     })
+    it('fails on write if it is closed already', async () => {
+      await subject.close()
+      expect(() => subject.writeRecord('text value=1')).to.throw(
+        'writeApi: already closed!'
+      )
+      expect(() =>
+        subject.writeRecords(['text value=1', 'text value=2'])
+      ).to.throw('writeApi: already closed!')
+      expect(() =>
+        subject.writePoint(new Point('test').floatField('value', 1))
+      ).to.throw('writeApi: already closed!')
+      expect(() =>
+        subject.writePoints([new Point('test').floatField('value', 1)])
+      ).to.throw('writeApi: already closed!')
+    })
   })
   describe('configuration', () => {
     let subject: WriteApi


### PR DESCRIPTION
Fixes #245

## Proposed Changes

Throw error when writing to a closed WringApi.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
