### PR TITLE
feat: change default InfluxDB port to 8086

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,9 +33,9 @@ jobs:
             cd ./packages/core
             yarn test:ci
             yarn lint:ci
-            yarn build
             cd ../apis
             yarn test
+            yarn eslint ../../examples
             cd ../..
             yarn apidoc:ci
       # Upload results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ### Features
 
 1. [#238](https://github.com/influxdata/influxdb-client-js/pull/238): Respect context path in client's url option.
-1. [#240](https://github.com/influxdata/influxdb-client-js/pull/240): Add helpers to let users choose how to deserialize dateTime:RFC3339 query response data type
+1. [#240](https://github.com/influxdata/influxdb-client-js/pull/240): Add helpers to let users choose how to deserialize dateTime:RFC3339 query response data type.
+1. [#248](https://github.com/influxdata/influxdb-client-js/pull/248): Change default InfluxDB URL to http://localhost:8086 .
 1. [#250](https://github.com/influxdata/influxdb-client-js/pull/250): Simplify precision for WriteApi retrieval.
 1. [#253](https://github.com/influxdata/influxdb-client-js/pull/253): Allow to simply receive the whole query response as a string.
 1. [#257](https://github.com/influxdata/influxdb-client-js/pull/257): Regenerate APIs from swagger.

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,7 @@ This directory contains javascript and typescript examples for node.js and brows
   - [node](https://nodejs.org/en/) installed
   - Run `npm install` in this directory
 - Node.js examples
-  - Change variables in [./env.js](env.js) to configure connection to your InfluxDB instance. The file can be used as-is against a new [docker influxDB v2.0 installation](https://v2.docs.influxdata.com/v2.0/get-started/)
+  - Change variables in [./env.js](env.js) to configure connection to your InfluxDB instance. The file can be used as-is against a new [docker InfluxDB v2.0 OSS GA installation](https://v2.docs.influxdata.com/v2.0/get-started/)
   - Examples are executable. If it does not work for you, run `npm run ts-node EXAMPLE.ts`.
   - [write.js](./write.js)
     Write data points to InfluxDB.

--- a/examples/createBucket.js
+++ b/examples/createBucket.js
@@ -38,7 +38,7 @@ async function recreateBucket(name) {
   }
 
   console.log(`*** Create Bucket "${name}" ***`)
-  // creates a bucket, entity properties are specified in the "body" property 
+  // creates a bucket, entity properties are specified in the "body" property
   const bucket = await bucketsAPI.postBuckets({body: {orgID, name}})
   console.log(
     JSON.stringify(

--- a/examples/env.js
+++ b/examples/env.js
@@ -1,5 +1,5 @@
 /** InfluxDB v2 URL */
-const url = process.env['INFLUX_URL'] || 'http://localhost:9999'
+const url = process.env['INFLUX_URL'] || 'http://localhost:8086'
 /** InfluxDB authorization token */
 const token = process.env['INFLUX_TOKEN'] || 'my-token'
 /** Organization within InfluxDB  */

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "preinstall": "node ./scripts/require-yarn.js",
     "clean": "rimraf temp docs && yarn workspaces run clean",
     "build": "cd packages/core && yarn build && cd ../apis && yarn build",
-    "test": "cd packages/core && yarn test && yarn build && cd ../apis && yarn test",
+    "test": "cd packages/core && yarn test && yarn build && cd ../apis && yarn test && yarn eslint ../../examples",
     "coverage": "cd packages/core && yarn coverage",
     "coverage:send": "cd packages/core && yarn coverage:send"
   },

--- a/packages/apis/src/index.ts
+++ b/packages/apis/src/index.ts
@@ -13,7 +13,7 @@
  * const {InfluxDB} = require('@influxdata/influxdb-client')
  * const {OrgsAPI} = require('@influxdata/influxdb-client-apis')
  * const influxDB = new InfluxDB({
- *   url: "http://localhost:9999", 
+ *   url: "http://localhost:8086", 
  *   token: "my-token"
  * })
  * ...

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,7 +8,7 @@
  * ```
  * import {InfluxDB} = from('@influxdata/influxdb-client')
  * const influxDB = new InfluxDB({
- *   url: "http://localhost:9999",
+ *   url: "http://localhost:8086",
  *   token: "your-api-token"
  * })
  * ```

--- a/packages/core/test/integration/rxjs/QueryApi.test.ts
+++ b/packages/core/test/integration/rxjs/QueryApi.test.ts
@@ -11,7 +11,7 @@ const ORG = `my-org`
 const QUERY_PATH = `/api/v2/query?org=${ORG}`
 
 const clientOptions: ClientOptions = {
-  url: 'http://fake:9999',
+  url: 'http://fake:8086',
   token: 'a',
 }
 

--- a/packages/core/test/unit/Influxdb.test.ts
+++ b/packages/core/test/unit/Influxdb.test.ts
@@ -5,41 +5,41 @@ describe('InfluxDB', () => {
   describe('constructor', () => {
     it('is created from string url', () => {
       expect(
-        (new InfluxDB('http://localhost:9999') as any)._options
+        (new InfluxDB('http://localhost:8086') as any)._options
       ).to.deep.equal({
-        url: 'http://localhost:9999',
+        url: 'http://localhost:8086',
       })
     })
     it('is created from configuration with url', () => {
       expect(
-        (new InfluxDB({url: 'http://localhost:9999'}) as any)._options
+        (new InfluxDB({url: 'http://localhost:8086'}) as any)._options
       ).to.deep.equal({
-        url: 'http://localhost:9999',
+        url: 'http://localhost:8086',
       })
     })
     it('is created from configuration with url and token', () => {
       expect(
         (new InfluxDB({
-          url: 'https://localhost:9999?token=a',
+          url: 'https://localhost:8086?token=a',
           token: 'b',
         }) as any)._options
       ).to.deep.equal({
-        url: 'https://localhost:9999?token=a',
+        url: 'https://localhost:8086?token=a',
         token: 'b',
       })
     })
     it('is created from string url with trailing slash', () => {
       expect(
-        (new InfluxDB('http://localhost:9999/') as any)._options
+        (new InfluxDB('http://localhost:8086/') as any)._options
       ).to.deep.equal({
-        url: 'http://localhost:9999',
+        url: 'http://localhost:8086',
       })
     })
     it('is created from configuration with url with trailing slash', () => {
       expect(
-        (new InfluxDB({url: 'http://localhost:9999/'}) as any)._options
+        (new InfluxDB({url: 'http://localhost:8086/'}) as any)._options
       ).to.deep.equal({
-        url: 'http://localhost:9999',
+        url: 'http://localhost:8086',
       })
     })
     it('fails on null arg', () => {
@@ -61,32 +61,32 @@ describe('InfluxDB', () => {
       expect(
         () =>
           new InfluxDB({
-            url: 'ws://localhost:9999?token=b',
+            url: 'ws://localhost:8086?token=b',
           })
       ).to.throw('Unsupported')
     })
     it('creates instance with transport initialized', () => {
       expect(
         new InfluxDB({
-          url: 'http://localhost:9999',
+          url: 'http://localhost:8086',
         })
       ).has.property('transport')
       expect(
         new InfluxDB(({
-          url: 'http://localhost:9999',
+          url: 'http://localhost:8086',
           transport: null,
         } as any) as ClientOptions)
       ).has.property('transport')
       expect(
         new InfluxDB(({
-          url: 'http://localhost:9999',
+          url: 'http://localhost:8086',
           transport: {} as Transport,
         } as any) as ClientOptions)
       ).has.property('transport')
     })
   })
   describe('apis', () => {
-    const influxDb = new InfluxDB('http://localhost:9999?token=a')
+    const influxDb = new InfluxDB('http://localhost:8086?token=a')
     it('serves queryApi writeApi without a pending schedule', () => {
       expect(influxDb.getWriteApi('org', 'bucket')).to.be.ok
       expect(influxDb.getWriteApi('org', 'bucket', WritePrecision.s)).to.be.ok

--- a/packages/core/test/unit/QueryApi.test.ts
+++ b/packages/core/test/unit/QueryApi.test.ts
@@ -12,7 +12,7 @@ const ORG = `my-org`
 const QUERY_PATH = `/api/v2/query?org=${ORG}`
 
 const clientOptions: ClientOptions = {
-  url: 'http://fake:9999',
+  url: 'http://fake:8086',
   token: 'a',
 }
 

--- a/packages/core/test/unit/WriteApi.test.ts
+++ b/packages/core/test/unit/WriteApi.test.ts
@@ -13,7 +13,7 @@ import {collectLogging, CollectedLogs} from '../util'
 import Logger from '../../src/impl/Logger'
 
 const clientOptions: ClientOptions = {
-  url: 'http://fake:9999',
+  url: 'http://fake:8086',
   token: 'a',
 }
 const ORG = 'org'

--- a/packages/core/test/unit/impl/browser/FetchTransport.test.ts
+++ b/packages/core/test/unit/impl/browser/FetchTransport.test.ts
@@ -13,7 +13,7 @@ describe('FetchTransport', () => {
   describe('constructor', () => {
     it('creates the transport with url', () => {
       const options = {
-        url: 'http://test:9999',
+        url: 'http://test:8086',
       }
       const transport: any = new FetchTransport(options)
       expect(transport.defaultHeaders).to.deep.equal({
@@ -24,7 +24,7 @@ describe('FetchTransport', () => {
     })
     it('creates the transport with url and token', () => {
       const options = {
-        url: 'http://test:9999',
+        url: 'http://test:8086',
         token: 'a',
       }
       const transport: any = new FetchTransport(options)
@@ -37,7 +37,7 @@ describe('FetchTransport', () => {
     })
   })
   describe('request', () => {
-    const transport = new FetchTransport({url: 'http://test:9999'})
+    const transport = new FetchTransport({url: 'http://test:8086'})
     it('receives json data', async () => {
       emulateFetchApi({
         headers: {'content-type': 'application/json'},
@@ -167,7 +167,7 @@ describe('FetchTransport', () => {
     })
   })
   describe('send', () => {
-    const transport = new FetchTransport({url: 'http://test:9999'})
+    const transport = new FetchTransport({url: 'http://test:8086'})
     function fakeCallbacks(): any {
       return {
         next: sinon.fake(),

--- a/packages/core/test/unit/impl/node/NodeHttpTransport.test.ts
+++ b/packages/core/test/unit/impl/node/NodeHttpTransport.test.ts
@@ -37,59 +37,59 @@ function sendTestData(
     })
   })
 }
-const TEST_URL = 'http://test:9999'
+const TEST_URL = 'http://test:8086'
 
 describe('NodeHttpTransport', () => {
   describe('constructor', () => {
     it('creates the transport from http url', () => {
       const transport: any = new NodeHttpTransport({
-        url: 'http://test:9999',
+        url: 'http://test:8086',
       })
       expect(transport.defaultOptions).to.deep.equal({
         hostname: 'test',
-        port: '9999',
+        port: '8086',
         protocol: 'http:',
         timeout: 10000,
-        url: 'http://test:9999',
+        url: 'http://test:8086',
       })
       expect(transport.requestApi).to.equal(http.request)
     })
     it('creates the transport from https url', () => {
       const transport: any = new NodeHttpTransport({
-        url: 'https://test:9999',
+        url: 'https://test:8086',
       })
       expect(transport.defaultOptions).to.deep.equal({
         hostname: 'test',
-        port: '9999',
+        port: '8086',
         protocol: 'https:',
         timeout: 10000,
-        url: 'https://test:9999',
+        url: 'https://test:8086',
       })
       expect(transport.requestApi).to.equal(https.request)
     })
     it('creates the transport with contextPath', () => {
       const transport: any = new NodeHttpTransport({
-        url: 'http://test:9999/influx',
+        url: 'http://test:8086/influx',
       })
       expect(transport.defaultOptions).to.deep.equal({
         hostname: 'test',
-        port: '9999',
+        port: '8086',
         protocol: 'http:',
         timeout: 10000,
-        url: 'http://test:9999/influx',
+        url: 'http://test:8086/influx',
       })
       expect(transport.contextPath).equals('/influx')
     })
     it('creates the transport with contextPath/', () => {
       const transport: any = new NodeHttpTransport({
-        url: 'http://test:9999/influx/',
+        url: 'http://test:8086/influx/',
       })
       expect(transport.defaultOptions).to.deep.equal({
         hostname: 'test',
-        port: '9999',
+        port: '8086',
         protocol: 'http:',
         timeout: 10000,
-        url: 'http://test:9999/influx/',
+        url: 'http://test:8086/influx/',
       })
       expect(transport.contextPath).equals('/influx')
     })
@@ -97,7 +97,7 @@ describe('NodeHttpTransport', () => {
       expect(
         () =>
           new NodeHttpTransport({
-            url: 'other://test:9999',
+            url: 'other://test:8086',
           })
       ).to.throw()
     })


### PR DESCRIPTION
Fixes #247 

Default InfluxDB port changed from 9999 to 8086 in examples, code comments and (for the sake of completeness) tests.

\+ check examples for eslint errors during CI tests

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
