### PR TITLE
fix(core): repair nesting of flux expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 1. [#237](https://github.com/influxdata/influxdb-client-js/pull/237): Fixed line splitter of query results that might have produced wrong results for query responses with quoted data.
 1. [#242](https://github.com/influxdata/influxdb-client-js/pull/242): Repair escaping of backslash in line protocol string field.
 1. [#246](https://github.com/influxdata/influxdb-client-js/pull/246): Throw error on attempt to write points using a closed WriteApi instance.
+1. [#252](https://github.com/influxdata/influxdb-client-js/pull/252): Repair nesting of flux expressions.
 
 ## 1.6.0 [2020-08-14]
 

--- a/packages/core/src/query/flux.ts
+++ b/packages/core/src/query/flux.ts
@@ -29,6 +29,15 @@ class FluxParameter implements FluxParameterLike, ParameterizedQuery {
 }
 
 /**
+ * Checks if the supplied object is FluxParameterLike
+ * @param value - any value
+ * @returns true if it is
+ */
+function isFluxParameterLike(value: any): boolean {
+  return typeof value === 'object' && typeof value[FLUX_VALUE] === 'function'
+}
+
+/**
  * Escapes content of the supplied string so it can be wrapped into double qoutes
  * to become a [flux string literal](https://docs.influxdata.com/flux/v0.65/language/lexical-elements/#string-literals).
  * @param value - string value
@@ -243,9 +252,12 @@ export function flux(
       } else {
         sanitized = toFluxValue(val)
         if (sanitized === '') {
-          throw new Error(
-            `Unsupported parameter literal '${val}' at index: ${i}, type: ${typeof val}`
-          )
+          // do not allow to insert empty strings, unless it is FluxParameterLike
+          if (!isFluxParameterLike(val)) {
+            throw new Error(
+              `Unsupported parameter literal '${val}' at index: ${i}, type: ${typeof val}`
+            )
+          }
         }
       }
       parts[partIndex++] = sanitized

--- a/packages/core/src/query/flux.ts
+++ b/packages/core/src/query/flux.ts
@@ -222,7 +222,9 @@ export function flux(
   strings: TemplateStringsArray,
   ...values: any
 ): ParameterizedQuery {
-  if (strings.length == 1 && (!values || values.length === 0)) return strings[0] // the simplest case
+  if (strings.length == 1 && (!values || values.length === 0)) {
+    return fluxExpression(strings[0]) // the simplest case
+  }
   const parts = new Array<string>(strings.length + values.length)
   let partIndex = 0
   for (let i = 0; i < strings.length; i++) {

--- a/packages/core/test/unit/query/flux.test.ts
+++ b/packages/core/test/unit/query/flux.test.ts
@@ -148,9 +148,27 @@ describe('Flux Tagged Template', () => {
       'from(bucket:"my-bucket") |> range(start: 0) |> filter(fn: (r) => r._measurement == "temperature")'
     )
   })
+  it('interpolates a wrapped string', () => {
+    expect(flux`from(bucket:"${'my-bucket'}")`.toString()).equals(
+      'from(bucket:"my-bucket")'
+    )
+  })
   it('fails on undefined', () => {
     try {
       flux`${undefined}`
+      expect.fail()
+    } catch (_e) {
+      // ok expected, undefined is not supported
+    }
+  })
+  it('fails on empty toString', () => {
+    try {
+      const x = {
+        toString(): string {
+          return ''
+        },
+      }
+      flux`${x}`
       expect.fail()
     } catch (_e) {
       // ok expected, undefined is not supported
@@ -166,17 +184,21 @@ describe('Flux Tagged Template', () => {
   })
 
   it('processes a simple nested flux template', () => {
-    // nested flux templates
     const flux1 = flux`from(bucket:"my-bucket")`
     expect(flux`${flux1} |> range(start: ${0})")`.toString()).equals(
       'from(bucket:"my-bucket") |> range(start: 0)")'
     )
   })
-  it('processes a simple nested flux template', () => {
-    // nested flux templates
+  it('processes a parameterized nested flux template', () => {
     const flux1 = flux`from(bucket:${'my-bucket'})`
     expect(flux`${flux1} |> range(start: ${0})")`.toString()).equals(
       'from(bucket:"my-bucket") |> range(start: 0)")'
+    )
+  })
+  it('processes an empty nested flux template', () => {
+    const empty = flux``
+    expect(flux`from(bucket:"my-bucket")${empty}`.toString()).equals(
+      'from(bucket:"my-bucket")'
     )
   })
 })

--- a/packages/core/test/unit/query/flux.test.ts
+++ b/packages/core/test/unit/query/flux.test.ts
@@ -127,7 +127,7 @@ describe('Flux Values', () => {
 })
 
 describe('Flux Tagged Template', () => {
-  it('creates a string from string', () => {
+  it('creates a string from a simple string', () => {
     expect(
       flux`from(bucket:"my-bucket") |> range(start: 0) |> filter(fn: (r) => r._measurement == "temperature")`.toString()
     ).equals(
@@ -165,9 +165,16 @@ describe('Flux Tagged Template', () => {
     }
   })
 
-  it('processes a nested flux template', () => {
+  it('processes a simple nested flux template', () => {
     // nested flux templates
     const flux1 = flux`from(bucket:"my-bucket")`
+    expect(flux`${flux1} |> range(start: ${0})")`.toString()).equals(
+      'from(bucket:"my-bucket") |> range(start: 0)")'
+    )
+  })
+  it('processes a simple nested flux template', () => {
+    // nested flux templates
+    const flux1 = flux`from(bucket:${'my-bucket'})`
     expect(flux`${flux1} |> range(start: ${0})")`.toString()).equals(
       'from(bucket:"my-bucket") |> range(start: 0)")'
     )

--- a/packages/core/test/unit/query/flux.test.ts
+++ b/packages/core/test/unit/query/flux.test.ts
@@ -24,12 +24,7 @@ describe('Flux Values', () => {
     const subject = fluxInteger(123)
     expect(subject.toString()).equals('123')
     expect((subject as any)[FLUX_VALUE]()).equals('123')
-    try {
-      fluxInteger('123a')
-      expect.fail()
-    } catch (_e) {
-      // OK, this must happen
-    }
+    expect(() => fluxInteger('123a')).to.throw()
   })
   it('creates fluxBool', () => {
     expect(fluxBool('true').toString()).equals('true')
@@ -49,18 +44,8 @@ describe('Flux Values', () => {
     const subject = fluxFloat(123.456)
     expect(subject.toString()).equals('123.456')
     expect((subject as any)[FLUX_VALUE]()).equals('123.456')
-    try {
-      fluxFloat('123..')
-      expect.fail()
-    } catch (_e) {
-      // OK, this must happen
-    }
-    try {
-      fluxFloat('123.a')
-      expect.fail()
-    } catch (_e) {
-      // OK, this must happen
-    }
+    expect(() => fluxFloat('123..')).to.throw()
+    expect(() => fluxFloat('123.a')).to.throw()
   })
   it('creates fluxDuration', () => {
     const subject = fluxDuration('1ms')
@@ -154,25 +139,15 @@ describe('Flux Tagged Template', () => {
     )
   })
   it('fails on undefined', () => {
-    try {
-      flux`${undefined}`
-      expect.fail()
-    } catch (_e) {
-      // ok expected, undefined is not supported
-    }
+    expect(() => flux`${undefined}`).to.throw()
   })
-  it('fails on empty toString', () => {
-    try {
-      const x = {
-        toString(): string {
-          return ''
-        },
-      }
-      flux`${x}`
-      expect.fail()
-    } catch (_e) {
-      // ok expected, undefined is not supported
+  it('converts object with empty toString to ""', () => {
+    const x = {
+      toString(): string {
+        return ''
+      },
     }
+    expect(flux`${x}`.toString()).equals('""')
   })
   it('fails on wrong usage of template', () => {
     try {


### PR DESCRIPTION
Fixes #251

This PR fixes the `flux` template function so that 
- a non-interpolated (simple) string returns a flux expression
- an empty flux expression can be wrapped into another flux expression

It also improves and repairs the tests of the flux template function, some of them were not executed due to incorrect usage of mocha.
 
## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
