### PR TITLE
feat(core/query): allow to receive the whole query response as text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 1. [#238](https://github.com/influxdata/influxdb-client-js/pull/238): Respect context path in client's url option.
 1. [#240](https://github.com/influxdata/influxdb-client-js/pull/240): Add helpers to let users choose how to deserialize dateTime:RFC3339 query response data type
 1. [#250](https://github.com/influxdata/influxdb-client-js/pull/250): Simplify precision for WriteApi retrieval.
+1. [#253](https://github.com/influxdata/influxdb-client-js/pull/253): Allow to simply receive the whole query response as a string.
 
 ### Bug Fixes
 

--- a/packages/core/src/QueryApi.ts
+++ b/packages/core/src/QueryApi.ts
@@ -121,7 +121,7 @@ export default interface QueryApi {
   collectLines(query: string | ParameterizedQuery): Promise<Array<string>>
 
   /**
-   * Text executes the query and returns the full response body as a string.
+   * Text executes a query and returns the full response as a string.
    * Use with caution, a possibly huge stream is copied to memory.
    *
    * @param query - query

--- a/packages/core/src/QueryApi.ts
+++ b/packages/core/src/QueryApi.ts
@@ -92,6 +92,15 @@ export default interface QueryApi {
   ): void
 
   /**
+   * QueryRaw executes a query and returns the full response as a string.
+   * Use with caution, a possibly huge stream is copied to memory.
+   *
+   * @param query - query
+   * @returns Promise of response text
+   */
+  queryRaw(query: string | ParameterizedQuery): Promise<string>
+
+  /**
    * CollectRows executes the query and collects all the results in the returned Promise.
    * This method is suitable to collect simple results. Use with caution,
    * a possibly huge stream of results is copied to memory.
@@ -119,13 +128,4 @@ export default interface QueryApi {
    * @returns Promise of returned csv lines
    */
   collectLines(query: string | ParameterizedQuery): Promise<Array<string>>
-
-  /**
-   * Text executes a query and returns the full response as a string.
-   * Use with caution, a possibly huge stream is copied to memory.
-   *
-   * @param query - query
-   * @returns Promise of response text
-   */
-  text(query: string | ParameterizedQuery): Promise<string>
 }

--- a/packages/core/src/QueryApi.ts
+++ b/packages/core/src/QueryApi.ts
@@ -119,4 +119,13 @@ export default interface QueryApi {
    * @returns Promise of returned csv lines
    */
   collectLines(query: string | ParameterizedQuery): Promise<Array<string>>
+
+  /**
+   * Text executes the query and returns the full response body as a string.
+   * Use with caution, a possibly huge stream is copied to memory.
+   *
+   * @param query - query
+   * @returns Promise of response text
+   */
+  text(query: string | ParameterizedQuery): Promise<string>
 }

--- a/packages/core/src/impl/QueryApiImpl.ts
+++ b/packages/core/src/impl/QueryApiImpl.ts
@@ -108,7 +108,7 @@ export class QueryApiImpl implements QueryApi {
     })
   }
 
-  text(query: string | ParameterizedQuery): Promise<string> {
+  queryRaw(query: string | ParameterizedQuery): Promise<string> {
     const {org, type, gzip} = this.options
     return this.transport.request(
       `/api/v2/query?org=${encodeURIComponent(org)}`,

--- a/packages/core/src/impl/QueryApiImpl.ts
+++ b/packages/core/src/impl/QueryApiImpl.ts
@@ -108,6 +108,28 @@ export class QueryApiImpl implements QueryApi {
     })
   }
 
+  text(query: string | ParameterizedQuery): Promise<string> {
+    const {org, type, gzip} = this.options
+    return this.transport.request(
+      `/api/v2/query?org=${encodeURIComponent(org)}`,
+      JSON.stringify(
+        this.decorateRequest({
+          query: query.toString(),
+          dialect: DEFAULT_dialect,
+          type,
+        })
+      ),
+      {
+        method: 'POST',
+        headers: {
+          accept: 'text/csv',
+          'accept-encoding': gzip ? 'gzip' : 'identity',
+          'content-type': 'application/json; encoding=utf-8',
+        },
+      }
+    )
+  }
+
   private createExecutor(query: string | ParameterizedQuery): QueryExecutor {
     const {org, type, gzip} = this.options
 

--- a/packages/core/src/impl/node/NodeHttpTransport.ts
+++ b/packages/core/src/impl/node/NodeHttpTransport.ts
@@ -126,10 +126,11 @@ export class NodeHttpTransport implements Transport {
           buffer = Buffer.concat([buffer, data])
         },
         complete: (): void => {
+          const responseType = options.headers?.accept ?? contentType
           try {
-            if (contentType.includes('json')) {
+            if (responseType.includes('json')) {
               resolve(JSON.parse(buffer.toString('utf8')))
-            } else if (contentType.includes('text')) {
+            } else if (responseType.includes('text')) {
               resolve(buffer.toString('utf8'))
             } else {
               resolve(buffer)

--- a/packages/core/test/integration/rxjs/QueryApi.test.ts
+++ b/packages/core/test/integration/rxjs/QueryApi.test.ts
@@ -53,14 +53,13 @@ describe('RxJS QueryApi integration', () => {
       })
       .persist()
 
-    try {
-      await from(subject.rows('from(bucket:"my-bucket") |> range(start: 0)'))
-        .pipe(toArray())
-        .toPromise()
-      expect.fail('Server returned 500!')
-    } catch (_) {
-      // expected failure
-    }
+    await from(subject.rows('from(bucket:"my-bucket") |> range(start: 0)'))
+      .pipe(toArray())
+      .toPromise()
+      .then(
+        () => expect.fail('Server returned 500!'),
+        () => true // failure is expected
+      )
   })
   ;[
     ['response2', undefined],

--- a/packages/core/test/unit/QueryApi.test.ts
+++ b/packages/core/test/unit/QueryApi.test.ts
@@ -238,12 +238,12 @@ describe('QueryApi', () => {
         ]
       })
       .persist()
-    try {
-      await subject.collectLines('from(bucket:"my-bucket") |> range(start: 0)')
-      expect.fail('client error expected on server error')
-    } catch (e) {
-      // OK error is expected
-    }
+    await subject
+      .collectLines('from(bucket:"my-bucket") |> range(start: 0)')
+      .then(
+        () => expect.fail('client error expected on server error'),
+        () => true // failure is expected
+      )
   })
   it('collectRows collects rows', async () => {
     const subject = new InfluxDB(clientOptions).getQueryApi(ORG).with({})
@@ -297,11 +297,101 @@ describe('QueryApi', () => {
         ]
       })
       .persist()
-    try {
-      await subject.collectRows('from(bucket:"my-bucket") |> range(start: 0)')
-      expect.fail('client error expected on server error')
-    } catch (e) {
-      // OK error is expected
-    }
+    await subject
+      .collectRows('from(bucket:"my-bucket") |> range(start: 0)')
+      .then(
+        () => expect.fail('client error expected on server error'),
+        () => true // error is expected
+      )
+  })
+  it('collectLines collects raw lines', async () => {
+    const subject = new InfluxDB(clientOptions).getQueryApi(ORG).with({})
+    nock(clientOptions.url)
+      .post(QUERY_PATH)
+      .reply((_uri, _requestBody) => {
+        return [
+          200,
+          fs.createReadStream('test/fixture/query/simpleResponse.txt'),
+          {'retry-after': '1'},
+        ]
+      })
+      .persist()
+    const data = await subject.collectLines(
+      'from(bucket:"my-bucket") |> range(start: 0)'
+    )
+    expect(data).to.deep.equal(simpleResponseLines)
+  })
+  it('text returns the whole response text', async () => {
+    const subject = new InfluxDB(clientOptions).getQueryApi(ORG).with({})
+    const expected = fs
+      .readFileSync('test/fixture/query/simpleResponse.txt')
+      .toString()
+    nock(clientOptions.url)
+      .post(QUERY_PATH)
+      .reply((_uri, _requestBody) => {
+        return [200, expected, {'retry-after': '1', 'content-type': 'text/csv'}]
+      })
+      .persist()
+    const data = await subject.text(
+      'from(bucket:"my-bucket") |> range(start: 0)'
+    )
+    expect(data).equals(expected)
+  })
+  it('text returns the whole response even if response content type is not text', async () => {
+    const subject = new InfluxDB(clientOptions).getQueryApi(ORG).with({})
+    const expected = fs
+      .readFileSync('test/fixture/query/simpleResponse.txt')
+      .toString()
+    nock(clientOptions.url)
+      .post(QUERY_PATH)
+      .reply((_uri, _requestBody) => {
+        return [200, expected, {'retry-after': '1'}]
+      })
+      .persist()
+    const data = await subject.text(
+      'from(bucket:"my-bucket") |> range(start: 0)'
+    )
+    expect(data).equals(expected)
+  })
+  it('text returns the plain response text even it is gzip encoded', async () => {
+    const subject = new InfluxDB(clientOptions)
+      .getQueryApi(ORG)
+      .with({gzip: true})
+    nock(clientOptions.url)
+      .post(QUERY_PATH)
+      .reply((_uri, _requestBody) => {
+        return [
+          200,
+          fs
+            .createReadStream('test/fixture/query/simpleResponse.txt')
+            .pipe(zlib.createGzip()),
+          {'content-encoding': 'gzip', 'content-type': 'text/csv'},
+        ]
+      })
+      .persist()
+    const data = await subject.text(
+      'from(bucket:"my-bucket") |> range(start: 0)'
+    )
+    const expected = fs
+      .readFileSync('test/fixture/query/simpleResponse.txt')
+      .toString()
+    expect(data).equals(expected)
+  })
+  it('text fails on server error', async () => {
+    const subject = new InfluxDB(clientOptions).getQueryApi(ORG).with({})
+    nock(clientOptions.url)
+      .post(QUERY_PATH)
+      .reply((_uri, _requestBody) => {
+        return [
+          500,
+          fs.createReadStream('test/fixture/query/simpleResponse.txt'),
+          {'retry-after': '1'},
+        ]
+      })
+      .persist()
+    await subject.text('from(bucket:"my-bucket") |> range(start: 0)').then(
+      () => expect.fail('client error expected on server error'),
+      () => true // error is expected
+    )
   })
 })

--- a/packages/core/test/unit/impl/browser/emulateBrowser.ts
+++ b/packages/core/test/unit/impl/browser/emulateBrowser.ts
@@ -39,12 +39,8 @@ function createResponse({
   }
   if (typeof body === 'string') {
     retVal.text = function(): Promise<string> {
-      if (typeof body === 'string') {
-        if (body === 'error') return Promise.reject(new Error('error data'))
-        return Promise.resolve(body)
-      } else {
-        return Promise.reject(new Error('String body expected, but ' + body))
-      }
+      if (body === 'error') return Promise.reject(new Error('error data'))
+      return Promise.resolve(body)
     }
   }
   if (body instanceof Uint8Array) {

--- a/packages/core/test/unit/impl/node/NodeHttpTransport.test.ts
+++ b/packages/core/test/unit/impl/node/NodeHttpTransport.test.ts
@@ -549,6 +549,21 @@ describe('NodeHttpTransport', () => {
         expect(retVal).deep.equals(pair[1])
       })
     })
+    it(`return text even without explicit request headers `, async () => {
+      nock(transportOptions.url)
+        .get('/test')
+        .reply(200, '..', {
+          'content-type': 'application/text',
+        })
+        .persist()
+      const data = await new NodeHttpTransport({
+        ...transportOptions,
+        timeout: 10000,
+      }).request('/test', '', {
+        method: 'GET',
+      })
+      expect(data).equals('..')
+    })
     it(`fails on invalid json`, async () => {
       nock(transportOptions.url)
         .get('/test')
@@ -556,32 +571,35 @@ describe('NodeHttpTransport', () => {
           'content-type': 'application/json',
         })
         .persist()
-      try {
-        await new NodeHttpTransport({
-          ...transportOptions,
-          timeout: 10000,
-        }).request('/test', '', {
+      await new NodeHttpTransport({
+        ...transportOptions,
+        timeout: 10000,
+      })
+        .request('/test', '', {
           method: 'GET',
-          headers: {'content-type': 'applicaiton/json'},
+          headers: {'content-type': 'application/json'},
         })
-        expect.fail(`exception shall be thrown because of wrong JSON`)
-      } catch (e) {
-        expect(e)
-      }
+        .then(
+          () => expect.fail(`exception shall be thrown because of wrong JSON`),
+          () => true // OK that it fails
+        )
     })
     it(`fails on communication error`, async () => {
-      try {
-        await new NodeHttpTransport({
-          ...transportOptions,
-          timeout: 10000,
-        }).request('/test', '', {
+      await new NodeHttpTransport({
+        ...transportOptions,
+        timeout: 10000,
+      })
+        .request('/test', '', {
           method: 'GET',
-          headers: {'content-type': 'applicaiton/json'},
+          headers: {'content-type': 'application/json'},
         })
-        expect.fail(`exception shall be thrown because of wrong JSON`)
-      } catch (e) {
-        expect(e)
-      }
+        .then(
+          () =>
+            expect.fail(
+              `exception shall be thrown because of communication error`
+            ),
+          () => true // OK that it fails
+        )
     })
   })
 })


### PR DESCRIPTION
This PR adds the following method to QueryApi:

```
  /**
   * QueryRaw executes a query and returns the full response as a string.
   * Use with caution, a possibly huge stream is copied to memory.
   *
   * @param query - query
   * @returns Promise of response text
   */
  queryRaw(query: string | ParameterizedQuery): Promise<string>
```

The new method is suitable in cases that require the whole flux CSV response. It fits well with the examples provided in https://github.com/influxdata/giraffe

Additionally
+ wrong usage of expect.fail was fixed in all tests
+ transport implementations were changed to prefer the requested content type, if possible

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
