### PR TITLE
fix(core/transport): return text data also for application/csv content type

### DIFF
--- a/packages/core/src/impl/browser/FetchTransport.ts
+++ b/packages/core/src/impl/browser/FetchTransport.ts
@@ -136,7 +136,10 @@ export default class FetchTransport implements Transport {
     const responseType = options.headers?.accept ?? responseContentType
     if (responseType.includes('json')) {
       return await response.json()
-    } else if (responseType.includes('text')) {
+    } else if (
+      responseType.includes('text') ||
+      responseType.startsWith('application/csv')
+    ) {
       return await response.text()
     }
   }

--- a/packages/core/src/impl/node/NodeHttpTransport.ts
+++ b/packages/core/src/impl/node/NodeHttpTransport.ts
@@ -130,7 +130,10 @@ export class NodeHttpTransport implements Transport {
           try {
             if (responseType.includes('json')) {
               resolve(JSON.parse(buffer.toString('utf8')))
-            } else if (responseType.includes('text')) {
+            } else if (
+              responseType.includes('text') ||
+              responseType.startsWith('application/csv')
+            ) {
               resolve(buffer.toString('utf8'))
             } else {
               resolve(buffer)

--- a/packages/core/test/unit/impl/browser/FetchTransport.test.ts
+++ b/packages/core/test/unit/impl/browser/FetchTransport.test.ts
@@ -61,6 +61,16 @@ describe('FetchTransport', () => {
       })
       expect(response).is.deep.equal('{}')
     })
+    it('receives text data for application/csv', async () => {
+      emulateFetchApi({
+        headers: {'content-type': 'application/csv'},
+        body: '{}',
+      })
+      const response = await transport.request('/whatever', '', {
+        method: 'GET',
+      })
+      expect(response).is.deep.equal('{}')
+    })
     it('receives text data even if response is application/json', async () => {
       emulateFetchApi({
         headers: {'content-type': 'application/json; charset=utf-8'},

--- a/packages/core/test/unit/impl/node/NodeHttpTransport.test.ts
+++ b/packages/core/test/unit/impl/node/NodeHttpTransport.test.ts
@@ -564,6 +564,21 @@ describe('NodeHttpTransport', () => {
       })
       expect(data).equals('..')
     })
+    it(`return text for CSV response`, async () => {
+      nock(transportOptions.url)
+        .get('/test')
+        .reply(200, '..', {
+          'content-type': 'application/csv',
+        })
+        .persist()
+      const data = await new NodeHttpTransport({
+        ...transportOptions,
+        timeout: 10000,
+      }).request('/test', '', {
+        method: 'GET',
+      })
+      expect(data).equals('..')
+    })
     it(`fails on invalid json`, async () => {
       nock(transportOptions.url)
         .get('/test')


### PR DESCRIPTION
transport.request must also return text when application/csv content type is received

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
