### PR TITLE
chore(core): repair type of ChunkToLines

### DIFF
--- a/packages/core/src/impl/ChunksToLines.ts
+++ b/packages/core/src/impl/ChunksToLines.ts
@@ -4,7 +4,8 @@ import Cancellable from '../util/Cancellable'
 /**
  * Converts lines to table calls
  */
-export default class ChunksToLines implements CommunicationObserver<any> {
+export default class ChunksToLines
+  implements CommunicationObserver<Uint8Array> {
   previous?: Uint8Array
   finished = false
   quoted = false


### PR DESCRIPTION
ChunksToLines is of type `CommunicationObserver<Uint8Array>`

- [x] Rebased/mergeable
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
