### PR TITLE
feat(core): convert FluxTableColumn and FluxTableMetaData to interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
 1. [#253](https://github.com/influxdata/influxdb-client-js/pull/253): Allow to simply receive the whole query response as a string.
 1. [#257](https://github.com/influxdata/influxdb-client-js/pull/257): Regenerate APIs from swagger.
 
+### Breaking Changes
+
+1. [#258](https://github.com/influxdata/influxdb-client-js/pull/258): Convert FluxTableColumn and FluxTableMetaData to interface.
+   This change is unlikely to cause any harm, since the clients are expected to use only FluxTableColumn/FluxTableMetaData
+   fields or methods that didn't change. See [#258](https://github.com/influxdata/influxdb-client-js/pull/258) for details
+   and backward compatibility notes.
+
 ### Bug Fixes
 
 1. [#237](https://github.com/influxdata/influxdb-client-js/pull/237): Fixed line splitter of query results that might have produced wrong results for query responses with quoted data.

--- a/packages/core/src/impl/linesToTables.ts
+++ b/packages/core/src/impl/linesToTables.ts
@@ -2,8 +2,13 @@ import {CommunicationObserver} from '../transport'
 import Cancellable from '../util/Cancellable'
 import FluxResultObserver from '../query/FluxResultObserver'
 import LineSplitter from '../util/LineSplitter'
-import FluxTableColumn, {ColumnType} from '../query/FluxTableColumn'
-import FluxTableMetaData from '../query/FluxTableMetaData'
+import FluxTableColumn, {
+  ColumnType,
+  newFluxTableColumn,
+} from '../query/FluxTableColumn'
+import FluxTableMetaData, {
+  createFluxTableMetaData,
+} from '../query/FluxTableMetaData'
 
 export function toLineObserver(
   consumer: FluxResultObserver<string[]>
@@ -29,7 +34,7 @@ export function toLineObserver(
           if (!columns) {
             columns = new Array(size)
             for (let i = 0; i < size; i++) {
-              columns[i] = new FluxTableColumn()
+              columns[i] = newFluxTableColumn()
             }
           }
           if (!values[0].startsWith('#')) {
@@ -43,7 +48,7 @@ export function toLineObserver(
             for (let i = firstColumnIndex; i < size; i++) {
               columns[i - firstColumnIndex].label = values[i]
             }
-            lastMeta = new FluxTableMetaData(columns)
+            lastMeta = createFluxTableMetaData(columns)
             expectMeta = false
           } else if (values[0] === '#datatype') {
             for (let i = 1; i < size; i++) {

--- a/packages/core/src/query/FluxTableColumn.ts
+++ b/packages/core/src/query/FluxTableColumn.ts
@@ -13,33 +13,9 @@ export type ColumnType =
   | string
 
 /**
- * FluxTableColumnLike provides metadata of a flux table column.
- */
-export interface FluxTableColumnLike {
-  /**
-   * Label (e.g., "_start", "_stop", "_time").
-   */
-  label: string
-
-  /**
-   * The data type of column (e.g., "string", "long", "dateTime:RFC3339").
-   */
-  dataType?: ColumnType
-
-  /**
-   * Boolean flag indicating if the column is a part of the table's group key.
-   */
-  group?: boolean
-
-  /**
-   * Default value to be used for rows whose string value is the empty string.
-   */
-  defaultValue?: string
-}
-/**
  * Column metadata class of a {@link http://bit.ly/flux-spec#table | flux table} column.
  */
-export default class FluxTableColumn {
+export default interface FluxTableColumn {
   /**
    * Label (e.g., "_start", "_stop", "_time").
    */
@@ -64,18 +40,40 @@ export default class FluxTableColumn {
    * Index of this column in the row array
    */
   index: number
+}
 
-  /**
-   * Creates a flux table column from an object supplied.
-   * @param object - source object
-   * @returns column instance
-   */
-  static from(object: FluxTableColumnLike): FluxTableColumn {
-    const retVal = new FluxTableColumn()
-    retVal.label = object.label
-    retVal.dataType = object.dataType as ColumnType
-    retVal.group = Boolean(object.group)
-    retVal.defaultValue = object.defaultValue ?? ''
-    return retVal
-  }
+/**
+ * FluxTableColumn implementation.
+ */
+class FluxTableColumnImpl implements FluxTableColumn {
+  label: string
+  dataType: ColumnType
+  group: boolean
+  defaultValue: string
+  index: number
+}
+
+/**
+ * Creates a new flux table column.
+ * @returns column instance
+ */
+export function newFluxTableColumn(): FluxTableColumn {
+  return new FluxTableColumnImpl()
+}
+
+/**
+ * Creates a flux table column from a partial FluxTableColumn.
+ * @param object - source object
+ * @returns column instance
+ */
+export function createFluxTableColumn(
+  object: Partial<FluxTableColumn>
+): FluxTableColumn {
+  const retVal = new FluxTableColumnImpl()
+  retVal.label = String(object.label)
+  retVal.dataType = object.dataType as ColumnType
+  retVal.group = Boolean(object.group)
+  retVal.defaultValue = object.defaultValue ?? ''
+  retVal.index = object.index ?? 0
+  return retVal
 }

--- a/packages/core/src/query/FluxTableMetaData.ts
+++ b/packages/core/src/query/FluxTableMetaData.ts
@@ -51,21 +51,36 @@ export function serializeDateTimeAsString(): void {
 /**
  * Represents metadata of a {@link http://bit.ly/flux-spec#table | flux table}.
  */
-export default class FluxTableMetaData {
+export default interface FluxTableMetaData {
   /**
    * Table columns.
    */
   columns: Array<FluxTableColumn>
-  constructor(columns: FluxTableColumn[]) {
-    columns.forEach((col, i) => (col.index = i))
-    this.columns = columns
-  }
+
   /**
    * Gets columns by name
    * @param label - column label
    * @returns table column
    * @throws IllegalArgumentError if column is not found
    **/
+  column(label: string): FluxTableColumn
+
+  /**
+   * Creates an object out of the supplied values with the help of columns .
+   * @param values - a row with data for each column
+   */
+  toObject(values: string[]): {[key: string]: any}
+}
+
+/**
+ * FluxTableMetaData Implementation.
+ */
+class FluxTableMetaDataImpl implements FluxTableMetaData {
+  columns: Array<FluxTableColumn>
+  constructor(columns: FluxTableColumn[]) {
+    columns.forEach((col, i) => (col.index = i))
+    this.columns = columns
+  }
   column(label: string): FluxTableColumn {
     for (let i = 0; i < this.columns.length; i++) {
       const col = this.columns[i]
@@ -73,10 +88,6 @@ export default class FluxTableMetaData {
     }
     throw new IllegalArgumentError(`Column ${label} not found!`)
   }
-  /**
-   * Creates an object out of the supplied values with the help of columns .
-   * @param values - a row with data for each column
-   */
   toObject(values: string[]): {[key: string]: any} {
     const acc: any = {}
     for (let i = 0; i < this.columns.length && i < values.length; i++) {
@@ -89,4 +100,15 @@ export default class FluxTableMetaData {
     }
     return acc
   }
+}
+
+/**
+ * Created FluxTableMetaData from the columns supplied.
+ * @param columns -  columns
+ * @returns - instance
+ */
+export function createFluxTableMetaData(
+  columns: FluxTableColumn[]
+): FluxTableMetaData {
+  return new FluxTableMetaDataImpl(columns)
 }

--- a/packages/core/src/query/index.ts
+++ b/packages/core/src/query/index.ts
@@ -4,11 +4,12 @@ export {
   serializeDateTimeAsDate,
   serializeDateTimeAsNumber,
   serializeDateTimeAsString,
+  createFluxTableMetaData,
 } from './FluxTableMetaData'
 export {default as FluxResultObserver} from './FluxResultObserver'
 export {
   default as FluxTableColumn,
   ColumnType,
-  FluxTableColumnLike,
+  createFluxTableColumn,
 } from './FluxTableColumn'
 export * from './flux'

--- a/packages/core/test/integration/rxjs/QueryApi.test.ts
+++ b/packages/core/test/integration/rxjs/QueryApi.test.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai'
 import nock from 'nock' // WARN: nock must be imported before NodeHttpTransport, since it modifies node's http
-import {InfluxDB, ClientOptions, FluxTableMetaData} from '../../../src'
+import {InfluxDB, ClientOptions} from '../../../src'
 import fs from 'fs'
 import simpleResponseLines from '../../fixture/query/simpleResponseLines.json'
 import zlib from 'zlib'
@@ -90,9 +90,7 @@ describe('RxJS QueryApi integration', () => {
             concat(of(group.key), group.pipe(map(({values}) => values)))
           ),
           map((data, index) =>
-            data instanceof FluxTableMetaData
-              ? {index, meta: data}
-              : {index, row: data}
+            Array.isArray(data) ? {index, row: data} : {index, meta: data}
           ),
           groupBy(value => 'meta' in value),
           flatMap(group => group.pipe(toArray())),

--- a/packages/core/test/unit/query/FluxTableMetaData.test.ts
+++ b/packages/core/test/unit/query/FluxTableMetaData.test.ts
@@ -1,28 +1,29 @@
 import {
   FluxTableColumn,
-  FluxTableMetaData,
+  createFluxTableMetaData,
   ColumnType,
   typeSerializers,
   serializeDateTimeAsDate,
   serializeDateTimeAsNumber,
   serializeDateTimeAsString,
+  createFluxTableColumn,
 } from '../../../src'
 import {expect} from 'chai'
 
 describe('FluxTableMetaData', () => {
   it('returns columns by name or id', () => {
     const columns: FluxTableColumn[] = [
-      FluxTableColumn.from({
+      createFluxTableColumn({
         label: 'a',
         defaultValue: 'def',
         dataType: 'long',
         group: false,
       }),
-      FluxTableColumn.from({
+      createFluxTableColumn({
         label: 'b',
       }),
     ]
-    const subject = new FluxTableMetaData(columns)
+    const subject = createFluxTableMetaData(columns)
     expect(subject.column('a')).to.equals(columns[0])
     expect(subject.column('b')).to.equals(columns[1])
     expect(subject.columns[0]).to.equals(columns[0])
@@ -31,17 +32,17 @@ describe('FluxTableMetaData', () => {
   })
   it('creates objects', () => {
     const columns: FluxTableColumn[] = [
-      FluxTableColumn.from({
+      createFluxTableColumn({
         label: 'a',
         defaultValue: '1',
         dataType: 'long',
         group: false,
       }),
-      FluxTableColumn.from({
+      createFluxTableColumn({
         label: 'b',
       }),
     ]
-    const subject = new FluxTableMetaData(columns)
+    const subject = createFluxTableMetaData(columns)
     expect(subject.toObject(['', ''])).to.deep.equal({a: 1, b: ''})
     expect(subject.toObject(['2', 'y'])).to.deep.equal({a: 2, b: 'y'})
     expect(subject.toObject(['3', 'y', 'z'])).to.deep.equal({a: 3, b: 'y'})
@@ -67,12 +68,12 @@ describe('FluxTableMetaData', () => {
   for (const entry of serializationTable) {
     it(`serializes ${entry[0]}/${entry[1]}`, () => {
       const columns: FluxTableColumn[] = [
-        FluxTableColumn.from({
+        createFluxTableColumn({
           label: 'a',
           dataType: entry[0],
         }),
       ]
-      const subject = new FluxTableMetaData(columns)
+      const subject = createFluxTableMetaData(columns)
       expect(subject.toObject([entry[1]])).to.deep.equal({a: entry[2]})
     })
   }
@@ -90,25 +91,25 @@ describe('FluxTableMetaData', () => {
     it('customizes serialization of long datatype', () => {
       typeSerializers['long'] = (_x: string): any => []
       const columns: FluxTableColumn[] = [
-        FluxTableColumn.from({
+        createFluxTableColumn({
           label: 'a',
           dataType: 'long',
           group: false,
         }),
       ]
-      const subject = new FluxTableMetaData(columns)
+      const subject = createFluxTableMetaData(columns)
       expect(subject.toObject([''])).to.deep.equal({a: []})
     })
     it('customizes serialization using serializeDateTimeAsDate', () => {
       serializeDateTimeAsDate()
       const columns: FluxTableColumn[] = [
-        FluxTableColumn.from({
+        createFluxTableColumn({
           label: 'a',
           dataType: 'dateTime:RFC3339',
           group: false,
         }),
       ]
-      const subject = new FluxTableMetaData(columns)
+      const subject = createFluxTableMetaData(columns)
       expect(subject.toObject([''])).to.deep.equal({a: null})
       expect(
         subject.toObject(['2020-08-19T09:14:23.798594313Z'])
@@ -117,13 +118,13 @@ describe('FluxTableMetaData', () => {
     it('customizes serialization using serializeDateTimeAsNumber', () => {
       serializeDateTimeAsNumber()
       const columns: FluxTableColumn[] = [
-        FluxTableColumn.from({
+        createFluxTableColumn({
           label: 'a',
           dataType: 'dateTime:RFC3339',
           group: false,
         }),
       ]
-      const subject = new FluxTableMetaData(columns)
+      const subject = createFluxTableMetaData(columns)
       expect(subject.toObject([''])).to.deep.equal({a: null})
       expect(
         subject.toObject(['2020-08-19T09:14:23.798594313Z'])
@@ -133,13 +134,13 @@ describe('FluxTableMetaData', () => {
       serializeDateTimeAsDate()
       serializeDateTimeAsString()
       const columns: FluxTableColumn[] = [
-        FluxTableColumn.from({
+        createFluxTableColumn({
           label: 'a',
           dataType: 'dateTime:RFC3339',
           group: false,
         }),
       ]
-      const subject = new FluxTableMetaData(columns)
+      const subject = createFluxTableMetaData(columns)
       expect(subject.toObject([''])).to.deep.equal({a: null})
       expect(
         subject.toObject(['1970-01-01T00:26:16.063594313Z'])

--- a/packages/core/test/unit/query/FluxTableMetaData.test.ts
+++ b/packages/core/test/unit/query/FluxTableMetaData.test.ts
@@ -40,6 +40,7 @@ describe('FluxTableMetaData', () => {
       }),
       createFluxTableColumn({
         label: 'b',
+        index: 2, // index can be possibly set, but it gets overriden during createFluxTableMetaData
       }),
     ]
     const subject = createFluxTableMetaData(columns)


### PR DESCRIPTION
This PR changes FluxTableColumn and FluxTableMetaData classes to interfaces. This change better reflects what the library users should care (i.e. shape of the object passed, not the instance) and also allows for better tree shaking (influxdata/giraffe#282 will completely tree shake the whole @influxdata/influxdb-client package, it would not without this change). 

This change should not cause major compatibility issues, because:

- the new interfaces have the same shape as the previous classes
- it is not expected that users will create new FluxTableColumn or FluxTableMetaData instances or use `instanceof` checks against such classes. In the rare case they already do, there are new exported functions: createFluxTableColumn, createFluxTableMetaDta that replace constructor.
- all existing tests already pass, with a small adjustment in RX-js integration tests

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
