### PR TITLE
fix(core): finish query when cancelled by the user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 1. [#242](https://github.com/influxdata/influxdb-client-js/pull/242): Repair escaping of backslash in line protocol string field.
 1. [#246](https://github.com/influxdata/influxdb-client-js/pull/246): Throw error on attempt to write points using a closed WriteApi instance.
 1. [#252](https://github.com/influxdata/influxdb-client-js/pull/252): Repair nesting of flux expressions.
+1. [#259](https://github.com/influxdata/influxdb-client-js/pull/259): Finish query when cancelled by the user.
 
 ## 1.6.0 [2020-08-14]
 

--- a/packages/core/src/impl/ChunksToLines.ts
+++ b/packages/core/src/impl/ChunksToLines.ts
@@ -44,16 +44,14 @@ export default class ChunksToLines
     if (this.target.useCancellable) {
       // eslint-disable-next-line @typescript-eslint/no-this-alias
       const self = this
-      let cancelled = false
       this.target.useCancellable({
         cancel(): void {
           cancellable.cancel()
           self.previous = undefined // do not emit more lines
-          cancelled = true
           self.complete()
         },
         isCancelled(): boolean {
-          return cancelled
+          return cancellable.isCancelled()
         },
       })
     }

--- a/packages/core/src/impl/ChunksToLines.ts
+++ b/packages/core/src/impl/ChunksToLines.ts
@@ -41,7 +41,22 @@ export default class ChunksToLines
     }
   }
   useCancellable(cancellable: Cancellable): void {
-    this.target.useCancellable && this.target.useCancellable(cancellable)
+    if (this.target.useCancellable) {
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      const self = this
+      let cancelled = false
+      this.target.useCancellable({
+        cancel(): void {
+          cancellable.cancel()
+          self.previous = undefined // do not emit more lines
+          cancelled = true
+          self.complete()
+        },
+        isCancelled(): boolean {
+          return cancelled
+        },
+      })
+    }
   }
 
   private bufferReceived(chunk: Uint8Array): void {
@@ -59,6 +74,10 @@ export default class ChunksToLines
         if (!this.quoted) {
           /* do not emit CR+LR or LF line ending */
           const end = index > 0 && chunk[index - 1] === 13 ? index - 1 : index
+          // do not emmit more lines if the processing is already finished
+          if (this.finished) {
+            return
+          }
           this.target.next(this.chunks.toUtf8String(chunk, start, end))
           start = index + 1
         }

--- a/packages/core/src/impl/browser/FetchTransport.ts
+++ b/packages/core/src/impl/browser/FetchTransport.ts
@@ -36,16 +36,20 @@ export default class FetchTransport implements Transport {
   ): void {
     const observer = completeCommunicationObserver(callbacks)
     let cancelled = false
-    if (callbacks && callbacks.useCancellable && !(options as any).signal) {
+    let signal = (options as any).signal
+    if (callbacks && callbacks.useCancellable) {
       const controller = new AbortController()
-      const signal = controller.signal
+      if (!signal) {
+        signal = controller.signal
+        options = {...(options as object), ...signal} as SendOptions
+      }
       callbacks.useCancellable({
         cancel() {
           cancelled = true
           controller.abort()
         },
         isCancelled() {
-          return signal.aborted
+          return cancelled || signal.aborted
         },
       })
     }

--- a/packages/core/src/impl/browser/FetchTransport.ts
+++ b/packages/core/src/impl/browser/FetchTransport.ts
@@ -113,9 +113,7 @@ export default class FetchTransport implements Transport {
         }
       })
       .catch(e => {
-        if (cancelled) {
-          observer.complete()
-        } else {
+        if (!cancelled) {
           observer.error(e)
         }
       })

--- a/packages/core/test/unit/impl/browser/FetchTransport.test.ts
+++ b/packages/core/test/unit/impl/browser/FetchTransport.test.ts
@@ -3,6 +3,7 @@ import {expect} from 'chai'
 import {removeFetchApi, emulateFetchApi} from './emulateBrowser'
 import sinon from 'sinon'
 import {CLIENT_LIB_VERSION} from '../../../../src/impl/version'
+import {SendOptions, Cancellable} from '../../../../src'
 
 describe('FetchTransport', () => {
   afterEach(() => {
@@ -172,7 +173,9 @@ describe('FetchTransport', () => {
         next: sinon.fake(),
         error: sinon.fake(),
         complete: sinon.fake(),
-        useCancellable: sinon.fake(),
+        useCancellable: sinon.spy((c: Cancellable): void => {
+          expect(c.isCancelled()).is.equal(false) // not cancelled
+        }),
         responseStarted: sinon.fake(),
       }
     }
@@ -203,10 +206,30 @@ describe('FetchTransport', () => {
         callbacks: fakeCallbacks(),
       },
       {
-        url: 'customNext_canceled',
+        url: 'customNext_cancelledAndThenError',
         body: [Buffer.from('a'), Buffer.from('b')],
         callbacks: ((): void => {
           const overriden = fakeCallbacks()
+          return {
+            ...overriden,
+            next(...args: any): void {
+              overriden.next.call(overriden, args)
+              const cancellable = overriden.useCancellable.args[0][0]
+              cancellable.cancel()
+              throw new Error()
+            },
+          }
+        })(),
+      },
+      {
+        url: 'customNext_cancelledWithSignal',
+        body: [Buffer.from('a'), Buffer.from('b')],
+        signal: {aborted: true},
+        callbacks: ((): void => {
+          const overriden = fakeCallbacks()
+          overriden.useCancellable = sinon.spy((c: Cancellable): void => {
+            expect(c.isCancelled()).is.equal(true) // cancelled because of aborted signal
+          })
           return {
             ...overriden,
             next(...args: any): void {
@@ -266,10 +289,11 @@ describe('FetchTransport', () => {
           status = 200,
           headers = {},
           errorBody,
+          signal,
         },
         i
       ) => {
-        it(`receives data in chunks ${i}`, async () => {
+        it(`receives data in chunks ${i} (${url})`, async () => {
           emulateFetchApi({
             headers: {
               'content-type': 'text/plain',
@@ -281,22 +305,17 @@ describe('FetchTransport', () => {
           })
           if (callbacks) {
             await new Promise((resolve: any) =>
-              transport.send(
-                url,
-                '',
-                {method: 'POST'},
-                {
-                  ...callbacks,
-                  complete() {
-                    callbacks.complete && callbacks.complete()
-                    resolve()
-                  },
-                  error(e: Error) {
-                    callbacks.error && callbacks.error(e)
-                    resolve()
-                  },
-                }
-              )
+              transport.send(url, '', {method: 'POST', signal} as SendOptions, {
+                ...callbacks,
+                complete() {
+                  callbacks.complete && callbacks.complete()
+                  resolve()
+                },
+                error(e: Error) {
+                  callbacks.error && callbacks.error(e)
+                  resolve()
+                },
+              })
             )
             if (callbacks.useCancellable) {
               expect(callbacks.useCancellable.callCount).equals(1)
@@ -308,8 +327,8 @@ describe('FetchTransport', () => {
             expect(callbacks.responseStarted.callCount).equals(
               url === 'error' ? 0 : 1
             )
-            expect(callbacks.complete.callCount).equals(isError ? 0 : 1)
             expect(callbacks.error.callCount).equals(isError ? 1 : 0)
+            expect(callbacks.complete.callCount).equals(isError ? 0 : 1)
             const customNext = url.startsWith('customNext')
             if (!customNext) {
               expect(callbacks.next.callCount).equals(


### PR DESCRIPTION
This PR fixes
- browser (fetch) transport: do not throw any error after the user programmatically cancels result processing
- browser (fetch) transport: use [abortable fetch](https://developers.google.com/web/updates/2017/09/abortable-fetch) to also abort HTTP processing if the user programmatically cancels query result processing
- browser (fetch) transport: query processing is always completed after the user programmatically cancels result processing
   - i.e. the same as in NodeHttpTransport
- chunk to CSV lines conversion: do not emit new lines after the user programmatically cancels processing of a query

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
