### PR TITLE
fix(core): require status code 204 in write response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.8.0 [unreleased]
 
+### Bug Fixes
+
+1. [#264](https://github.com/influxdata/influxdb-client-js/pull/264): Require 204 status code in a write response.
+
 ## 1.7.0 [2020-10-02]
 
 ### Features

--- a/packages/core/src/impl/completeCommunicationObserver.ts
+++ b/packages/core/src/impl/completeCommunicationObserver.ts
@@ -30,8 +30,9 @@ export default function completeCommunicationObserver(
         if (callbacks.complete) callbacks.complete()
       }
     },
-    responseStarted: (headers: Headers): void => {
-      if (callbacks.responseStarted) callbacks.responseStarted(headers)
+    responseStarted: (headers: Headers, statusCode?: number): void => {
+      if (callbacks.responseStarted)
+        callbacks.responseStarted(headers, statusCode)
     },
   }
   return retVal

--- a/packages/core/src/transport.ts
+++ b/packages/core/src/transport.ts
@@ -24,8 +24,9 @@ export interface CommunicationObserver<T> {
   /**
    * Informs about a start of response processing.
    * @param headers - response HTTP headers
+   * @param statusCode - response status code
    */
-  responseStarted?: (headers: Headers) => void
+  responseStarted?: (headers: Headers, statusCode?: number) => void
   /**
    * Setups cancelllable for this communication.
    */


### PR DESCRIPTION
Fixes #263 

## Proposed Changes

1. A warning is printed to console on an attempt to configure the client with `url` having `/api/v2` suffix:
`Please remove '/api/v2' context path from InfluxDB base url, using http://test:8096 !`
2. WriteAPI requires status code 204 in HTTP POST response
3. Transport layer was changed (in a backward-compatible way) to also report the response status code.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
