### PR TITLE
chore(core): make QueryApi instance immutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 1. [#264](https://github.com/influxdata/influxdb-client-js/pull/264): Require 204 status code in a write response.
+1. [#265](https://github.com/influxdata/influxdb-client-js/pull/265): Make QueryApi instance immutable.
 
 ## 1.7.0 [2020-10-02]
 

--- a/packages/core/src/QueryApi.ts
+++ b/packages/core/src/QueryApi.ts
@@ -46,9 +46,9 @@ export interface Row {
  */
 export default interface QueryApi {
   /**
-   * Adds extra options for this query API.
+   * Returns a new query API with extra options applied.
    * @param options - query options to use
-   * @returns this
+   * @returns queryApi instance with the supplied options
    */
   with(options: Partial<QueryOptions>): QueryApi
 

--- a/packages/core/src/WriteApi.ts
+++ b/packages/core/src/WriteApi.ts
@@ -14,6 +14,7 @@ export default interface WriteApi {
    * Instructs to use the following default tags  when writing points.
    * Not applicable for writing records/lines.
    * @param tags - default tags
+   * @returns this
    */
   useDefaultTags(tags: {[key: string]: string}): WriteApi
 

--- a/packages/core/src/impl/QueryApiImpl.ts
+++ b/packages/core/src/impl/QueryApiImpl.ts
@@ -19,13 +19,12 @@ const identity = <T>(value: T): T => value
 
 export class QueryApiImpl implements QueryApi {
   private options: QueryOptions
-  constructor(private transport: Transport, org: string) {
-    this.options = {org}
+  constructor(private transport: Transport, org: string | QueryOptions) {
+    this.options = typeof org === 'string' ? {org} : org
   }
 
   with(options: Partial<QueryOptions>): QueryApi {
-    this.options = {...this.options, ...options}
-    return this
+    return new QueryApiImpl(this.transport, {...this.options, ...options})
   }
 
   lines(query: string | ParameterizedQuery): Observable<string> {

--- a/packages/core/test/unit/QueryApi.test.ts
+++ b/packages/core/test/unit/QueryApi.test.ts
@@ -24,8 +24,13 @@ describe('QueryApi', () => {
     nock.cleanAll()
     nock.enableNetConnect()
   })
+  it('with function does not mutate this', () => {
+    const first = new InfluxDB(clientOptions).getQueryApi(ORG)
+    const second = first.with({gzip: true})
+    expect(first).is.not.equal(second)
+  })
   it('receives lines', async () => {
-    const subject = new InfluxDB(clientOptions).getQueryApi(ORG).with({})
+    const subject = new InfluxDB(clientOptions).getQueryApi(ORG)
     nock(clientOptions.url)
       .post(QUERY_PATH)
       .reply((_uri, _requestBody) => {


### PR DESCRIPTION
The `QueryApi.with` function now returns a new QueryApi function. Making the QueryApi immutable is rather an idiomatic change. Immutability clarifies the API and avoids unwanted side-effects. This impact on existing usage is hard to imagine.


- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
