### PR TITLE
feat: introduce @influxdata/influxdb-client-browser module

### DIFF
--- a/.circleci/deploy-nightly-version.sh
+++ b/.circleci/deploy-nightly-version.sh
@@ -10,11 +10,7 @@ git config user.email "noreply@influxdata.com"
 git commit -am "chore(release): prepare to release influxdb-client-js-${VERSION}.nightly"
 
 # Build Core
-cd "${SCRIPT_PATH}"/../packages/core
-yarn build
-
-# Build Apis
-cd "${SCRIPT_PATH}"/../packages/apis
+cd "${SCRIPT_PATH}"/..
 yarn build
 
 # Publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.8.0 [unreleased]
 
+### Features
+
+1. [#267](https://github.com/influxdata/influxdb-client-js/pull/267): Introduce `@influxdata/influxdb-client-browser` module.
+
 ### Bug Fixes
 
 1. [#264](https://github.com/influxdata/influxdb-client-js/pull/264): Require 204 status code in a write response.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ $ yarn add @influxdata/influxdb-client
 $ pnpm add @influxdata/influxdb-client
 ```
 
+[@influxdata/influxdb-client](./packages/core/README.md) module primarily works in Node.js (main CJS and module ESM), but a browser (browser UMD) distribution is also available therein. If you need only a browser distribution, use [@influxdata/influxdb-client-browser](./packages/core-browser/README.md) that targets browser environment (main UMD and module ESM).
+
 To use InfluxDB management APIs in your project, add also `@influxdata/influxdb-client-apis` dependency to your project.
 
 ```

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "apidoc:gh-pages": "gh-pages -d docs/dist -m 'Updates [skip CI]'",
     "preinstall": "node ./scripts/require-yarn.js",
     "clean": "rimraf temp docs && yarn workspaces run clean",
-    "build": "cd packages/core && yarn build && cd ../apis && yarn build",
+    "build": "cd packages/core && yarn build && cd ../core-browser && yarn build && cd ../apis && yarn build",
     "test": "cd packages/core && yarn test && yarn build && cd ../apis && yarn test && yarn eslint ../../examples",
     "coverage": "cd packages/core && yarn coverage",
     "coverage:send": "cd packages/core && yarn coverage:send"

--- a/packages/apis/rollup.config.js
+++ b/packages/apis/rollup.config.js
@@ -2,26 +2,14 @@ import {terser} from 'rollup-plugin-terser'
 import gzip from 'rollup-plugin-gzip'
 import typescript from 'rollup-plugin-typescript2'
 import pkg from './package.json'
-import replace from '@rollup/plugin-replace'
 
 const tsBuildConfigPath = './tsconfig.build.json'
 
 const input = 'src/index.ts'
-function createConfig({browser, format, out, name, target, noTerser}) {
+function createConfig({format, out, name, target, noTerser}) {
   return {
     input,
     plugins: [
-      replace(
-        browser
-          ? {
-              'process.env.ROLLUP_BROWSER': 'true',
-              delimiters: ['', ''],
-            }
-          : {
-              'process.env.ROLLUP_BROWSER': 'false',
-              delimiters: ['', ''],
-            }
-      ),
       typescript({
         tsconfig: tsBuildConfigPath,
         tsconfigOverride: {
@@ -44,23 +32,20 @@ function createConfig({browser, format, out, name, target, noTerser}) {
 }
 
 export default [
-  createConfig({browser: false, format: 'cjs', out: pkg.main}),
-  createConfig({browser: false, format: 'esm', out: pkg.module}),
-  createConfig({browser: true, format: 'umd', out: pkg.browser}),
+  createConfig({format: 'cjs', out: pkg.main}),
+  createConfig({format: 'esm', out: pkg.module}),
+  createConfig({format: 'umd', out: pkg.browser}),
   createConfig({
-    browser: true,
     format: 'esm',
     out: pkg.browser.replace('.js', '.mjs'),
   }),
   createConfig({
-    browser: true,
     format: 'iife',
     name: 'influxdbApis',
     out: 'dist/influxdbApis.min.js',
     target: 'es5',
   }),
   createConfig({
-    browser: true,
     format: 'iife',
     name: 'influxdbApis',
     out: 'dist/influxdbApis.js',

--- a/packages/apis/src/APIBase.ts
+++ b/packages/apis/src/APIBase.ts
@@ -7,6 +7,12 @@ declare function btoa(plain: string): string
 export interface RequestOptions {
   headers?: {[key: string]: string}
 }
+
+function base64(value: string): string {
+  return typeof btoa === 'function' // browser (window,worker) environment
+    ? btoa(value)
+    : Buffer.from(value, 'binary').toString('base64')
+}
 /**
  * Base class for all apis.
  */
@@ -57,9 +63,7 @@ export class APIBase {
       const value = `${request.auth.user}:${request.auth.password}`
       ;(sendOptions.headers || (sendOptions.headers = {}))[
         'authorization'
-      ] = process.env.ROLLUP_BROWSER
-        ? btoa(value)
-        : Buffer.from(value, 'binary').toString('base64')
+      ] = base64(value)
     }
     return this.transport.request(
       path,

--- a/packages/core-browser/.npmignore
+++ b/packages/core-browser/.npmignore
@@ -1,0 +1,8 @@
+node_modules
+build
+.rpt2_cache
+.DS_Store
+.nyc_output
+*.lcov
+yarn-error.log
+

--- a/packages/core-browser/README.md
+++ b/packages/core-browser/README.md
@@ -2,11 +2,11 @@
 
 The reference javascript browser client for InfluxDB 2.0. The package.json
 
-- **main** points to browser UMD distribution
-- **module** points to browser ESM distribution
-- **browser** points to browser UMD distribution
+- **main** points to browser UMD distribution of @influxdata/influxdb-client
+- **module** points to browser ESM distribution of @influxdata/influxdb-client
+- **browser** points to browser UMD distribution of @influxdata/influxdb-client
 
-Browser distributions do not work in Node.js and vice versa, different APIs are used. See `@influxdata/influxdb-client` for a distribution that can be used in Node.js environment.
+Browser distributions do not work in Node.js and vice versa, different APIs are used in Node.js. See `@influxdata/influxdb-client` for a distribution that can be used in Node.js environment.
 
 See https://github.com/influxdata/influxdb-client-js to know more.
 

--- a/packages/core-browser/README.md
+++ b/packages/core-browser/README.md
@@ -1,0 +1,13 @@
+# @influxdata/influxdb-client-browser
+
+The reference javascript browser client for InfluxDB 2.0. The package.json
+
+- **main** points to browser UMD distribution
+- **module** points to browser ESM distribution
+- **browser** points to browser UMD distribution
+
+Browser distributions do not work in Node.js and vice versa, different APIs are used. See `@influxdata/influxdb-client` for a distribution that can be used in Node.js environment.
+
+See https://github.com/influxdata/influxdb-client-js to know more.
+
+**Note: This library is for use with InfluxDB 2.x or 1.8+. For connecting to InfluxDB 1.x instances, see [node-influx](https://github.com/node-influx/node-influx).**

--- a/packages/core-browser/package.json
+++ b/packages/core-browser/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@influxdata/influxdb-client-browser",
+  "version": "1.7.0",
+  "description": "InfluxDB 2.0 client for browser",
+  "scripts": {
+    "apidoc:extract": "echo \"Nothing to do\"",
+    "build": "yarn run clean && cpr ../core/dist ./dist",
+    "clean": "rimraf dist"
+  },
+  "main": "dist/index.browser.js",
+  "module": "dist/index.browser.mjs",
+  "browser": "dist/index.browser.js",
+  "homepage": "https://github.com/influxdata/influxdb-client-js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/influxdata/influxdb-client-js",
+    "directory": "packages/core-browser"
+  },
+  "keywords": [
+    "influxdb",
+    "influxdata"
+  ],
+  "author": {
+    "name": "Pavel Zavora"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "cpr": "^3.0.1",
+    "rimraf": "^3.0.0"
+  }
+}

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -6,7 +6,7 @@ The reference javascript client for InfluxDB 2.0. Both node and browser environm
 - **module** points to node.js ESM distribution
 - **browser** points to browser (UMD) distribution
 
-Node distributions do not work in browser and vice versa, because different platform APIs are used. See `@influxdata/influxdb-client-browser` that targets only browser.
+Node.js distributions do not work in browser and vice versa, because different platform APIs are used. See `@influxdata/influxdb-client-browser` that targets only browser.
 
 See https://github.com/influxdata/influxdb-client-js to know more.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,13 @@
-# influxdb-client-javascript
+# @influxdata/influxdb-client
 
-The reference javascript client for InfluxDB 2.0. Both node and browser environments are supported.
+The reference javascript client for InfluxDB 2.0. Both node and browser environments are supported. The package.json
+
+- **main** points to node.js CJS distribution
+- **module** points to node.js ESM distribution
+- **browser** points to browser (UMD) distribution
+
+Node distributions do not work in browser and vice versa, because different platform APIs are used. See `@influxdata/influxdb-client-browser` that targets only browser.
+
 See https://github.com/influxdata/influxdb-client-js to know more.
 
 **Note: This library is for use with InfluxDB 2.x or 1.8+. For connecting to InfluxDB 1.x instances, see [node-influx](https://github.com/node-influx/node-influx).**

--- a/yarn.lock
+++ b/yarn.lock
@@ -4644,7 +4644,7 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
+minimist@>=1.2.2, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2269,6 +2269,16 @@ cosmiconfig@^5.1.0:
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
 
+cpr@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/cpr/-/cpr-3.0.1.tgz#b9a55038b7cd81a35c17b9761895bd8496aef1e5"
+  integrity sha1-uaVQOLfNgaNcF7l2GJW9hJau8eU=
+  dependencies:
+    graceful-fs "^4.1.5"
+    minimist "^1.2.0"
+    mkdirp "~0.5.1"
+    rimraf "^2.5.4"
+
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -3409,7 +3419,7 @@ globby@^9.2.0:
     pify "^4.0.1"
     slash "^2.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.5, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
@@ -4634,7 +4644,7 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@>=1.2.2, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
+minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==


### PR DESCRIPTION
This PR adds a new `@influxdata/influxdb-client-browser` module to let users use ESM distribution that works in a browser environment (window / worker) when bundling their app (using parcel, rollup, webpack, ...). The README.md files in core and core-browser packages were enhanced to provide more details.

@influxdata/influxdb-client has not changed, it still contains all 6 types of distributions with 3 of them provided via `package.json`:
- ([main](https://github.com/influxdata/influxdb-client-js/blob/master/packages/core/package.json#L22)) CJS for node.js
- ([module](https://github.com/influxdata/influxdb-client-js/blob/master/packages/core/package.json#L23)) ESM for node.js
- ([browser](https://github.com/influxdata/influxdb-client-js/blob/master/packages/core/package.json#L24)) UMD for browser
- ESM for browser
- IIFE for browser
- IIFE minimized for browser

@influxdata/influxdb-client-browser copies distributions from `@influxdata/influxdb-client` with different pointers in its `package.json`:
- (main) UMD for browser
- (module) ESM for browser
- (browser) UMD for browser

Additionally, `@influxdata/influxdb-client-apis` module has been changed herein so that the same distribution files work fine in both browser and Node.js environment, it is now distinguished at runtime. There is just one ESM distribution that works in the browser and Node.js .

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
