### PR TITLE
fix: deploying nightly packages

### DIFF
--- a/.circleci/deploy-nightly-version.sh
+++ b/.circleci/deploy-nightly-version.sh
@@ -5,6 +5,7 @@ SCRIPT_PATH="$( cd "$(dirname "$0")" || exit ; pwd -P )"
 # Update Version
 VERSION=$(cat packages/core/src/impl/version.ts | sed 's/[^0-9.]*//g' | awk -F. '{$2+=1; OFS="."; print $1"."$2"."$3}')
 sed -i -e "s/CLIENT_LIB_VERSION = '.*'/CLIENT_LIB_VERSION = '${VERSION}.nightly'/" packages/core/src/impl/version.ts
+yarn lerna version "$VERSION"-nightly."$CIRCLE_BUILD_NUM" --no-git-tag-version --yes
 git config user.name "CircleCI Builder"
 git config user.email "noreply@influxdata.com"
 git commit -am "chore(release): prepare to release influxdb-client-js-${VERSION}.nightly"
@@ -14,4 +15,4 @@ cd "${SCRIPT_PATH}"/..
 yarn build
 
 # Publish
-yarn lerna publish --canary preminor --no-git-tag-version --force-publish --preid nightly --yes
+yarn lerna publish --canary from-package --no-git-tag-version --force-publish --preid nightly --yes


### PR DESCRIPTION
## Proposed Changes

- uses `$CIRCLE_BUILD_NUM` for 'indexing' of nightly build. 


The Lerna uses number of commit from latest tag to retrieve 'index' of canary build. This doesn't work if we have initial deploy from local machine and then deploy from CI (both have same index).

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [ ] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
