### PR TITLE
fix(core): don't set User-Agent header in browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 1. [#264](https://github.com/influxdata/influxdb-client-js/pull/264): Require 204 status code in a write response.
 1. [#265](https://github.com/influxdata/influxdb-client-js/pull/265): Make QueryApi instance immutable.
+1. [#270](https://github.com/influxdata/influxdb-client-js/pull/270): Do not set User-Agent header in browser.
 
 ## 1.7.0 [2020-10-02]
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "preinstall": "node ./scripts/require-yarn.js",
     "clean": "rimraf temp docs && yarn workspaces run clean",
     "build": "cd packages/core && yarn build && cd ../core-browser && yarn build && cd ../apis && yarn build",
-    "test": "cd packages/core && yarn test && yarn build && cd ../apis && yarn test && yarn eslint ../../examples",
+    "test": "cd packages/core && yarn test && yarn build && cd ../apis && yarn test && yarn eslint --ignore-pattern node_modules ../../examples",
     "coverage": "cd packages/core && yarn coverage",
     "coverage:send": "cd packages/core && yarn coverage:send"
   },

--- a/packages/core/src/impl/browser/FetchTransport.ts
+++ b/packages/core/src/impl/browser/FetchTransport.ts
@@ -10,7 +10,6 @@ import {ConnectionOptions} from '../../options'
 import {HttpError} from '../../errors'
 import completeCommunicationObserver from '../completeCommunicationObserver'
 import Logger from '../Logger'
-import {CLIENT_LIB_VERSION} from '../version'
 
 /**
  * Transport layer that use browser fetch.
@@ -22,7 +21,7 @@ export default class FetchTransport implements Transport {
   constructor(private connectionOptions: ConnectionOptions) {
     this.defaultHeaders = {
       'content-type': 'application/json; charset=utf-8',
-      'User-Agent': `influxdb-client-js/${CLIENT_LIB_VERSION}`,
+      // 'User-Agent': `influxdb-client-js/${CLIENT_LIB_VERSION}`, // user-agent can hardly be customized https://github.com/influxdata/influxdb-client-js/issues/262
     }
     if (this.connectionOptions.token) {
       this.defaultHeaders['Authorization'] =

--- a/packages/core/test/unit/impl/browser/FetchTransport.test.ts
+++ b/packages/core/test/unit/impl/browser/FetchTransport.test.ts
@@ -2,7 +2,6 @@ import FetchTransport from '../../../../src/impl/browser/FetchTransport'
 import {expect} from 'chai'
 import {removeFetchApi, emulateFetchApi} from './emulateBrowser'
 import sinon from 'sinon'
-import {CLIENT_LIB_VERSION} from '../../../../src/impl/version'
 import {SendOptions, Cancellable} from '../../../../src'
 import {CollectedLogs, collectLogging} from '../../../util'
 
@@ -26,7 +25,6 @@ describe('FetchTransport', () => {
       const transport: any = new FetchTransport(options)
       expect(transport.defaultHeaders).to.deep.equal({
         'content-type': 'application/json; charset=utf-8',
-        'User-Agent': `influxdb-client-js/${CLIENT_LIB_VERSION}`,
       })
       expect(transport.connectionOptions).to.deep.equal(options)
     })
@@ -38,7 +36,6 @@ describe('FetchTransport', () => {
       const transport: any = new FetchTransport(options)
       expect(transport.defaultHeaders).to.deep.equal({
         'content-type': 'application/json; charset=utf-8',
-        'User-Agent': `influxdb-client-js/${CLIENT_LIB_VERSION}`,
         Authorization: 'Token a',
       })
       expect(transport.connectionOptions).to.deep.equal(options)


### PR DESCRIPTION
Fixes #262

- Opera and Chrome do not allow to control User-Agent header
- Firefox and Safari do, but it fails in the cloud anyway

Therefore this PR proposes to skip the setting of a custom User-Agent header when used in the browser. A custom User-Agent header is set only when used from node.js.

\+ changed the main `yarn test` to work also when examples are installed

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
