### PR TITLE
fix: deploying nightly browser package

### DIFF
--- a/.circleci/deploy-nightly-version.sh
+++ b/.circleci/deploy-nightly-version.sh
@@ -5,7 +5,7 @@ SCRIPT_PATH="$( cd "$(dirname "$0")" || exit ; pwd -P )"
 # Update Version
 VERSION=$(cat packages/core/src/impl/version.ts | sed 's/[^0-9.]*//g' | awk -F. '{$2+=1; OFS="."; print $1"."$2"."$3}')
 sed -i -e "s/CLIENT_LIB_VERSION = '.*'/CLIENT_LIB_VERSION = '${VERSION}.nightly'/" packages/core/src/impl/version.ts
-yarn lerna version "$VERSION"-nightly."$CIRCLE_BUILD_NUM" --no-git-tag-version --yes
+yarn lerna version "$VERSION"-nightly."$CIRCLE_BUILD_NUM" --no-git-tag-version --force-publish --yes
 git config user.name "CircleCI Builder"
 git config user.email "noreply@influxdata.com"
 git commit -am "chore(release): prepare to release influxdb-client-js-${VERSION}.nightly"


### PR DESCRIPTION
## Proposed Changes

Added `--force-push` to force lerna update version for all packages - including `browser`.

![Screenshot 2020-11-02 at 08 31 22](https://user-images.githubusercontent.com/455137/97841419-137dcf00-1ce6-11eb-9db0-eb261cb8a761.png)
![Screenshot 2020-11-02 at 08 31 05](https://user-images.githubusercontent.com/455137/97841424-15479280-1ce6-11eb-8bdf-762af5f6a589.png)

https://app.circleci.com/pipelines/github/influxdata/influxdb-client-js/450/workflows/9aac3bb6-03db-4521-8fb7-59e60bc73ac4/jobs/896
https://github.com/lerna/lerna/tree/master/commands/version#--force-publish

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [ ] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
