### PR TITLE
chore(core-browser): depend on core

### DIFF
--- a/packages/core-browser/package.json
+++ b/packages/core-browser/package.json
@@ -25,6 +25,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "@influxdata/influxdb-client": "^1.8.0",
     "cpr": "^3.0.1",
     "rimraf": "^3.0.0"
   }


### PR DESCRIPTION
This PR ensures that lerna will deploy `core-browser` package upon change in the `core` package.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
