### PR TITLE
feat(core): allow to notify about write success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 1. [#275](https://github.com/influxdata/influxdb-client-js/pull/275): Export CSV results parser.
 1. [#275](https://github.com/influxdata/influxdb-client-js/pull/275): Export fuction to transform CSV string to giraffe table.
 1. [#275](https://github.com/influxdata/influxdb-client-js/pull/275): Add tree shaking optimizations.
+1. [#276](https://github.com/influxdata/influxdb-client-js/pull/276): Allow to notify about write success.
 
 ## 1.8.0 [2020-10-30]
 

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -39,7 +39,7 @@ export interface RetryDelayStrategyOptions {
  */
 export interface WriteRetryOptions extends RetryDelayStrategyOptions {
   /**
-   * writeFailed is called to inform about write error
+   * WriteFailed is called to inform about write errors.
    * @param this - the instance of the API that failed
    * @param error - write error
    * @param lines - failed lines
@@ -53,6 +53,14 @@ export interface WriteRetryOptions extends RetryDelayStrategyOptions {
     lines: Array<string>,
     attempts: number
   ): Promise<void> | void
+
+  /**
+   * WriteSuccess is informed about successfully written lines.
+   * @param this - the instance of the API in use
+   * @param lines - written lines
+   */
+  writeSuccess(this: WriteApi, lines: Array<string>): void
+
   /** max number of retries when write fails */
   maxRetries: number
   /** the maximum size of retry-buffer (in lines) */
@@ -84,6 +92,7 @@ export const DEFAULT_WriteOptions: WriteOptions = {
   batchSize: 1000,
   flushInterval: 60000,
   writeFailed: function() {},
+  writeSuccess: function() {},
   maxRetries: 3,
   maxBufferLines: 32_000,
   // a copy of DEFAULT_RetryDelayStrategyOptions, so that DEFAULT_WriteOptions could be tree-shaken

--- a/packages/core/test/unit/impl/RetryBuffer.test.ts
+++ b/packages/core/test/unit/impl/RetryBuffer.test.ts
@@ -1,6 +1,7 @@
 import {expect} from 'chai'
 import RetryBuffer from '../../../src/impl/RetryBuffer'
 import {CollectedLogs, collectLogging} from '../../util'
+import {waitForCondition} from '../util/waitForCondition'
 
 describe('RetryBuffer', () => {
   let logs: CollectedLogs
@@ -22,9 +23,7 @@ describe('RetryBuffer', () => {
       input.push([['a' + i], i])
       subject.addLines(['a' + i], i, 2)
     }
-    await new Promise<void>((resolve, _reject) =>
-      setTimeout(() => resolve(), 10)
-    )
+    await waitForCondition(() => output.length >= 10)
     expect(output).length.is.greaterThan(0)
     subject.addLines([], 1, 1) // shall be ignored
     subject.close()
@@ -43,9 +42,6 @@ describe('RetryBuffer', () => {
       if (i >= 5) input.push([['a' + i], i])
       subject.addLines(['a' + i], i, 100)
     }
-    await new Promise<void>((resolve, _reject) =>
-      setTimeout(() => resolve(), 10)
-    )
     await subject.flush()
     expect(subject.close()).equals(0)
     expect(logs.error).length.is.greaterThan(0) // 5 entries over limit

--- a/packages/core/test/unit/util/waitForCondition.ts
+++ b/packages/core/test/unit/util/waitForCondition.ts
@@ -1,0 +1,24 @@
+/**
+ * Wait for the supplied `condition` to become truethy
+ * for at most `timeout` milliseconds. The `condition`
+ * every `step` milliseconds.
+ * @param condition - condition to validate
+ * @param timeout - maximum wait time
+ * @param step - interval to validate the condition
+ */
+export async function waitForCondition(
+  condition: () => any,
+  timeout = 100,
+  step = 5
+): Promise<void> {
+  for (;;) {
+    await new Promise(resolve => setTimeout(resolve, step))
+    timeout -= step
+    if (timeout <= 0) {
+      break
+    }
+    if (condition()) return
+  }
+  // eslint-disable-next-line no-console
+  console.error('WARN:waitForCondition: timeouted')
+}


### PR DESCRIPTION
This PR allows being notified about the success of the write operation when `writeSuccess` is supplied during the creation of WriteApi. Additionally, the existing WriteApi tests are improved to wait for success or failure (instead of waiting 20ms), the tests thus become more robust (they started to fail seldomly in CI).

## Proposed Changes

_Briefly describe your proposed changes:_

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
