### PR TITLE
feat(core): allow to specify custom HTTP headers in WriteApi or QueryApi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 1. [#275](https://github.com/influxdata/influxdb-client-js/pull/275): Add tree shaking optimizations.
 1. [#276](https://github.com/influxdata/influxdb-client-js/pull/276): Allow to notify about write success.
 1. [#280](https://github.com/influxdata/influxdb-client-js/pull/280): Upgrade to the latest node v14 LTS.
+1. [#283](https://github.com/influxdata/influxdb-client-js/pull/283): Allow to specify custom HTTP headers in WriteApi or QueryApi.
 
 ## 1.8.0 [2020-10-30]
 

--- a/packages/core/src/InfluxDB.ts
+++ b/packages/core/src/InfluxDB.ts
@@ -10,7 +10,7 @@ import {IllegalArgumentError} from './errors'
 import {Transport} from './transport'
 // replaced by ./impl/browser/FetchTransport in browser builds
 import TransportImpl from './impl/node/NodeHttpTransport'
-import QueryApi from './QueryApi'
+import QueryApi, {QueryOptions} from './QueryApi'
 import QueryApiImpl from './impl/QueryApiImpl'
 
 /**
@@ -82,10 +82,10 @@ export default class InfluxDB {
    * {@link https://github.com/influxdata/influxdb-client-js/blob/master/examples/rxjs-query.ts | rxjs-query.ts example},
    * and {@link https://github.com/influxdata/influxdb-client-js/blob/master/examples/index.html | browser example},
    *
-   * @param org - organization
+   * @param org - organization or query options
    * @returns QueryApi instance
    */
-  getQueryApi(org: string): QueryApi {
+  getQueryApi(org: string | QueryOptions): QueryApi {
     return new QueryApiImpl(this.transport, org)
   }
 }

--- a/packages/core/src/QueryApi.ts
+++ b/packages/core/src/QueryApi.ts
@@ -33,7 +33,7 @@ export interface QueryOptions {
    */
   now?: () => string
   /**
-   * Extra HTTP headers that will be sent with every query request.
+   * HTTP headers that will be sent with every query request.
    */
   headers?: {[key: string]: string}
 }

--- a/packages/core/src/QueryApi.ts
+++ b/packages/core/src/QueryApi.ts
@@ -32,6 +32,10 @@ export interface QueryOptions {
    * for example `new Date().toISOString()`.
    */
   now?: () => string
+  /**
+   * Extra HTTP headers that will be sent with every query request.
+   */
+  headers?: {[key: string]: string}
 }
 
 /** Wraps values and associated metadata of a query result row */

--- a/packages/core/src/impl/QueryApiImpl.ts
+++ b/packages/core/src/impl/QueryApiImpl.ts
@@ -111,7 +111,7 @@ export class QueryApiImpl implements QueryApi {
   }
 
   queryRaw(query: string | ParameterizedQuery): Promise<string> {
-    const {org, type, gzip} = this.options
+    const {org, type, gzip, headers} = this.options
     return this.transport.request(
       `/api/v2/query?org=${encodeURIComponent(org)}`,
       JSON.stringify(
@@ -127,13 +127,14 @@ export class QueryApiImpl implements QueryApi {
           accept: 'text/csv',
           'accept-encoding': gzip ? 'gzip' : 'identity',
           'content-type': 'application/json; encoding=utf-8',
+          ...headers,
         },
       }
     )
   }
 
   private createExecutor(query: string | ParameterizedQuery): QueryExecutor {
-    const {org, type, gzip} = this.options
+    const {org, type, gzip, headers} = this.options
 
     return (consumer): void => {
       this.transport.send(
@@ -150,6 +151,7 @@ export class QueryApiImpl implements QueryApi {
           headers: {
             'content-type': 'application/json; encoding=utf-8',
             'accept-encoding': gzip ? 'gzip' : 'identity',
+            ...headers,
           },
         },
         chunksToLines(consumer, this.transport.chunkCombiner)

--- a/packages/core/src/impl/WriteApiImpl.ts
+++ b/packages/core/src/impl/WriteApiImpl.ts
@@ -59,12 +59,7 @@ export default class WriteApiImpl implements WriteApi, PointSettings {
   private closed = false
   private httpPath: string
   private writeOptions: WriteOptions
-  private sendOptions: SendOptions = {
-    method: 'POST',
-    headers: {
-      'content-type': 'text/plain; charset=utf-8',
-    },
-  }
+  private sendOptions: SendOptions
   private _timeoutHandle: any = undefined
   private currentTime: () => string
   private dateToProtocolTimestamp: (d: Date) => string
@@ -90,6 +85,13 @@ export default class WriteApiImpl implements WriteApi, PointSettings {
     this.dateToProtocolTimestamp = dateToProtocolTimestamp[precision]
     if (this.writeOptions.defaultTags) {
       this.useDefaultTags(this.writeOptions.defaultTags)
+    }
+    this.sendOptions = {
+      method: 'POST',
+      headers: {
+        'content-type': 'text/plain; charset=utf-8',
+        ...writeOptions?.headers,
+      },
     }
 
     const scheduleNextSend = (): void => {

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -77,6 +77,8 @@ export interface WriteOptions extends WriteRetryOptions {
   flushInterval: number
   /** default tags, unescaped */
   defaultTags?: Record<string, string>
+  /** HTTP headers that will be sent with every write request */
+  headers?: {[key: string]: string}
 }
 
 /** default RetryDelayStrategyOptions */


### PR DESCRIPTION
Fixes #282

## Proposed Changes

This PR allows specifying custom HTTP headers in an API instance returned by `InfluxDB.getQueryApi` or `InfluxDB.getWriteApi` via the existing `options` parameter.

Examples:
```js
const org = 'my-org'
const influxDB = new InfluxDB({url: 'http://localhost:8086', token: 'abcd'})

// the returned API instances are authorized with `myToken` in place of default `abcd`
const writeApi = influxDB.getWriteApi(org, bucket, precision, {headers: {authorization: `Token myToken`}})
const queryApi = influxDB.getQueryApi({org, headers: {authorization: `Token myToken`}})
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
