### PR TITLE
chore(core): add tests for custom errors

### DIFF
--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -39,6 +39,7 @@ export class IllegalArgumentError extends Error {
   /* istanbul ignore next */
   constructor(message: string) {
     super(message)
+    this.name = 'IllegalArgumentError'
     Object.setPrototypeOf(this, IllegalArgumentError.prototype)
   }
 }
@@ -63,6 +64,7 @@ export class HttpError extends Error implements RetriableDecision {
     } else {
       this.message = `${statusCode} ${statusMessage}`
     }
+    this.name = 'HttpError'
     this.setRetryAfter(retryAfter)
   }
 
@@ -141,6 +143,7 @@ export class RequestTimedOutError extends Error implements RetriableDecision {
   constructor() {
     super()
     Object.setPrototypeOf(this, RequestTimedOutError.prototype)
+    this.name = 'RequestTimedOutError'
     this.message = 'Request timed out'
   }
   canRetry(): boolean {

--- a/packages/core/test/unit/errors.test.ts
+++ b/packages/core/test/unit/errors.test.ts
@@ -10,6 +10,33 @@ import {
 } from '../../src/errors'
 
 describe('errors', () => {
+  describe('have standard error properties', () => {
+    const pairs: {error: Error; name: string}[] = [
+      {error: new HttpError(200, 'OK'), name: 'HttpError'},
+      {error: new IllegalArgumentError('Not OK'), name: 'IllegalArgumentError'},
+      {error: new RequestTimedOutError(), name: 'RequestTimedOutError'},
+      {error: new AbortError(), name: 'AbortError'},
+    ]
+    pairs.forEach(({error, name}) => {
+      describe(`${name}`, () => {
+        it('has descriptive name property', () => {
+          expect(error.name).equals(name)
+        })
+        it('has message property', () => {
+          expect(error.message).is.not.empty
+        })
+        it('has expected toString', () => {
+          expect(error.toString()).matches(new RegExp(`^${name}:.*`))
+        })
+      })
+    })
+  })
+  describe('message property is defined', () => {
+    expect(new HttpError(200, 'OK').message).is.not.empty
+    expect(new IllegalArgumentError('Not OK').message).is.not.empty
+    expect(new RequestTimedOutError().message).is.not.empty
+    expect(new AbortError().message).is.not.empty
+  })
   describe('retriable errors', () => {
     const testSetOK = [
       new HttpError(503, 'Service Unavailable'),


### PR DESCRIPTION
This PR adds tests to check that the custom errors conform to the Error standard.
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
