### PR TITLE
feat(core): throw HttpError with code and message from response body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 1. [#276](https://github.com/influxdata/influxdb-client-js/pull/276): Allow to notify about write success.
 1. [#280](https://github.com/influxdata/influxdb-client-js/pull/280): Upgrade to the latest node v14 LTS.
 1. [#283](https://github.com/influxdata/influxdb-client-js/pull/283): Allow to specify custom HTTP headers in WriteApi or QueryApi.
+1. [#287](https://github.com/influxdata/influxdb-client-js/pull/287): Throw HttpError with code and message from response body.
 
 ## 1.8.0 [2020-10-30]
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -49,7 +49,7 @@ export class IllegalArgumentError extends Error {
 export class HttpError extends Error implements RetriableDecision {
   private _retryAfter: number
   /** application error code, when available */
-  public code: string | undefined // application-specific code
+  public code: string | undefined
   /** json error response */
   public json: any
 
@@ -73,7 +73,7 @@ export class HttpError extends Error implements RetriableDecision {
           this.message = this.json.message
           this.code = this.json.code
         } catch (e) {
-          // never mind silently ignore
+          // silently ignore, body string is still available
         }
       }
       if (!this.message) {

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -48,18 +48,37 @@ export class IllegalArgumentError extends Error {
  */
 export class HttpError extends Error implements RetriableDecision {
   private _retryAfter: number
+  /** application error code, when available */
+  public code: string | undefined // application-specific code
+  /** json error response */
+  public json: any
 
   /* istanbul ignore next because of super() not being covered*/
   constructor(
     readonly statusCode: number,
     readonly statusMessage: string | undefined,
     readonly body?: string,
-    retryAfter?: string | undefined | null
+    retryAfter?: string | undefined | null,
+    readonly contentType?: string | undefined | null,
+    message?: string
   ) {
     super()
     Object.setPrototypeOf(this, HttpError.prototype)
-    if (body) {
-      this.message = `${statusCode} ${statusMessage} : ${body}`
+    if (message) {
+      this.message = message
+    } else if (body) {
+      if (contentType?.startsWith('application/json')) {
+        try {
+          this.json = JSON.parse(body)
+          this.message = this.json.message
+          this.code = this.json.code
+        } catch (e) {
+          // never mind silently ignore
+        }
+      }
+      if (!this.message) {
+        this.message = `${statusCode} ${statusMessage} : ${body}`
+      }
     } else {
       this.message = `${statusCode} ${statusMessage}`
     }

--- a/packages/core/src/impl/WriteApiImpl.ts
+++ b/packages/core/src/impl/WriteApiImpl.ts
@@ -182,12 +182,14 @@ export default class WriteApiImpl implements WriteApi, PointSettings {
               self.retryStrategy.success()
               resolve()
             } else {
+              const message = `204 HTTP response status code expected, but ${responseStatusCode} returned`
               const error = new HttpError(
                 responseStatusCode,
-                `204 HTTP response status code expected, but ${responseStatusCode} returned`,
+                message,
                 undefined,
                 '0'
               )
+              error.message = message
               callbacks.error(error)
             }
           },

--- a/packages/core/src/impl/browser/FetchTransport.ts
+++ b/packages/core/src/impl/browser/FetchTransport.ts
@@ -96,7 +96,8 @@ export default class FetchTransport implements Transport {
                   response.status,
                   response.statusText,
                   text,
-                  response.headers.get('retry-after')
+                  response.headers.get('retry-after'),
+                  response.headers.get('content-type')
                 )
               )
             })
@@ -107,7 +108,8 @@ export default class FetchTransport implements Transport {
                   response.status,
                   response.statusText,
                   undefined,
-                  response.headers.get('retry-after')
+                  response.headers.get('retry-after'),
+                  response.headers.get('content-type')
                 )
               )
             })
@@ -152,7 +154,8 @@ export default class FetchTransport implements Transport {
         status,
         response.statusText,
         data,
-        response.headers.get('retry-after')
+        response.headers.get('retry-after'),
+        response.headers.get('content-type')
       )
     }
     const responseType = options.headers?.accept ?? responseContentType

--- a/packages/core/src/impl/node/NodeHttpTransport.ts
+++ b/packages/core/src/impl/node/NodeHttpTransport.ts
@@ -228,9 +228,12 @@ export class NodeHttpTransport implements Transport {
       responseData.on('error', listeners.error)
       if (statusCode >= 300) {
         let body = ''
+        const isJson = String(res.headers['content-type']).startsWith(
+          'application/json'
+        )
         responseData.on('data', s => {
           body += s.toString()
-          if (body.length > 1000) {
+          if (!isJson && body.length > 1000) {
             body = body.slice(0, 1000)
             res.resume()
           }
@@ -244,7 +247,8 @@ export class NodeHttpTransport implements Transport {
               statusCode,
               res.statusMessage,
               body,
-              res.headers['retry-after']
+              res.headers['retry-after'],
+              res.headers['content-type']
             )
           )
         })

--- a/packages/core/test/unit/WriteApi.test.ts
+++ b/packages/core/test/unit/WriteApi.test.ts
@@ -357,7 +357,7 @@ describe('WriteApi', () => {
       expect(logs.error[0][0]).equals('Write to InfluxDB failed.')
       expect(logs.error[0][1]).instanceOf(HttpError)
       expect(logs.error[0][1].statusCode).equals(200)
-      expect(logs.error[0][1].statusMessage).equals(
+      expect(logs.error[0][1].message).equals(
         `204 HTTP response status code expected, but 200 returned`
       )
       expect(logs.warn).deep.equals([])

--- a/packages/core/test/unit/impl/browser/FetchTransport.test.ts
+++ b/packages/core/test/unit/impl/browser/FetchTransport.test.ts
@@ -192,6 +192,35 @@ describe('FetchTransport', () => {
               .equals('')
         )
     })
+    it('throws error with json body', async () => {
+      const body = '{"code":"mycode","message":"mymsg"}'
+      emulateFetchApi({
+        headers: {'content-type': 'application/json'},
+        body,
+        status: 500,
+      })
+      await transport
+        .request('/whatever', '', {
+          method: 'GET',
+        })
+        .then(
+          () => Promise.reject('client error expected'),
+          (e: any) => {
+            expect(e)
+              .property('body')
+              .equals(body)
+            expect(e)
+              .property('json')
+              .deep.equals(JSON.parse(body))
+            expect(e)
+              .property('message')
+              .equals('mymsg')
+            expect(e)
+              .property('code')
+              .equals('mycode')
+          }
+        )
+    })
   })
   describe('send', () => {
     const transport = new FetchTransport({url: 'http://test:8086'})


### PR DESCRIPTION
Fixes #285

## Proposed Changes
If InfluxDB error response contains JSON with code and message, the client throws an HttpError with code and message properties taken from the response. Additionally, the thrown error contains `json` property with a parsed error response.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
