### PR TITLE
fix(core): remove WritePrecision enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
 1. [#287](https://github.com/influxdata/influxdb-client-js/pull/287): Throw HttpError with code and message from response body.
 1. [#289](https://github.com/influxdata/influxdb-client-js/pull/289): Improve distributions, support deno.
 
+### Breaking Changes
+
+1. [#291](https://github.com/influxdata/influxdb-client-js/pull/291): Remove WritePrecision const enum. A typescript code
+   has to be changed to use the precision value directly ('ns' in place of WritePrecision.ns). No changes are required
+   for a javascript code or a typescript code that already uses the precision value directly.
+
 ## 1.8.0 [2020-10-30]
 
 ### Features

--- a/packages/core/src/InfluxDB.ts
+++ b/packages/core/src/InfluxDB.ts
@@ -1,10 +1,5 @@
 import WriteApi from './WriteApi'
-import {
-  ClientOptions,
-  WritePrecision,
-  WriteOptions,
-  WritePrecisionType,
-} from './options'
+import {ClientOptions, WriteOptions, WritePrecisionType} from './options'
 import WriteApiImpl from './impl/WriteApiImpl'
 import {IllegalArgumentError} from './errors'
 import {Transport} from './transport'
@@ -61,7 +56,7 @@ export default class InfluxDB {
   getWriteApi(
     org: string,
     bucket: string,
-    precision: WritePrecisionType = WritePrecision.ns,
+    precision: WritePrecisionType = 'ns',
     writeOptions?: Partial<WriteOptions>
   ): WriteApi {
     return new WriteApiImpl(

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -115,17 +115,7 @@ export interface ClientOptions extends ConnectionOptions {
 }
 
 /**
- * Precission for write operations.
+ * Timestamp precision used in write operations.
  * See {@link https://v2.docs.influxdata.com/v2.0/api/#operation/PostWrite }
  */
-export const enum WritePrecision {
-  /** nanosecond */
-  ns = 'ns',
-  /* microsecond */
-  us = 'us',
-  /** millisecond */
-  ms = 'ms',
-  /* second */
-  s = 's',
-}
-export type WritePrecisionType = keyof typeof WritePrecision | WritePrecision
+export type WritePrecisionType = 'ns' | 'us' | 'ms' | 's'

--- a/packages/core/test/unit/Influxdb.test.ts
+++ b/packages/core/test/unit/Influxdb.test.ts
@@ -1,5 +1,5 @@
 import {expect} from 'chai'
-import {InfluxDB, ClientOptions, WritePrecision} from '../../src'
+import {InfluxDB, ClientOptions} from '../../src'
 
 describe('InfluxDB', () => {
   describe('constructor', () => {
@@ -89,7 +89,6 @@ describe('InfluxDB', () => {
     const influxDb = new InfluxDB('http://localhost:8086?token=a')
     it('serves queryApi writeApi without a pending schedule', () => {
       expect(influxDb.getWriteApi('org', 'bucket')).to.be.ok
-      expect(influxDb.getWriteApi('org', 'bucket', WritePrecision.s)).to.be.ok
       expect(influxDb.getWriteApi('org', 'bucket', 's')).to.be.ok
     })
     it('serves queryApi', () => {

--- a/packages/core/test/unit/WriteApi.test.ts
+++ b/packages/core/test/unit/WriteApi.test.ts
@@ -3,7 +3,6 @@ import nock from 'nock' // WARN: nock must be imported before NodeHttpTransport,
 import {
   ClientOptions,
   HttpError,
-  WritePrecision,
   WriteOptions,
   Point,
   WriteApi,
@@ -21,7 +20,7 @@ const clientOptions: ClientOptions = {
 }
 const ORG = 'org'
 const BUCKET = 'bucket'
-const PRECISION = WritePrecision.s
+const PRECISION: WritePrecisionType = 's'
 
 const WRITE_PATH_NS = `/api/v2/write?org=${ORG}&bucket=${BUCKET}&precision=ns`
 


### PR DESCRIPTION
Fixes #290

The core module exports WritePrecision, which is a [const enum](https://www.typescriptlang.org/docs/handbook/enums.html#const-enums) that is inlined during package build. Typescript code that imports this client fails during compilation because of this enum when  `--isolatedModules` flag is used. 

_Briefly describe your proposed changes:_

Since WritePrecision is not used directly in exported APIs (but WritePrecisionType is), it can be removed. WritePrecisionType already properly describes the shape of the expected value type (including also the shape of the removed WritePrecision const enum).

This PR introduces a breaking change. In an unlikely event of using a removed WritePrecision, a typescript code has to be changed to use the precision constant directly (`'ns'` in place of `WritePrecision.ns`). No changes are required in javascript code, the compiled library remains the same, only type definitions changed.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
