### PR TITLE
feat(deno): add deno query example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 1. [#283](https://github.com/influxdata/influxdb-client-js/pull/283): Allow to specify custom HTTP headers in WriteApi or QueryApi.
 1. [#287](https://github.com/influxdata/influxdb-client-js/pull/287): Throw HttpError with code and message from response body.
 1. [#289](https://github.com/influxdata/influxdb-client-js/pull/289): Support `deno`.
+1. [#292](https://github.com/influxdata/influxdb-client-js/pull/289): Add query.deno.ts example.
 
 ### Breaking Changes
 

--- a/examples/.eslintrc.json
+++ b/examples/.eslintrc.json
@@ -19,6 +19,12 @@
       "rules": {
         "@typescript-eslint/explicit-function-return-type": "off"
       }
+    },
+    {
+      "files": ["query.deno.ts"],
+      "rules": {
+        "prettier/prettier": "off"
+      }
     }
   ]
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # InfluxDB Client Examples
 
-This directory contains javascript and typescript examples for node.js and browser environments.
+This directory contains javascript and typescript examples for node.js, browser, and deno.
 
 - Node.js examples
   - Prerequisites

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,11 +2,11 @@
 
 This directory contains javascript and typescript examples for node.js and browser environments.
 
-- Prerequisites
-  - [node](https://nodejs.org/en/) installed
-  - Run `npm install` in this directory
 - Node.js examples
-  - Change variables in [./env.js](env.js) to configure connection to your InfluxDB instance. The file can be used as-is against a new [docker InfluxDB v2.0 OSS GA installation](https://v2.docs.influxdata.com/v2.0/get-started/)
+  - Prerequisites
+    - [node](https://nodejs.org/en/) installed
+    - Run `npm install` in this directory
+    - Change variables in [./env.js](env.js) to configure connection to your InfluxDB instance. The file can be used as-is against a new [docker InfluxDB v2.0 OSS GA installation](https://v2.docs.influxdata.com/v2.0/get-started/)
   - Examples are executable. If it does not work for you, run `npm run ts-node EXAMPLE.ts`.
   - [write.js](./write.js)
     Write data points to InfluxDB.
@@ -35,3 +35,6 @@ This directory contains javascript and typescript examples for node.js and brows
     to a configured influxDB database, see [scripts/server.js](./scripts/server.js) for details.
   - Click `Visualize with Giraffe Line Chart` to open [giraffe.html](./giraffe.html) that
     shows how visualize query results with [@influxdata/giraffe](https://github.com/influxdata/giraffe).
+- Deno examples
+  - [query.deno.ts](./query.deno.ts) shows how to query InfluxDB with [Flux](https://v2.docs.influxdata.com/v2.0/query-data/get-started/).
+    It is almost the same as node's [query.ts](./query.ts) example, the difference is the import statement that works in [deno](https://deno.land) and built-in typescript support.

--- a/examples/query.deno.ts
+++ b/examples/query.deno.ts
@@ -6,30 +6,30 @@
 import {
   FluxTableMetaData,
   InfluxDB,
-} from "https://cdn.skypack.dev/@influxdata/influxdb-client-browser@1.9.0-nightly.1044?dts";
+} from 'https://cdn.skypack.dev/@influxdata/influxdb-client-browser@1.9.0-nightly.1044?dts'
 
-const url = "http://localhost:8086";
-const token = "my-token";
-const org = "my-org";
+const url = 'http://localhost:8086'
+const token = 'my-token'
+const org = 'my-org'
 
-const queryApi = new InfluxDB({ url, token }).getQueryApi(org);
+const queryApi = new InfluxDB({url, token}).getQueryApi(org)
 const fluxQuery =
-  'from(bucket:"my-bucket" ) |> range(start: 0) |> filter(fn: (r) => r._measurement == "temperature")';
+  'from(bucket:"my-bucket" ) |> range(start: 0) |> filter(fn: (r) => r._measurement == "temperature")'
 
-console.log("** QUERY ROWS ***");
+console.log('** QUERY ROWS ***')
 queryApi.queryRows(fluxQuery, {
   next(row: string[], tableMeta: FluxTableMetaData) {
-    const o = tableMeta.toObject(row);
+    const o = tableMeta.toObject(row)
     // console.log(JSON.stringify(o, null, 2))
     console.log(
-      `${o._time} ${o._measurement} in '${o.location}' (${o.example}): ${o._field}=${o._value}`,
-    );
+      `${o._time} ${o._measurement} in '${o.location}' (${o.example}): ${o._field}=${o._value}`
+    )
   },
   error(error: Error) {
-    console.error(error);
-    console.log("\nFinished ERROR");
+    console.error(error)
+    console.log('\nFinished ERROR')
   },
   complete() {
-    console.log("\nFinished SUCCESS");
+    console.log('\nFinished SUCCESS')
   },
-});
+})

--- a/examples/query.deno.ts
+++ b/examples/query.deno.ts
@@ -4,32 +4,32 @@
 //////////////////////////////////////////////////////
 
 import {
-  InfluxDB,
   FluxTableMetaData,
-} from 'https://cdn.skypack.dev/@influxdata/influxdb-client-browser@1.9.0-nightly.1044?dts'
+  InfluxDB,
+} from "https://cdn.skypack.dev/@influxdata/influxdb-client-browser@1.9.0-nightly.1044?dts";
 
-const url = 'http://localhost:8086'
-const token = 'my-token'
-const org = 'my-org'
+const url = "http://localhost:8086";
+const token = "my-token";
+const org = "my-org";
 
-const queryApi = new InfluxDB({url, token}).getQueryApi(org)
+const queryApi = new InfluxDB({ url, token }).getQueryApi(org);
 const fluxQuery =
-  'from(bucket:"my-bucket" ) |> range(start: 0) |> filter(fn: (r) => r._measurement == "temperature")'
+  'from(bucket:"my-bucket" ) |> range(start: 0) |> filter(fn: (r) => r._measurement == "temperature")';
 
-console.log('** QUERY ROWS ***')
+console.log("** QUERY ROWS ***");
 queryApi.queryRows(fluxQuery, {
   next(row: string[], tableMeta: FluxTableMetaData) {
-    const o = tableMeta.toObject(row)
+    const o = tableMeta.toObject(row);
     // console.log(JSON.stringify(o, null, 2))
     console.log(
-      `${o._time} ${o._measurement} in '${o.location}' (${o.example}): ${o._field}=${o._value}`
-    )
+      `${o._time} ${o._measurement} in '${o.location}' (${o.example}): ${o._field}=${o._value}`,
+    );
   },
   error(error: Error) {
-    console.error(error)
-    console.log('\nFinished ERROR')
+    console.error(error);
+    console.log("\nFinished ERROR");
   },
   complete() {
-    console.log('\nFinished SUCCESS')
+    console.log("\nFinished SUCCESS");
   },
-})
+});

--- a/examples/query.deno.ts
+++ b/examples/query.deno.ts
@@ -1,0 +1,35 @@
+#!/usr/bin/env -S deno run --allow-net
+//////////////////////////////////////////////////////
+// A modified query.ts example that works with deno //
+//////////////////////////////////////////////////////
+
+import {
+  InfluxDB,
+  FluxTableMetaData,
+} from 'https://cdn.skypack.dev/@influxdata/influxdb-client-browser@1.9.0-nightly.1044?dts'
+
+const url = 'http://localhost:8086'
+const token = 'my-token'
+const org = 'my-org'
+
+const queryApi = new InfluxDB({url, token}).getQueryApi(org)
+const fluxQuery =
+  'from(bucket:"my-bucket" ) |> range(start: 0) |> filter(fn: (r) => r._measurement == "temperature")'
+
+console.log('** QUERY ROWS ***')
+queryApi.queryRows(fluxQuery, {
+  next(row: string[], tableMeta: FluxTableMetaData) {
+    const o = tableMeta.toObject(row)
+    // console.log(JSON.stringify(o, null, 2))
+    console.log(
+      `${o._time} ${o._measurement} in '${o.location}' (${o.example}): ${o._field}=${o._value}`
+    )
+  },
+  error(error: Error) {
+    console.error(error)
+    console.log('\nFinished ERROR')
+  },
+  complete() {
+    console.log('\nFinished SUCCESS')
+  },
+})


### PR DESCRIPTION
This PR adds a query example that shows how [deno](https://deno.land) is supported.


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
