### PR TITLE
feat(apis): regenerate APIs from swagger 2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 1. [#296](https://github.com/influxdata/influxdb-client-js/pull/296): Allow to specify escaped field values.
+1. [#295](https://github.com/influxdata/influxdb-client-js/pull/295): Regenerate APIs from InfluxDB 2.0.3 swagger.
 
 ## 1.9.0 [2020-12-04]
 

--- a/packages/apis/DEVELOPMENT.md
+++ b/packages/apis/DEVELOPMENT.md
@@ -12,7 +12,7 @@ $ yarn build
 
 - update local resources/swagger.yml to the latest version
   - `wget -O resources/swagger.yml https://raw.githubusercontent.com/influxdata/influxdb/master/http/swagger.yml`
-- re-generate src/generated/types.ts and resources/operations.json
+- re-generate src/generated/types.ts and resources/operations.json using [oats](https://github.com/influxdata/oats)
   - `rm -rf src/generated/*.ts`
   - `oats -i 'types' --storeOperations resources/operations.json resources/swagger.yml > src/generated/types.ts`
 - generate src/generated APIs from resources/operations.json

--- a/packages/apis/resources/operations.json
+++ b/packages/apis/resources/operations.json
@@ -3068,6 +3068,7 @@
     "server": "/api/v2",
     "path": "/delete",
     "operation": "post",
+    "operationId": "PostDelete",
     "basicAuth": false,
     "summary": "Delete time series data from InfluxDB",
     "positionalParams": [],
@@ -3300,7 +3301,7 @@
     "operation": "post",
     "operationId": "PostSources",
     "basicAuth": false,
-    "summary": "Creates a source",
+    "summary": "Create a source",
     "positionalParams": [],
     "headerParams": [
       {
@@ -4585,7 +4586,7 @@
     "operation": "get",
     "operationId": "GetDashboardsIDLabels",
     "basicAuth": false,
-    "summary": "list all labels for a dashboard",
+    "summary": "List all labels for a dashboard",
     "positionalParams": [
       {
         "name": "dashboardID",
@@ -5400,7 +5401,7 @@
     "operation": "delete",
     "operationId": "DeleteAuthorizationsID",
     "basicAuth": false,
-    "summary": "Delete a authorization",
+    "summary": "Delete an authorization",
     "positionalParams": [
       {
         "name": "authID",
@@ -5952,7 +5953,7 @@
     "operation": "delete",
     "operationId": "DeleteBucketsIDLabelsID",
     "basicAuth": false,
-    "summary": "delete a label from a bucket",
+    "summary": "Delete a label from a bucket",
     "positionalParams": [
       {
         "name": "bucketID",
@@ -7364,7 +7365,7 @@
       "description": "Export resources as an InfluxDB template.",
       "required": false,
       "mediaType": "application/json",
-      "type": "TemplateExport"
+      "type": "TemplateExportByID | TemplateExportByName"
     },
     "responses": [
       {

--- a/packages/apis/resources/swagger.yml
+++ b/packages/apis/resources/swagger.yml
@@ -1873,6 +1873,7 @@ paths:
                 $ref: "#/components/schemas/Error"
   /delete:
     post:
+      operationId: PostDelete
       summary: Delete time series data from InfluxDB
       requestBody:
         description: Predicate delete request
@@ -1990,7 +1991,7 @@ paths:
       operationId: PostSources
       tags:
         - Sources
-      summary: Creates a source
+      summary: Create a source
       parameters:
         - $ref: "#/components/parameters/TraceSpan"
       requestBody:
@@ -2814,7 +2815,7 @@ paths:
       operationId: GetDashboardsIDLabels
       tags:
         - Dashboards
-      summary: list all labels for a dashboard
+      summary: List all labels for a dashboard
       parameters:
         - $ref: "#/components/parameters/TraceSpan"
         - in: path
@@ -3305,7 +3306,7 @@ paths:
       operationId: DeleteAuthorizationsID
       tags:
         - Authorizations
-      summary: Delete a authorization
+      summary: Delete an authorization
       parameters:
         - $ref: "#/components/parameters/TraceSpan"
         - in: path
@@ -3681,7 +3682,7 @@ paths:
       operationId: DeleteBucketsIDLabelsID
       tags:
         - Buckets
-      summary: delete a label from a bucket
+      summary: Delete a label from a bucket
       parameters:
         - $ref: "#/components/parameters/TraceSpan"
         - in: path
@@ -4602,7 +4603,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TemplateExport"
+              oneOf:
+                - $ref: "#/components/schemas/TemplateExportByID"
+                - $ref: "#/components/schemas/TemplateExportByName"
       responses:
         "200":
           description: InfluxDB template created
@@ -7022,15 +7025,15 @@ components:
           maxLength: 1
           minLength: 1
         annotations:
-          description: Https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/#columns
+          description: https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/#columns
           type: array
+          uniqueItems: true
           items:
             type: string
             enum:
               - "group"
               - "datatype"
               - "default"
-            uniqueItems: true
         commentPrefix:
           description: Character prefixed to comment strings
           type: string
@@ -7126,7 +7129,7 @@ components:
               description: ID of org that authorization is scoped to.
             permissions:
               type: array
-              minLength: 1
+              minItems: 1
               description: List of permissions for an auth.  An auth must have at least one Permission.
               items:
                 $ref: "#/components/schemas/Permission"
@@ -7475,7 +7478,7 @@ components:
         - Task
         - Telegraf
         - Variable
-    TemplateExport:
+    TemplateExportByID:
       type: object
       properties:
         stackID:
@@ -7507,7 +7510,39 @@ components:
               $ref: "#/components/schemas/TemplateKind"
             name:
               type: string
+              description: "if defined with id, name is used for resource exported by id. if defined independently, resources strictly matching name are exported"
           required: [id, kind]
+    TemplateExportByName:
+      type: object
+      properties:
+        stackID:
+          type: string
+        orgIDs:
+          type: array
+          items:
+            type: object
+            properties:
+              orgID:
+                type: string
+              resourceFilters:
+                type: object
+                properties:
+                  byLabel:
+                    type: array
+                    items:
+                      type: string
+                  byResourceKind:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/TemplateKind"
+        resources:
+          type: object
+          properties:
+            kind:
+              $ref: "#/components/schemas/TemplateKind"
+            name:
+              type: string
+          required: [name, kind]
     Template:
       type: array
       items:
@@ -8445,45 +8480,6 @@ components:
     TaskStatusType:
       type: string
       enum: [active, inactive]
-    Invite:
-      properties:
-        id:
-          description: the idpe id of the invite
-          readOnly: true
-          type: string
-        email:
-          type: string
-        role:
-          type: string
-          enum:
-            - member
-            - owner
-        expiresAt:
-          format: date-time
-          type: string
-        links:
-          type: object
-          readOnly: true
-          example:
-            self: "/api/v2/invites/1"
-          properties:
-            self:
-              type: string
-              format: uri
-      required: [id, email, role]
-    Invites:
-      type: object
-      properties:
-        links:
-          type: object
-          properties:
-            self:
-              type: string
-              format: uri
-        invites:
-          type: array
-          items:
-            $ref: "#/components/schemas/Invite"
     User:
       properties:
         id:
@@ -8944,8 +8940,32 @@ components:
           $ref: "#/components/schemas/Legend"
         xColumn:
           type: string
+        generateXAxisTicks:
+          type: array
+          items:
+            type: string
+        xTotalTicks:
+          type: integer
+        xTickStart:
+          type: number
+          format: float
+        xTickStep:
+          type: number
+          format: float
         yColumn:
           type: string
+        generateYAxisTicks:
+          type: array
+          items:
+            type: string
+        yTotalTicks:
+          type: integer
+        yTickStart:
+          type: number
+          format: float
+        yTickStep:
+          type: number
+          format: float
         shadeBelow:
           type: boolean
         hoverDimension:
@@ -8956,6 +8976,13 @@ components:
           enum: [overlaid, stacked]
         geom:
           $ref: "#/components/schemas/XYGeom"
+        legendColorizeRows:
+          type: boolean
+        legendOpacity:
+          type: number
+          format: float
+        legendOrientationThreshold:
+          type: integer
     XYGeom:
       type: string
       enum: [line, step, stacked, bar, monotoneX]
@@ -9000,8 +9027,32 @@ components:
           $ref: "#/components/schemas/Legend"
         xColumn:
           type: string
+        generateXAxisTicks:
+          type: array
+          items:
+            type: string
+        xTotalTicks:
+          type: integer
+        xTickStart:
+          type: number
+          format: float
+        xTickStep:
+          type: number
+          format: float
         yColumn:
           type: string
+        generateYAxisTicks:
+          type: array
+          items:
+            type: string
+        yTotalTicks:
+          type: integer
+        yTickStart:
+          type: number
+          format: float
+        yTickStep:
+          type: number
+          format: float
         upperColumn:
           type: string
         mainColumn:
@@ -9013,6 +9064,13 @@ components:
           enum: [auto, x, y, xy]
         geom:
           $ref: "#/components/schemas/XYGeom"
+        legendColorizeRows:
+          type: boolean
+        legendOpacity:
+          type: number
+          format: float
+        legendOrientationThreshold:
+          type: integer
     LinePlusSingleStatProperties:
       type: object
       required:
@@ -9057,8 +9115,32 @@ components:
           $ref: "#/components/schemas/Legend"
         xColumn:
           type: string
+        generateXAxisTicks:
+          type: array
+          items:
+            type: string
+        xTotalTicks:
+          type: integer
+        xTickStart:
+          type: number
+          format: float
+        xTickStep:
+          type: number
+          format: float
         yColumn:
           type: string
+        generateYAxisTicks:
+          type: array
+          items:
+            type: string
+        yTotalTicks:
+          type: integer
+        yTickStart:
+          type: number
+          format: float
+        yTickStep:
+          type: number
+          format: float
         shadeBelow:
           type: boolean
         hoverDimension:
@@ -9073,6 +9155,13 @@ components:
           type: string
         decimalPlaces:
           $ref: "#/components/schemas/DecimalPlaces"
+        legendColorizeRows:
+          type: boolean
+        legendOpacity:
+          type: number
+          format: float
+        legendOrientationThreshold:
+          type: integer
     MosaicViewProperties:
       type: object
       required:
@@ -9118,6 +9207,18 @@ components:
           type: boolean
         xColumn:
           type: string
+        generateXAxisTicks:
+          type: array
+          items:
+            type: string
+        xTotalTicks:
+          type: integer
+        xTickStart:
+          type: number
+          format: float
+        xTickStep:
+          type: number
+          format: float
         ySeriesColumns:
           type: array
           items:
@@ -9148,6 +9249,13 @@ components:
           type: string
         ySuffix:
           type: string
+        legendColorizeRows:
+          type: boolean
+        legendOpacity:
+          type: number
+          format: float
+        legendOrientationThreshold:
+          type: integer
     ScatterViewProperties:
       type: object
       required:
@@ -9194,8 +9302,32 @@ components:
           type: boolean
         xColumn:
           type: string
+        generateXAxisTicks:
+          type: array
+          items:
+            type: string
+        xTotalTicks:
+          type: integer
+        xTickStart:
+          type: number
+          format: float
+        xTickStep:
+          type: number
+          format: float
         yColumn:
           type: string
+        generateYAxisTicks:
+          type: array
+          items:
+            type: string
+        yTotalTicks:
+          type: integer
+        yTickStart:
+          type: number
+          format: float
+        yTickStep:
+          type: number
+          format: float
         fillColumns:
           type: array
           items:
@@ -9226,6 +9358,13 @@ components:
           type: string
         ySuffix:
           type: string
+        legendColorizeRows:
+          type: boolean
+        legendOpacity:
+          type: number
+          format: float
+        legendOrientationThreshold:
+          type: integer
     HeatmapViewProperties:
       type: object
       required:
@@ -9271,8 +9410,32 @@ components:
           type: boolean
         xColumn:
           type: string
+        generateXAxisTicks:
+          type: array
+          items:
+            type: string
+        xTotalTicks:
+          type: integer
+        xTickStart:
+          type: number
+          format: float
+        xTickStep:
+          type: number
+          format: float
         yColumn:
           type: string
+        generateYAxisTicks:
+          type: array
+          items:
+            type: string
+        yTotalTicks:
+          type: integer
+        yTickStart:
+          type: number
+          format: float
+        yTickStep:
+          type: number
+          format: float
         xDomain:
           type: array
           items:
@@ -9297,6 +9460,13 @@ components:
           type: string
         binSize:
           type: number
+        legendColorizeRows:
+          type: boolean
+        legendOpacity:
+          type: number
+          format: float
+        legendOrientationThreshold:
+          type: integer
     SingleStatViewProperties:
       type: object
       required:
@@ -9398,6 +9568,13 @@ components:
           type: string
           enum: [overlaid, stacked]
         binCount:
+          type: integer
+        legendColorizeRows:
+          type: boolean
+        legendOpacity:
+          type: number
+          format: float
+        legendOrientationThreshold:
           type: integer
     GaugeViewProperties:
       type: object
@@ -9561,6 +9738,13 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/DashboardColor"
+        legendColorizeRows:
+          type: boolean
+        legendOpacity:
+          type: number
+          format: float
+        legendOrientationThreshold:
+          type: integer
     Axes:
       description: The viewport for a View's visualizations
       type: object
@@ -10080,6 +10264,10 @@ components:
         bucketID:
           type: string
           description: The ID of the bucket to write to.
+        allowInsecure:
+          type: boolean
+          description: Skip TLS verification on endpoint.
+          default: false
     ScraperTargetResponse:
       type: object
       allOf:
@@ -10854,7 +11042,7 @@ components:
           example: { "color": "ffb3b3", "description": "this is a description" }
     LabelCreateRequest:
       type: object
-      required: [orgID]
+      required: [orgID, name]
       properties:
         orgID:
           type: string
@@ -11625,12 +11813,7 @@ components:
       type: string
       enum: ["slack", "pagerduty", "http", "telegram"]
     DBRP:
-      required:
-        - orgID
-        - org
-        - bucketID
-        - database
-        - retention_policy
+      type: object
       properties:
         id:
           type: string
@@ -11656,6 +11839,17 @@ components:
           description: Specify if this mapping represents the default retention policy for the database specificed.
         links:
           $ref: "#/components/schemas/Links"
+      oneOf:
+        - required:
+          - orgID
+          - bucketID
+          - database
+          - retention_policy
+        - required:
+          - org
+          - bucketID
+          - database
+          - retention_policy
     DBRPs:
       properties:
         notificationEndpoints:

--- a/packages/apis/src/generated/AuthorizationsAPI.ts
+++ b/packages/apis/src/generated/AuthorizationsAPI.ts
@@ -128,7 +128,7 @@ export class AuthorizationsAPI {
     )
   }
   /**
-   * Delete a authorization.
+   * Delete an authorization.
    * See {@link https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteAuthorizationsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options

--- a/packages/apis/src/generated/BucketsAPI.ts
+++ b/packages/apis/src/generated/BucketsAPI.ts
@@ -244,7 +244,7 @@ export class BucketsAPI {
     )
   }
   /**
-   * delete a label from a bucket.
+   * Delete a label from a bucket.
    * See {@link https://v2.docs.influxdata.com/v2.0/api/#operation/DeleteBucketsIDLabelsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options

--- a/packages/apis/src/generated/DashboardsAPI.ts
+++ b/packages/apis/src/generated/DashboardsAPI.ts
@@ -382,7 +382,7 @@ export class DashboardsAPI {
     )
   }
   /**
-   * list all labels for a dashboard.
+   * List all labels for a dashboard.
    * See {@link https://v2.docs.influxdata.com/v2.0/api/#operation/GetDashboardsIDLabels }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options

--- a/packages/apis/src/generated/SourcesAPI.ts
+++ b/packages/apis/src/generated/SourcesAPI.ts
@@ -67,7 +67,7 @@ export class SourcesAPI {
     )
   }
   /**
-   * Creates a source.
+   * Create a source.
    * See {@link https://v2.docs.influxdata.com/v2.0/api/#operation/PostSources }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options

--- a/packages/apis/src/generated/TemplatesAPI.ts
+++ b/packages/apis/src/generated/TemplatesAPI.ts
@@ -1,6 +1,12 @@
 import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
-import {Template, TemplateApply, TemplateExport, TemplateSummary} from './types'
+import {
+  Template,
+  TemplateApply,
+  TemplateExportByID,
+  TemplateExportByName,
+  TemplateSummary,
+} from './types'
 
 export interface ApplyTemplateRequest {
   /** entity body */
@@ -8,7 +14,7 @@ export interface ApplyTemplateRequest {
 }
 export interface ExportTemplateRequest {
   /** Export resources as an InfluxDB template. */
-  body: TemplateExport
+  body: TemplateExportByID | TemplateExportByName
 }
 /**
  * Templates API

--- a/packages/apis/src/generated/types.ts
+++ b/packages/apis/src/generated/types.ts
@@ -300,9 +300,9 @@ export interface DBRP {
   /** the mapping identifier */
   readonly id?: string
   /** the organization ID that owns this mapping. */
-  orgID: string
+  orgID?: string
   /** the organization that owns this mapping. */
-  org: string
+  org?: string
   /** the bucket ID used as target for the translation. */
   bucketID: string
   /** InfluxDB v1 database */
@@ -418,6 +418,8 @@ export interface ScraperTargetRequest {
   orgID?: string
   /** The ID of the bucket to write to. */
   bucketID?: string
+  /** Skip TLS verification on endpoint. */
+  allowInsecure?: boolean
 }
 
 export interface Variables {
@@ -557,7 +559,7 @@ export interface Buckets {
 
 export interface LabelCreateRequest {
   orgID: string
-  name?: string
+  name: string
   /** Key/Value pairs associated with this label. Keys can be removed by sending an update with an empty value. */
   properties?: any
 }
@@ -668,13 +670,24 @@ export interface LinePlusSingleStatProperties {
   axes: Axes
   legend: Legend
   xColumn?: string
+  generateXAxisTicks?: string[]
+  xTotalTicks?: number
+  xTickStart?: number
+  xTickStep?: number
   yColumn?: string
+  generateYAxisTicks?: string[]
+  yTotalTicks?: number
+  yTickStart?: number
+  yTickStep?: number
   shadeBelow?: boolean
   hoverDimension?: 'auto' | 'x' | 'y' | 'xy'
   position: 'overlaid' | 'stacked'
   prefix: string
   suffix: string
   decimalPlaces: DecimalPlaces
+  legendColorizeRows?: boolean
+  legendOpacity?: number
+  legendOrientationThreshold?: number
 }
 
 export interface DashboardQuery {
@@ -788,11 +801,22 @@ export interface XYViewProperties {
   axes: Axes
   legend: Legend
   xColumn?: string
+  generateXAxisTicks?: string[]
+  xTotalTicks?: number
+  xTickStart?: number
+  xTickStep?: number
   yColumn?: string
+  generateYAxisTicks?: string[]
+  yTotalTicks?: number
+  yTickStart?: number
+  yTickStep?: number
   shadeBelow?: boolean
   hoverDimension?: 'auto' | 'x' | 'y' | 'xy'
   position: 'overlaid' | 'stacked'
   geom: XYGeom
+  legendColorizeRows?: boolean
+  legendOpacity?: number
+  legendOrientationThreshold?: number
 }
 
 export type XYGeom = 'line' | 'step' | 'stacked' | 'bar' | 'monotoneX'
@@ -829,6 +853,9 @@ export interface HistogramViewProperties {
   xAxisLabel: string
   position: 'overlaid' | 'stacked'
   binCount: number
+  legendColorizeRows?: boolean
+  legendOpacity?: number
+  legendOrientationThreshold?: number
 }
 
 export interface GaugeViewProperties {
@@ -899,6 +926,9 @@ export interface CheckViewProperties {
   queries: DashboardQuery[]
   /** Colors define color encoding of data into a visualization */
   colors: DashboardColor[]
+  legendColorizeRows?: boolean
+  legendOpacity?: number
+  legendOrientationThreshold?: number
 }
 
 export type Check = CheckDiscriminator
@@ -1028,7 +1058,15 @@ export interface ScatterViewProperties {
   /** If true, will display note when empty */
   showNoteWhenEmpty: boolean
   xColumn: string
+  generateXAxisTicks?: string[]
+  xTotalTicks?: number
+  xTickStart?: number
+  xTickStep?: number
   yColumn: string
+  generateYAxisTicks?: string[]
+  yTotalTicks?: number
+  yTickStart?: number
+  yTickStep?: number
   fillColumns: string[]
   symbolColumns: string[]
   xDomain: number[]
@@ -1039,6 +1077,9 @@ export interface ScatterViewProperties {
   xSuffix: string
   yPrefix: string
   ySuffix: string
+  legendColorizeRows?: boolean
+  legendOpacity?: number
+  legendOrientationThreshold?: number
 }
 
 export interface HeatmapViewProperties {
@@ -1052,7 +1093,15 @@ export interface HeatmapViewProperties {
   /** If true, will display note when empty */
   showNoteWhenEmpty: boolean
   xColumn: string
+  generateXAxisTicks?: string[]
+  xTotalTicks?: number
+  xTickStart?: number
+  xTickStep?: number
   yColumn: string
+  generateYAxisTicks?: string[]
+  yTotalTicks?: number
+  yTickStart?: number
+  yTickStep?: number
   xDomain: number[]
   yDomain: number[]
   xAxisLabel: string
@@ -1062,6 +1111,9 @@ export interface HeatmapViewProperties {
   yPrefix: string
   ySuffix: string
   binSize: number
+  legendColorizeRows?: boolean
+  legendOpacity?: number
+  legendOrientationThreshold?: number
 }
 
 export interface MosaicViewProperties {
@@ -1075,6 +1127,10 @@ export interface MosaicViewProperties {
   /** If true, will display note when empty */
   showNoteWhenEmpty: boolean
   xColumn: string
+  generateXAxisTicks?: string[]
+  xTotalTicks?: number
+  xTickStart?: number
+  xTickStep?: number
   ySeriesColumns: string[]
   fillColumns: string[]
   xDomain: number[]
@@ -1085,6 +1141,9 @@ export interface MosaicViewProperties {
   xSuffix: string
   yPrefix: string
   ySuffix: string
+  legendColorizeRows?: boolean
+  legendOpacity?: number
+  legendOrientationThreshold?: number
 }
 
 export interface BandViewProperties {
@@ -1100,12 +1159,23 @@ export interface BandViewProperties {
   axes: Axes
   legend: Legend
   xColumn?: string
+  generateXAxisTicks?: string[]
+  xTotalTicks?: number
+  xTickStart?: number
+  xTickStep?: number
   yColumn?: string
+  generateYAxisTicks?: string[]
+  yTotalTicks?: number
+  yTickStart?: number
+  yTickStep?: number
   upperColumn?: string
   mainColumn?: string
   lowerColumn?: string
   hoverDimension?: 'auto' | 'x' | 'y' | 'xy'
   geom: XYGeom
+  legendColorizeRows?: boolean
+  legendOpacity?: number
+  legendOrientationThreshold?: number
 }
 
 export interface CreateCell {
@@ -1558,7 +1628,7 @@ export interface Dialect {
   header?: boolean
   /** Separator between cells; the default is , */
   delimiter?: string
-  /** Https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/#columns */
+  /** https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/#columns */
   annotations?: Array<'group' | 'datatype' | 'default'>
   /** Character prefixed to comment strings */
   commentPrefix?: string
@@ -2092,7 +2162,7 @@ export type TelegramNotificationEndpoint = NotificationEndpointBase & {
   channel: string
 }
 
-export interface TemplateExport {
+export interface TemplateExportByID {
   stackID?: string
   orgIDs?: Array<{
     orgID?: string
@@ -2104,7 +2174,23 @@ export interface TemplateExport {
   resources?: {
     id: string
     kind: TemplateKind
+    /** if defined with id, name is used for resource exported by id. if defined independently, resources strictly matching name are exported */
     name?: string
+  }
+}
+
+export interface TemplateExportByName {
+  stackID?: string
+  orgIDs?: Array<{
+    orgID?: string
+    resourceFilters?: {
+      byLabel?: string[]
+      byResourceKind?: TemplateKind[]
+    }
+  }>
+  resources?: {
+    kind: TemplateKind
+    name: string
   }
 }
 


### PR DESCRIPTION
This PR regenerates APIs using https://raw.githubusercontent.com/influxdata/influxdb/v2.0.3/http/swagger.yml after required API generator (oats) changes described by https://github.com/bonitoo-io/oats/pull/1 .


<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
