### PR TITLE
feat(core): allow to access escaped field values

### DIFF
--- a/packages/core/src/Point.ts
+++ b/packages/core/src/Point.ts
@@ -17,7 +17,8 @@ export interface PointSettings {
 export class Point {
   private name: string
   private tags: {[key: string]: string} = {}
-  private fields: {[key: string]: string} = {}
+  /** escaped field values */
+  public fields: {[key: string]: string} = {}
   private time: string | number | Date | undefined
 
   /**

--- a/packages/core/src/WriteApi.ts
+++ b/packages/core/src/WriteApi.ts
@@ -1,4 +1,4 @@
-import {Point} from './Point'
+import {Point, PointSettings} from './Point'
 
 /**
  * The asynchronous buffering API to Write time-series data into InfluxDB 2.0.
@@ -9,7 +9,7 @@ import {Point} from './Point'
  * The data are formatted in [Line Protocol](https://bit.ly/2QL99fu).
  * <p>
  */
-export default interface WriteApi {
+export default interface WriteApi extends PointSettings {
   /**
    * Instructs to use the following default tags  when writing points.
    * Not applicable for writing records/lines.

--- a/packages/core/src/impl/WriteApiImpl.ts
+++ b/packages/core/src/impl/WriteApiImpl.ts
@@ -8,7 +8,7 @@ import {Transport, SendOptions} from '../transport'
 import {Headers} from '../results'
 import Logger from './Logger'
 import {HttpError, RetryDelayStrategy} from '../errors'
-import {Point, PointSettings} from '../Point'
+import {Point} from '../Point'
 import {escape} from '../util/escape'
 import {currentTime, dateToProtocolTimestamp} from '../util/currentTime'
 import {createRetryDelayStrategy} from './retryStrategy'
@@ -53,7 +53,7 @@ class WriteBuffer {
   }
 }
 
-export default class WriteApiImpl implements WriteApi, PointSettings {
+export default class WriteApiImpl implements WriteApi {
   private writeBuffer: WriteBuffer
   private closed = false
   private httpPath: string


### PR DESCRIPTION
This PR contains the following type-system enhancements

* feat(core): allow to access escaped field values
   * a user can now directly specify field values with `new Point().fields['unescapedFieldKey'] = 'escapedFieldValue'
   * there was previously no option to add `unsigned int values` as well as int numbers greater than Number.MAX_SAFE_INTEGER, it is now possible
* feat(core): enhance WriteApi interface to extend PointSettings
   * a protocol line can be now obtained from a typescript code with `point.toLineProtocol(writeAPI)`

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] `yarn test` completes successfully
- [ ] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
