### PR TITLE
chore(ci): ignore gh-pages branch in CI workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,13 @@ workflows:
     jobs:
       - tests:
           version: '14'
-      - coverage
+          filters:
+            branches:
+              ignore: gh-pages
+      - coverage:
+          filters:
+            branches:
+              ignore: gh-pages
       - deploy-preview:
           requires:
             - tests


### PR DESCRIPTION
This PR ignores `gh-pages` branch in tests ad coverage executions with the help of https://github.com/circleci/circleci-docs/blob/master/jekyll/_cci2/configuration-reference.md#filters

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] Rebased/mergeable
