### PR TITLE
feat: expose response headers, username+password authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Features
 
 1. [#302](https://github.com/influxdata/influxdb-client-js/pull/302): Expose response headers in all APIs.
-1. [#302](https://github.com/influxdata/influxdb-client-js/pull/302): Add `sessionAuth.js` example.
+1. [#302](https://github.com/influxdata/influxdb-client-js/pull/302): Add `tokens.js` example.
 
 ## 1.10.0 [2021-01-29]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 1.11.0 [unreleased]
 
+### Features
+
+1. [#302](https://github.com/influxdata/influxdb-client-js/pull/302): Expose response headers in all APIs.
+1. [#302](https://github.com/influxdata/influxdb-client-js/pull/302): Add `sessionAuth.js` example.
+
 ## 1.10.0 [2021-01-29]
 
 ### Features

--- a/examples/sessionAuth.js
+++ b/examples/sessionAuth.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/*
+This example shows how to use `username + password` authentication 
+against InfluxDB v2 OSS. This type of authentication shall be avoided 
+in favor of a token authentication, which is preferred for programmatic 
+access to InfluxDB v2, tokens can be easily managed in InfluxDB UI.
+`username + password` authentication might be required for creating
+a first token.
+*/
+
+const {InfluxDB} = require('@influxdata/influxdb-client')
+const {
+  AuthorizationsAPI,
+  SigninAPI,
+  SignoutAPI,
+} = require('@influxdata/influxdb-client-apis')
+const {url, username, password} = require('./env')
+
+async function signInDemo() {
+  const influxDB = new InfluxDB({url})
+  // sign in using user name and password, remember session cookie(s)
+  console.log('*** Signin ***')
+  const signinApi = new SigninAPI(influxDB)
+  const cookies = []
+  await signinApi.postSignin(
+    {auth: {user: username, password}},
+    {
+      responseStarted: (headers, status) => {
+        if (status < 300) {
+          const setCookie = headers['set-cookie']
+          if (typeof setCookie === 'string') {
+            cookies.push(setCookie.split(';').shift())
+          } else if (Array.isArray(setCookie)) {
+            setCookie.forEach(c => cookies.push(c.split(';').shift()))
+          }
+        }
+      },
+    }
+  )
+  // authorize communication with session cookies
+  const session = {headers: {cookie: cookies.join('; ')}}
+  // get all authorization tokens
+  console.log('*** GetAuthorizations ***')
+  const authorizationAPI = new AuthorizationsAPI(influxDB)
+  const authorizations = await authorizationAPI.getAuthorizations({}, session)
+  // console.log(JSON.stringify(authorizations?.authorizations, null, 2))
+  ;(authorizations.authorizations || []).forEach(auth => {
+    console.log(auth.token)
+    console.log(' ', auth.description)
+  })
+  console.log('\nFinished SUCCESS')
+  // invalidate the session
+  const signoutAPI = new SignoutAPI(influxDB)
+  await signoutAPI.postSignout(undefined, session)
+  console.log('Signout SUCCESS')
+}
+
+signInDemo().catch(error => {
+  console.error(error)
+  console.log('\nFinished ERROR')
+})

--- a/packages/apis/src/APIBase.ts
+++ b/packages/apis/src/APIBase.ts
@@ -1,11 +1,23 @@
 // this is effectively a clone of
-import {InfluxDB, Transport, SendOptions} from '@influxdata/influxdb-client'
+import {
+  InfluxDB,
+  Transport,
+  SendOptions,
+  Headers,
+} from '@influxdata/influxdb-client'
 
 // used only in browser builds
 declare function btoa(plain: string): string
 
 export interface RequestOptions {
+  /** HTTP request headers */
   headers?: {[key: string]: string}
+  /**
+   * Informs about a start of response processing.
+   * @param headers - response HTTP headers
+   * @param statusCode - response status code
+   */
+  responseStarted?: (headers: Headers, statusCode?: number) => void
 }
 
 function base64(value: string): string {
@@ -68,7 +80,8 @@ export class APIBase {
     return this.transport.request(
       path,
       request.body ? request.body : '',
-      sendOptions
+      sendOptions,
+      requestOptions?.responseStarted
     )
   }
 }

--- a/packages/apis/src/APIBase.ts
+++ b/packages/apis/src/APIBase.ts
@@ -63,7 +63,7 @@ export class APIBase {
       const value = `${request.auth.user}:${request.auth.password}`
       ;(sendOptions.headers || (sendOptions.headers = {}))[
         'authorization'
-      ] = base64(value)
+      ] = `Basic ${base64(value)}`
     }
     return this.transport.request(
       path,

--- a/packages/core/src/impl/node/NodeHttpTransport.ts
+++ b/packages/core/src/impl/node/NodeHttpTransport.ts
@@ -10,6 +10,7 @@ import {
   ChunkCombiner,
   CommunicationObserver,
   Headers,
+  ResponseStartedFn,
 } from '../../results'
 import nodeChunkCombiner from './nodeChunkCombiner'
 import zlib from 'zlib'
@@ -118,7 +119,12 @@ export class NodeHttpTransport implements Transport {
    * @param options - send options
    * @returns Promise of response body
    */
-  request(path: string, body: any, options: SendOptions): Promise<any> {
+  request(
+    path: string,
+    body: any,
+    options: SendOptions,
+    responseStarted?: ResponseStartedFn
+  ): Promise<any> {
     if (!body) {
       body = ''
     } else if (typeof body !== 'string') {
@@ -128,7 +134,10 @@ export class NodeHttpTransport implements Transport {
     let contentType: string
     return new Promise((resolve, reject) => {
       this.send(path, body as string, options, {
-        responseStarted(headers: Headers) {
+        responseStarted(headers: Headers, statusCode?: number) {
+          if (responseStarted) {
+            responseStarted(headers, statusCode)
+          }
           contentType = String(headers['content-type'])
         },
         next: (data: Uint8Array): void => {

--- a/packages/core/src/results/CommunicationObserver.ts
+++ b/packages/core/src/results/CommunicationObserver.ts
@@ -3,6 +3,14 @@ import {Cancellable} from './Cancellable'
  * Type of HTTP headers.
  */
 export type Headers = {[header: string]: string | string[] | undefined}
+
+/**
+ * Informs about a start of response processing.
+ * @param headers - response HTTP headers
+ * @param statusCode - response status code
+ */
+export type ResponseStartedFn = (headers: Headers, statusCode?: number) => void
+
 /**
  * Observes communication with the server.
  */
@@ -22,10 +30,8 @@ export interface CommunicationObserver<T> {
   complete(): void
   /**
    * Informs about a start of response processing.
-   * @param headers - response HTTP headers
-   * @param statusCode - response status code
    */
-  responseStarted?: (headers: Headers, statusCode?: number) => void
+  responseStarted?: ResponseStartedFn
   /**
    * Setups cancelllable for this communication.
    */

--- a/packages/core/src/transport.ts
+++ b/packages/core/src/transport.ts
@@ -1,10 +1,12 @@
-import {CommunicationObserver} from './results'
+import {CommunicationObserver, ResponseStartedFn} from './results'
 import {ChunkCombiner} from './results/chunkCombiner'
 /**
  * Options for sending a request message.
  */
 export interface SendOptions {
+  /** HTTP method (POST, PUT, GET, PATCH ...) */
   method: string
+  /** Request HTTP headers. */
   headers?: {[key: string]: string}
 }
 
@@ -35,7 +37,12 @@ export interface Transport {
    * @param requestBody - request body
    * @param options - send options
    */
-  request(path: string, body: any, options: SendOptions): Promise<any>
+  request(
+    path: string,
+    body: any,
+    options: SendOptions,
+    responseStarted?: ResponseStartedFn
+  ): Promise<any>
 
   /**
    * Combines response chunks to create a single response object.

--- a/packages/core/test/unit/impl/browser/FetchTransport.test.ts
+++ b/packages/core/test/unit/impl/browser/FetchTransport.test.ts
@@ -89,6 +89,28 @@ describe('FetchTransport', () => {
       })
       expect(response).is.deep.equal('{}')
     })
+    it('receives also response headers', async () => {
+      emulateFetchApi({
+        headers: {'content-type': 'application/json'},
+        body: '{}',
+      })
+      let responseMeta: any
+      const response = await transport.request(
+        '/whatever',
+        {anything: 'here'},
+        {
+          method: 'POST',
+        },
+        function(headers, status) {
+          responseMeta = [headers, status]
+        }
+      )
+      expect(response).is.deep.equal({})
+      expect(responseMeta).is.deep.equal([
+        {'content-type': 'application/json'},
+        200,
+      ])
+    })
     it('receives text data for application/csv', async () => {
       emulateFetchApi({
         headers: {'content-type': 'application/csv'},

--- a/packages/core/test/unit/impl/node/NodeHttpTransport.test.ts
+++ b/packages/core/test/unit/impl/node/NodeHttpTransport.test.ts
@@ -618,6 +618,34 @@ describe('NodeHttpTransport', () => {
       })
       expect(data).equals('..')
     })
+    it(`returns response headers and status code `, async () => {
+      nock(transportOptions.url)
+        .get('/test')
+        .reply(202, '', {
+          'content-type': 'application/text',
+          'custom-header': 'custom-val',
+        })
+        .persist()
+      let responseCustomHeader: string | undefined
+      let responseStatus: number | undefined
+      const data = await new NodeHttpTransport({
+        ...transportOptions,
+        timeout: 10000,
+      }).request(
+        '/test',
+        '',
+        {
+          method: 'GET',
+        },
+        (headers, status) => {
+          responseCustomHeader = String(headers['custom-header'])
+          responseStatus = status
+        }
+      )
+      expect(data).equals('')
+      expect(responseCustomHeader).equals('custom-val')
+      expect(responseStatus).equals(202)
+    })
     it(`return text for CSV response`, async () => {
       nock(transportOptions.url)
         .get('/test')


### PR DESCRIPTION
This PR 
- allows receiving HTTP response headers in all APIs
- allows authenticating users with username+password in all APIs
- adds `tokens.js` example that shows how to use username+password authentication to establish authenticated session to manage authorization tokens

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
