### PR TITLE
chore(core): remove deprecated zlib constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 1. [#302](https://github.com/influxdata/influxdb-client-js/pull/302): Expose response headers in all APIs.
 1. [#302](https://github.com/influxdata/influxdb-client-js/pull/302): Add `tokens.js` example.
 
+### Bug Fixes
+
+1. [#305](https://github.com/influxdata/influxdb-client-js/pull/305): Remove deprecated zlib constants.
+
 ## 1.10.0 [2021-01-29]
 
 ### Features

--- a/packages/core/src/impl/node/NodeHttpTransport.ts
+++ b/packages/core/src/impl/node/NodeHttpTransport.ts
@@ -19,8 +19,8 @@ import {CLIENT_LIB_VERSION} from '../version'
 import Logger from '../Logger'
 
 const zlibOptions = {
-  flush: zlib.Z_SYNC_FLUSH,
-  finishFlush: zlib.Z_SYNC_FLUSH,
+  flush: zlib.constants.Z_SYNC_FLUSH,
+  finishFlush: zlib.constants.Z_SYNC_FLUSH,
 }
 const emptyBuffer = Buffer.allocUnsafe(0)
 


### PR DESCRIPTION
Z_SYNC_FLUSH constant was moved from zlib to zlib.constants sync node v7.0 , so the code in this PR.

## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
