### PR TITLE
feat(examples): add queryRaw example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 1. [#302](https://github.com/influxdata/influxdb-client-js/pull/302): Add `tokens.js` example.
 1. [#306](https://github.com/influxdata/influxdb-client-js/pull/306): Regenerate APIs from swagger.
 1. [#309](https://github.com/influxdata/influxdb-client-js/pull/309): Allow to customize logger.
+1. [#313](https://github.com/influxdata/influxdb-client-js/pull/313): Add queryRaw example.
 
 ### Bug Fixes
 

--- a/examples/query.ts
+++ b/examples/query.ts
@@ -30,7 +30,20 @@ queryApi.queryRows(fluxQuery, {
   },
 })
 
-// // Execute query and collect all results in a Promise.
+// // Execute query and return the whole result as a string.
+// // Use with caution, it copies the whole stream of results into memory.
+// queryApi
+//   .queryRaw(fluxQuery)
+//   .then(result => {
+//     console.log(result)
+//     console.log('\nQueryRaw SUCCESS')
+//   })
+//   .catch(error => {
+//     console.error(error)
+//     console.log('\nQueryRaw ERROR')
+//   })
+
+// // Execute query and collect result rows in a Promise.
 // // Use with caution, it copies the whole stream of results into memory.
 // queryApi
 //   .collectRows(fluxQuery /*, you can specify a row mapper as a second arg */)


### PR DESCRIPTION
This PR adds an example that shows how to query the whole result. 

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
