### PR TITLE
feat(core/write): apply gzip compression to writes with body length > 1000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@
 
 ### Breaking Changes
 
-1. [#326](https://github.com/influxdata/influxdb-client-js/pull/326): Writes to InfluxDB are now gzipped
-   if the size of the request is greater that 1000 bytes. This change optimizes the communication with InfluxDB.
-   Whenever required, the threshold can be changed in `WriteOptions` during the creation of Write API. The gzip
-   encoding is implemented for node.js environment, but it does not work OOTB in the browser.
-   The browser transport can be however customized to do gzip, an example is provided in the `decorateRequest` field of
+1. [#326](https://github.com/influxdata/influxdb-client-js/pull/326): Write request to InfluxDB is gzipped
+   if the size greater than 1000 bytes, this change optimizes communication with InfluxDB. Whenever required,
+   the `gzipThreshold` can be changed in `WriteOptions` during the creation of Write API. The gzip
+   compression work fine in the node.js environment, but it does not work OOTB in the browser.
+   The browser transport must be customized to do gzip, an example is provided in the `decorateRequest` field of
    [FetchTransport](https://github.com/influxdata/influxdb-client-js/blob/master/packages/core/src/impl/browser/FetchTransport.ts).
 
 ## 1.12.0 [2021-04-01]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## 1.13.0 [unreleased]
 
+### Features
+
+1. [#326](https://github.com/influxdata/influxdb-client-js/pull/326): Apply gzip compression to writes.
+
+### Breaking Changes
+
+1. [#326](https://github.com/influxdata/influxdb-client-js/pull/326): Writes to InfluxDB are now gzipped
+   if the size of the request is greater that 1000 bytes. This change optimizes the communication with InfluxDB.
+   Whenever required, the threshold can be changed in `WriteOptions` during the creation of Write API. The gzip
+   encoding is implemented for node.js environment, but it does not work OOTB in the browser.
+   The browser transport can be however customized to do gzip, an example is provided in the `decorateRequest` field of
+   [FetchTransport](https://github.com/influxdata/influxdb-client-js/blob/master/packages/core/src/impl/browser/FetchTransport.ts).
+
 ## 1.12.0 [2021-04-01]
 
 ### Features

--- a/packages/core/src/impl/WriteApiImpl.ts
+++ b/packages/core/src/impl/WriteApiImpl.ts
@@ -91,6 +91,7 @@ export default class WriteApiImpl implements WriteApi {
         'content-type': 'text/plain; charset=utf-8',
         ...writeOptions?.headers,
       },
+      gzipThreshold: this.writeOptions.gzipThreshold,
     }
 
     const scheduleNextSend = (): void => {

--- a/packages/core/src/impl/browser/FetchTransport.ts
+++ b/packages/core/src/impl/browser/FetchTransport.ts
@@ -207,12 +207,12 @@ export default class FetchTransport implements Transport {
       // allow to specify custom options, such as signal, in SendOptions
       ...other,
     }
-    this.modifyFetchRequest(request, options, url)
+    this.requestDecorator(request, options, url)
     return fetch(url, request)
   }
 
   /**
-   * ModifyFetchRequest allows to modify requests before sending.
+   * RequestDecorator allows to modify requests before sending.
    * The following example shows a function that adds gzip
    * compression of requests using pako.js.
    *
@@ -231,7 +231,7 @@ export default class FetchTransport implements Transport {
    * }
    * ```
    */
-  public modifyFetchRequest: (
+  public requestDecorator: (
     request: RequestInit,
     options: SendOptions,
     url: string

--- a/packages/core/src/impl/browser/FetchTransport.ts
+++ b/packages/core/src/impl/browser/FetchTransport.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import {Transport, SendOptions} from '../../transport'
 import {ConnectionOptions} from '../../options'
 import {HttpError} from '../../errors'
@@ -191,7 +190,8 @@ export default class FetchTransport implements Transport {
     options: SendOptions
   ): Promise<Response> {
     const {method, headers, ...other} = options
-    return fetch(`${this.url}${path}`, {
+    const url = `${this.url}${path}`
+    const request: RequestInit = {
       method: method,
       body:
         method === 'GET' || method === 'HEAD'
@@ -206,6 +206,17 @@ export default class FetchTransport implements Transport {
       credentials: 'omit' as 'omit',
       // allow to specify custom options, such as signal, in SendOptions
       ...other,
-    })
+    }
+    this.modifyFetchRequest(request, options, url)
+    return fetch(url, request)
   }
+
+  /**
+   * ModifyFetchRequest allows to modify requests before sending.
+   */
+  public modifyFetchRequest: (
+    request: RequestInit,
+    options: SendOptions,
+    url: string
+  ) => void = function() {}
 }

--- a/packages/core/src/impl/browser/FetchTransport.ts
+++ b/packages/core/src/impl/browser/FetchTransport.ts
@@ -213,6 +213,23 @@ export default class FetchTransport implements Transport {
 
   /**
    * ModifyFetchRequest allows to modify requests before sending.
+   * The following example shows a function that adds gzip
+   * compression of requests using pako.js.
+   *
+   * ```ts
+   * function(request: RequestInit, options: SendOptions) {
+   *   const body = request.body
+   *   if (
+   *     typeof body === 'string' &&
+   *     options.gzipThreshold !== undefined &&
+   *     body.length > options.gzipThreshold
+   *   ) {
+   *     // gzip request, used in write API
+   *     ;(request.headers as Record<string, string>)['content-encoding'] = 'gzip'
+   *     request.body = pako.gzip(body, {to: 'string'})
+   *   }
+   * }
+   * ```
    */
   public modifyFetchRequest: (
     request: RequestInit,

--- a/packages/core/src/impl/browser/FetchTransport.ts
+++ b/packages/core/src/impl/browser/FetchTransport.ts
@@ -213,20 +213,21 @@ export default class FetchTransport implements Transport {
 
   /**
    * RequestDecorator allows to modify requests before sending.
+   *
    * The following example shows a function that adds gzip
    * compression of requests using pako.js.
    *
    * ```ts
-   * function(request: RequestInit, options: SendOptions) {
+   * const client = new InfluxDB({url: 'http://a'})
+   * client.transport.requestDecorator = function(request, options) {
    *   const body = request.body
    *   if (
    *     typeof body === 'string' &&
    *     options.gzipThreshold !== undefined &&
    *     body.length > options.gzipThreshold
    *   ) {
-   *     // gzip request, used in write API
-   *     ;(request.headers as Record<string, string>)['content-encoding'] = 'gzip'
-   *     request.body = pako.gzip(body, {to: 'string'})
+   *     request.headers['content-encoding'] = 'gzip'
+   *     request.body = pako.gzip(body)
    *   }
    * }
    * ```

--- a/packages/core/src/impl/node/NodeHttpTransport.ts
+++ b/packages/core/src/impl/node/NodeHttpTransport.ts
@@ -210,7 +210,7 @@ export class NodeHttpTransport implements Transport {
     ) {
       bodyPromise = bodyPromise.then(body => {
         return new Promise((resolve, reject) => {
-          zlib.gzip(body, zlibOptions, (err, res) => {
+          zlib.gzip(body, (err, res) => {
             /* istanbul ignore next - hard to simulate failure, manually reviewed */
             if (err) {
               return reject(err)

--- a/packages/core/src/impl/node/NodeHttpTransport.ts
+++ b/packages/core/src/impl/node/NodeHttpTransport.ts
@@ -215,6 +215,7 @@ export class NodeHttpTransport implements Transport {
             if (err) {
               return reject(err)
             }
+            options.headers['content-encoding'] = 'gzip'
             return resolve(res)
           })
         })

--- a/packages/core/src/impl/node/NodeHttpTransport.ts
+++ b/packages/core/src/impl/node/NodeHttpTransport.ts
@@ -206,7 +206,7 @@ export class NodeHttpTransport implements Transport {
     }
     if (
       sendOptions.gzipThreshold !== undefined &&
-      sendOptions.gzipThreshold > bodyBuffer.length
+      sendOptions.gzipThreshold < bodyBuffer.length
     ) {
       bodyPromise = bodyPromise.then(body => {
         return new Promise((resolve, reject) => {

--- a/packages/core/src/impl/node/NodeHttpTransport.ts
+++ b/packages/core/src/impl/node/NodeHttpTransport.ts
@@ -103,11 +103,16 @@ export class NodeHttpTransport implements Transport {
     options: SendOptions,
     callbacks?: Partial<CommunicationObserver<any>>
   ): void {
-    const message = this.createRequestMessage(path, body, options)
     const cancellable = new CancellableImpl()
     if (callbacks && callbacks.useCancellable)
       callbacks.useCancellable(cancellable)
-    this._request(message, cancellable, callbacks)
+    this.createRequestMessage(path, body, options).then(
+      (message: {[key: string]: any}) => {
+        this._request(message, cancellable, callbacks)
+      },
+      /* istanbul ignore next - hard to simulate failure, manually reviewed */
+      (err: Error) => callbacks?.error && callbacks.error(err)
+    )
   }
 
   /**
@@ -180,7 +185,7 @@ export class NodeHttpTransport implements Transport {
     path: string,
     body: string,
     sendOptions: SendOptions
-  ): {[key: string]: any} {
+  ): Promise<{[key: string]: any}> {
     const bodyBuffer = Buffer.from(body, 'utf-8')
     const headers: {[key: string]: any} = {
       'content-type': 'application/json; charset=utf-8',
@@ -189,6 +194,7 @@ export class NodeHttpTransport implements Transport {
     if (this.connectionOptions.token) {
       headers.authorization = 'Token ' + this.connectionOptions.token
     }
+    let bodyPromise = Promise.resolve(bodyBuffer)
     const options: {[key: string]: any} = {
       ...this.defaultOptions,
       path: this.contextPath + path,
@@ -197,11 +203,29 @@ export class NodeHttpTransport implements Transport {
         ...headers,
         ...sendOptions.headers,
       },
-      body: bodyBuffer,
     }
-    options.headers['content-length'] = bodyBuffer.length
+    if (
+      sendOptions.gzipThreshold !== undefined &&
+      sendOptions.gzipThreshold > bodyBuffer.length
+    ) {
+      bodyPromise = bodyPromise.then(body => {
+        return new Promise((resolve, reject) => {
+          zlib.gzip(body, zlibOptions, (err, res) => {
+            /* istanbul ignore next - hard to simulate failure, manually reviewed */
+            if (err) {
+              return reject(err)
+            }
+            return resolve(res)
+          })
+        })
+      })
+    }
 
-    return options
+    return bodyPromise.then(bodyBuffer => {
+      options.body = bodyBuffer
+      options.headers['content-length'] = bodyBuffer.length
+      return options
+    })
   }
 
   private _request(
@@ -215,6 +239,7 @@ export class NodeHttpTransport implements Transport {
       return
     }
     const req = this.requestApi(requestMessage, (res: http.IncomingMessage) => {
+      /* istanbul ignore next - hard to simulate failure, manually reviewed */
       if (cancellable.isCancelled()) {
         res.resume()
         listeners.complete()

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -79,6 +79,8 @@ export interface WriteOptions extends WriteRetryOptions {
   defaultTags?: Record<string, string>
   /** HTTP headers that will be sent with every write request */
   headers?: {[key: string]: string}
+  /** When specified, write bodies larger than the threshold are gzipped  */
+  gzipThreshold?: number
 }
 
 /** default RetryDelayStrategyOptions */
@@ -102,6 +104,7 @@ export const DEFAULT_WriteOptions: WriteOptions = {
   minRetryDelay: 5000,
   maxRetryDelay: 180000,
   exponentialBase: 5,
+  gzipThreshold: 1000,
 }
 
 /**

--- a/packages/core/src/transport.ts
+++ b/packages/core/src/transport.ts
@@ -8,6 +8,8 @@ export interface SendOptions {
   method: string
   /** Request HTTP headers. */
   headers?: {[key: string]: string}
+  /** When specified, message body larger than the treshold will is gzipped  */
+  gzipThreshold?: number
 }
 
 /**

--- a/packages/core/src/transport.ts
+++ b/packages/core/src/transport.ts
@@ -8,7 +8,7 @@ export interface SendOptions {
   method: string
   /** Request HTTP headers. */
   headers?: {[key: string]: string}
-  /** When specified, message body larger than the treshold will is gzipped  */
+  /** When specified, message body larger than the treshold is gzipped  */
   gzipThreshold?: number
 }
 

--- a/packages/core/test/unit/WriteApi.test.ts
+++ b/packages/core/test/unit/WriteApi.test.ts
@@ -13,6 +13,7 @@ import {
 import {collectLogging, CollectedLogs} from '../util'
 import {Logger} from '../../src/util/logger'
 import {waitForCondition} from './util/waitForCondition'
+import zlib from 'zlib'
 
 const clientOptions: ClientOptions = {
   url: 'http://fake:8086',
@@ -286,6 +287,79 @@ describe('WriteApi', () => {
             return [429, '', {'retry-after': '1'}]
           } else {
             messages.push(_requestBody.toString())
+            return [204, '', {'retry-after': '1'}]
+          }
+        })
+        .persist()
+      subject.writePoint(
+        new Point('test')
+          .tag('t', ' ')
+          .floatField('value', 1)
+          .timestamp('')
+      )
+      await waitForCondition(() => writeCounters.successLineCount == 1)
+      expect(logs.error).has.length(0)
+      expect(logs.warn).has.length(1) // request was retried once
+      subject.writePoint(new Point()) // ignored, since it generates no line
+      subject.writePoints([
+        new Point('test'), // will be ignored + warning
+        new Point('test').floatField('value', 2),
+        new Point('test').floatField('value', 3),
+        new Point('test').floatField('value', 4).timestamp('1'),
+        new Point('test').floatField('value', 5).timestamp(2.1),
+        new Point('test').floatField('value', 6).timestamp(new Date(3)),
+        new Point('test')
+          .floatField('value', 7)
+          .timestamp((false as any) as string), // server decides what to do with such values
+      ])
+      await waitForCondition(() => writeCounters.successLineCount == 7)
+      expect(logs.error).to.length(0)
+      expect(logs.warn).to.length(2)
+      expect(messages).to.have.length(2)
+      expect(messages[0]).to.equal('test,t=\\ ,xtra=1 value=1')
+      const lines = messages[1].split('\n')
+      expect(lines).has.length(6)
+      expect(lines[0]).to.satisfy((line: string) =>
+        line.startsWith('test,xtra=1 value=2')
+      )
+      expect(lines[0].substring(lines[0].lastIndexOf(' ') + 1)).to.have.length(
+        String(Date.now()).length + 6 // nanosecond precision
+      )
+      expect(lines[1]).to.satisfy((line: string) =>
+        line.startsWith('test,xtra=1 value=3')
+      )
+      expect(lines[0].substring(lines[0].lastIndexOf(' ') + 1)).to.have.length(
+        String(Date.now()).length + 6 // nanosecond precision
+      )
+      expect(lines[2]).to.be.equal('test,xtra=1 value=4 1')
+      expect(lines[3]).to.be.equal('test,xtra=1 value=5 2')
+      expect(lines[4]).to.be.equal('test,xtra=1 value=6 3000000')
+      expect(lines[5]).to.be.equal('test,xtra=1 value=7 false')
+    })
+    it('flushes gzipped line protocol', async () => {
+      const writeCounters = createWriteCounters()
+      useSubject({
+        flushInterval: 5,
+        maxRetries: 1,
+        batchSize: 10,
+        writeSuccess: writeCounters.writeSuccess,
+        gzipThreshold: 0,
+      })
+      let requests = 0
+      const messages: string[] = []
+      nock(clientOptions.url)
+        .post(WRITE_PATH_NS)
+        .reply(function(_uri, _requestBody) {
+          requests++
+          if (requests % 2) {
+            return [429, '', {'retry-after': '1'}]
+          } else {
+            if (this.req.headers['content-encoding'] == 'gzip') {
+              const plain = zlib.gunzipSync(
+                Buffer.from(_requestBody as string, 'hex')
+              )
+              messages.push(plain.toString())
+            }
             return [204, '', {'retry-after': '1'}]
           }
         })

--- a/packages/core/test/unit/WriteApi.test.ts
+++ b/packages/core/test/unit/WriteApi.test.ts
@@ -157,6 +157,7 @@ describe('WriteApi', () => {
     it('does not retry write when configured to do so', async () => {
       useSubject({maxRetries: 0, batchSize: 1})
       subject.writeRecord('test value=1')
+      await waitForCondition(() => logs.error.length > 0)
       await subject.close().then(() => {
         expect(logs.error).to.length(1)
         expect(logs.warn).is.deep.equal([])
@@ -175,6 +176,7 @@ describe('WriteApi', () => {
         },
       })
       subject.writeRecord('test value=1')
+      await waitForCondition(() => logs.warn.length > 0)
       await subject.close().then(() => {
         expect(logs.error).length(0)
         expect(logs.warn).is.deep.equal([

--- a/packages/core/test/unit/impl/browser/FetchTransport.test.ts
+++ b/packages/core/test/unit/impl/browser/FetchTransport.test.ts
@@ -89,6 +89,26 @@ describe('FetchTransport', () => {
       })
       expect(response).is.deep.equal('{}')
     })
+    it('allows to transform requests', async () => {
+      let lastRequest: any
+      emulateFetchApi(
+        {
+          headers: {'content-type': 'text/plain'},
+          body: '{}',
+        },
+        req => (lastRequest = req)
+      )
+      const transport = new FetchTransport({url: 'http://test:8086'})
+      transport.modifyFetchRequest = (request): void => {
+        request.body = 'modified'
+      }
+      await transport.request('/whatever', '', {
+        method: 'POST',
+      })
+      expect(lastRequest)
+        .property('body')
+        .equals('modified')
+    })
     it('receives also response headers', async () => {
       emulateFetchApi({
         headers: {'content-type': 'application/json'},

--- a/packages/core/test/unit/impl/browser/FetchTransport.test.ts
+++ b/packages/core/test/unit/impl/browser/FetchTransport.test.ts
@@ -99,7 +99,7 @@ describe('FetchTransport', () => {
         req => (lastRequest = req)
       )
       const transport = new FetchTransport({url: 'http://test:8086'})
-      transport.modifyFetchRequest = (request): void => {
+      transport.requestDecorator = (request): void => {
         request.body = 'modified'
       }
       await transport.request('/whatever', '', {

--- a/packages/core/test/unit/impl/browser/emulateBrowser.ts
+++ b/packages/core/test/unit/impl/browser/emulateBrowser.ts
@@ -79,8 +79,12 @@ let beforeEmulation:
   | {fetch: any; AbortController: any; TextEncoder: any}
   | undefined
 
-export function emulateFetchApi(spec: ResponseSpec): void {
-  function fetch(url: string, _options: any): Promise<any> {
+export function emulateFetchApi(
+  spec: ResponseSpec,
+  onRequest?: (options: any) => void
+): void {
+  function fetch(url: string, options: any): Promise<any> {
+    if (onRequest) onRequest(options)
     return url.indexOf('error') !== -1
       ? Promise.reject(new Error(url))
       : Promise.resolve(createResponse(spec))

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "resolveJsonModule": true,
-    "lib": ["DOM", "es2015"]
+    "lib": ["DOM", "es2018"]
   },
   "include": ["src/**/*.ts", "test/**/*.ts"],
   "exclude": ["*.js"]


### PR DESCRIPTION
Fixes #325

## Proposed Changes
   * WriteApi now gzips write requests when they are greater than 1000 bytes
   * Developers can customize the threshold that applies gzip compression in `WriteOptions`
```
  /** When specified, write bodies larger than the threshold are gzipped  */
  gzipThreshold?: number
```
   * `gzipThreshold` was also added in `SendOptions` of the transport layer
   * node.js transport implementation applies gzip threshold
   * the browser implements currently does not gzip at all
      * doing so would either triple the binary size of the client, or require an external dependency on gzip implementation
      * the browser transport can be customized to do gzip, an example provided with pako.js

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
