### PR TITLE
feat(core): use nanosecond precision by default in Point.toLineProtocol() 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.14.0 [unreleased]
 
+### Features
+
+1. [#338](https://github.com/influxdata/influxdb-client-js/pull/338): Use nanosecond precision by default in `Point.toLineProtocol()`.
+
 ## 1.13.0 [2021-04-30]
 
 ### Features

--- a/packages/core/src/Point.ts
+++ b/packages/core/src/Point.ts
@@ -151,7 +151,7 @@ export class Point {
   /**
    * Creates an InfluxDB protocol line out of this instance.
    * @param settings - settings control serialization of a point timestamp and can also add default tags,
-   * nanosecond timestamp precision is used when no settings are supplied.
+   * nanosecond timestamp precision is used when no `settings` or `settings.convertTime` is supplied.
    * @returns an InfluxDB protocol line out of this instance
    */
   public toLineProtocol(settings?: Partial<PointSettings>): string | undefined {

--- a/packages/core/src/Point.ts
+++ b/packages/core/src/Point.ts
@@ -1,3 +1,4 @@
+import {convertTimeToNanos} from './util/currentTime'
 import {escape} from './util/escape'
 
 /**
@@ -181,6 +182,8 @@ export class Point {
     let time = this.time
     if (settings && settings.convertTime) {
       time = settings.convertTime(time)
+    } else {
+      time = convertTimeToNanos(time)
     }
 
     return `${escape.measurement(this.name)}${tagsLine} ${fieldsLine}${

--- a/packages/core/src/Point.ts
+++ b/packages/core/src/Point.ts
@@ -5,7 +5,9 @@ import {escape} from './util/escape'
  * to a protocol line.
  */
 export interface PointSettings {
+  /** default tags to add to every point */
   defaultTags?: {[key: string]: string}
+  /** convertTime serializes of Point's timestamp to a string */
   convertTime?: (
     value: string | number | Date | undefined
   ) => string | undefined

--- a/packages/core/src/Point.ts
+++ b/packages/core/src/Point.ts
@@ -154,7 +154,7 @@ export class Point {
    * nanosecond timestamp precision is used when no settings are supplied.
    * @returns an InfluxDB protocol line out of this instance
    */
-  public toLineProtocol(settings?: PointSettings): string | undefined {
+  public toLineProtocol(settings?: Partial<PointSettings>): string | undefined {
     if (!this.name) return undefined
     let fieldsLine = ''
     Object.keys(this.fields)

--- a/packages/core/src/Point.ts
+++ b/packages/core/src/Point.ts
@@ -151,7 +151,7 @@ export class Point {
   /**
    * Creates an InfluxDB protocol line out of this instance.
    * @param settings - settings control serialization of a point timestamp and can also add default tags,
-   * nanosecond timestamp precision is used when no `settings` or `settings.convertTime` is supplied.
+   * nanosecond timestamp precision is used when no `settings` or no `settings.convertTime` is supplied.
    * @returns an InfluxDB protocol line out of this instance
    */
   public toLineProtocol(settings?: Partial<PointSettings>): string | undefined {

--- a/packages/core/src/Point.ts
+++ b/packages/core/src/Point.ts
@@ -8,7 +8,7 @@ import {escape} from './util/escape'
 export interface PointSettings {
   /** default tags to add to every point */
   defaultTags?: {[key: string]: string}
-  /** convertTime serializes of Point's timestamp to a string */
+  /** convertTime serializes Point's timestamp to a line protocol value */
   convertTime?: (
     value: string | number | Date | undefined
   ) => string | undefined
@@ -129,10 +129,13 @@ export class Point {
    * Sets point timestamp. Timestamp can be specified as a Date (preferred), number, string
    * or an undefined value. An undefined value instructs to assign a local timestamp using
    * the client's clock. An empty string can be used to let the server assign
-   * the timestamp. A number value represents time as a count of time units since epoch.
-   * The current time in nanoseconds can't precisely fit into a JS number, which
-   * can hold at most 2^53 integer number. Nanosecond precision numbers are thus supplied as
-   * a (base-10) string. An application can use ES2020 BigInt to represent nanoseconds,
+   * the timestamp. A number value represents time as a count of time units since epoch, the
+   * exact time unit then depends on the {@link InfluxDB.getWriteApi | precision} of the API
+   * that writes the point.
+   *
+   * Beware that the current time in nanoseconds can't precisely fit into a JS number,
+   * which can hold at most 2^53 integer number. Nanosecond precision numbers are thus supplied as
+   * a (base-10) string. An application can also use ES2020 BigInt to represent nanoseconds,
    * BigInt's `toString()` returns the required high-precision string.
    *
    * Note that InfluxDB requires the timestamp to fit into int64 data type.
@@ -147,7 +150,8 @@ export class Point {
 
   /**
    * Creates an InfluxDB protocol line out of this instance.
-   * @param settings - settings define the exact representation of point time and can also add default tags
+   * @param settings - settings control serialization of a point timestamp and can also add default tags,
+   * nanosecond timestamp precision is used when no settings are supplied.
    * @returns an InfluxDB protocol line out of this instance
    */
   public toLineProtocol(settings?: PointSettings): string | undefined {

--- a/packages/core/src/util/currentTime.ts
+++ b/packages/core/src/util/currentTime.ts
@@ -94,3 +94,24 @@ export const dateToProtocolTimestamp = {
   us: (d: Date): string => `${d.getTime()}000`,
   ns: (d: Date): string => `${d.getTime()}000000`,
 }
+
+/**
+ * convertTimeToNanos converts of Point's timestamp to a string
+ * @param value - supported timestamp value
+ * @returns line protocol value
+ */
+export function convertTimeToNanos(
+  value: string | number | Date | undefined
+): string | undefined {
+  if (value === undefined) {
+    return nanos()
+  } else if (typeof value === 'string') {
+    return value.length > 0 ? value : undefined
+  } else if (value instanceof Date) {
+    return `${value.getTime()}000000`
+  } else if (typeof value === 'number') {
+    return String(Math.floor(value))
+  } else {
+    return String(value)
+  }
+}


### PR DESCRIPTION
Fixes #337

## Proposed Changes

_Briefly describe your proposed changes:_

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
