### PR TITLE
feat(core): add uintField fn to Point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.15.0 [unreleased]
 
+### Features
+
+1. [#341](https://github.com/influxdata/influxdb-client-js/pull/341): Add uintField fn to `Point`.
+
 ## 1.14.0 [2021-06-04]
 
 ### Features

--- a/packages/core/src/Point.ts
+++ b/packages/core/src/Point.ts
@@ -90,6 +90,41 @@ export class Point {
   }
 
   /**
+   * Adds an unsigned integer field.
+   *
+   * @param name - field name
+   * @param value - field value
+   * @returns this
+   */
+  public uintField(name: string, value: number | any): Point {
+    if (typeof value === 'number') {
+      if (value < 0 || value > Number.MAX_SAFE_INTEGER) {
+        throw new Error(`uint value out of js unsigned integer range: ${value}`)
+      }
+      this.fields[name] = `${Math.floor(value as number)}u`
+    } else {
+      const strVal = String(value)
+      for (let i = 0; i < strVal.length; i++) {
+        const code = strVal.charCodeAt(i)
+        if (code < 48 || code > 57) {
+          throw new Error(
+            `uint value has an unsupported character at pos ${i}: ${value}`
+          )
+        }
+      }
+      if (
+        strVal.length > 20 ||
+        (strVal.length === 20 &&
+          strVal.localeCompare('18446744073709551615') > 0)
+      ) {
+        throw new Error(`uint value out of range: ${strVal}`)
+      }
+      this.fields[name] = `${strVal}u`
+    }
+    return this
+  }
+
+  /**
    * Adds a number field.
    *
    * @param name - field name

--- a/packages/core/test/fixture/pointTables.json
+++ b/packages/core/test/fixture/pointTables.json
@@ -117,5 +117,45 @@
     "name": "m11",
     "fields": [["f", "s", "\\\""]],
     "line": "m11 f=\"\\\\\\\"\""
+  },
+  {
+    "name": "uint1zero",
+    "fields": [["f", "u", 0]],
+    "line": "uint1zero f=0u"
+  },
+  {
+    "name": "uint2maxInt",
+    "fields": [["f", "u", 9007199254740991]],
+    "line": "uint2maxInt f=9007199254740991u"
+  },
+  {
+    "name": "uint3fraction",
+    "fields": [["f", "u", 55.4]],
+    "line": "uint3fraction f=55u"
+  },
+  {
+    "name": "uint4maxStr",
+    "fields": [["f", "u", "18446744073709551615"]],
+    "line": "uint4maxStr f=18446744073709551615u"
+  },
+  {
+    "name": "uintNegativeNumber",
+    "fields": [["f", "u", -1]],
+    "throws": "uint value out of js unsigned integer range: -1"
+  },
+  {
+    "name": "uintTooLargeNumber",
+    "fields": [["f", "u", 9007199254740992]],
+    "throws": "uint value out of js unsigned integer range: 9007199254740992"
+  },
+  {
+    "name": "uintNegativeString",
+    "fields": [["f", "u", "-1"]],
+    "throws": "uint value has an unsupported character at pos 0: -1"
+  },
+  {
+    "name": "uintTooLargeString",
+    "fields": [["f", "u", "18446744073709551616"]],
+    "throws": "uint value out of range: 18446744073709551616"
   }
 ]

--- a/packages/core/test/unit/Point.test.ts
+++ b/packages/core/test/unit/Point.test.ts
@@ -5,7 +5,7 @@ import {Point, PointSettings} from '../../src'
 interface PointTest {
   name?: string
   tags?: Array<[string, string]>
-  fields?: Array<[string, 'n' | 's' | 'b' | 'i', any]>
+  fields?: Array<[string, 'n' | 's' | 'b' | 'i' | 'u', any]>
   time?: string
   line: string | undefined
   toString: string | undefined
@@ -29,7 +29,7 @@ function createPoint(test: PointTest): Point {
       ? new Point().measurement(test.name)
       : new Point()
   ;(test.fields ?? []).forEach(
-    (field: [string, 'n' | 's' | 'b' | 'i', any]) => {
+    (field: [string, 'n' | 's' | 'b' | 'i' | 'u', any]) => {
       switch (field[1]) {
         case 'n':
           point.floatField(field[0], field[2])
@@ -42,6 +42,9 @@ function createPoint(test: PointTest): Point {
           break
         case 'i':
           point.intField(field[0], field[2])
+          break
+        case 'u':
+          point.uintField(field[0], field[2])
           break
       }
     }


### PR DESCRIPTION
This PR Adds uintField fn to Point class so that it simplifies adding of unsigned integer fields to a protocol line. Added js numbers must be >=0 and <Number.MAX_SAFE_INTEGER. Other values (including a possible bigint) are converted to string and checked that they contain just numbers and that the string is less than 2^64 (18446744073709551616)

## Proposed Changes

_Briefly describe your proposed changes:_

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
