### PR TITLE
feat(core): use exponential random retry strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 1. [#341](https://github.com/influxdata/influxdb-client-js/pull/341): Add uintField fn to `Point`.
 1. [#342](https://github.com/influxdata/influxdb-client-js/pull/342): Regenerate APIs from [oss.yml](https://github.com/influxdata/openapi/blob/master/contracts/oss.yml).
+1. [#343](https://github.com/influxdata/influxdb-client-js/pull/343): Use exponential random retry strategy when writing data.
 
 ## 1.14.0 [2021-06-04]
 

--- a/packages/core/src/impl/retryStrategy.ts
+++ b/packages/core/src/impl/retryStrategy.ts
@@ -24,7 +24,7 @@ export class RetryStrategyImpl implements RetryDelayStrategy {
     } else {
       if (failedAttempts && failedAttempts > 0) {
         // compute delay
-        if (this.options.randomize) {
+        if (this.options.randomRetry) {
           // random delay between deterministic delays
           let delay = Math.max(this.options.minRetryDelay, 1)
           let nextDelay = delay * this.options.exponentialBase

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -71,6 +71,8 @@ export interface WriteRetryOptions extends RetryDelayStrategyOptions {
 
   /** max number of retries when write fails */
   maxRetries: number
+  /** max time (millis) that can be spent with retries */
+  maxRetryTime: number
   /** the maximum size of retry-buffer (in lines) */
   maxBufferLines: number
 }
@@ -95,7 +97,7 @@ export interface WriteOptions extends WriteRetryOptions {
 export const DEFAULT_RetryDelayStrategyOptions = {
   retryJitter: 200,
   minRetryDelay: 5000,
-  maxRetryDelay: 180000,
+  maxRetryDelay: 125000,
   exponentialBase: 5,
   randomRetry: true,
 }
@@ -107,6 +109,7 @@ export const DEFAULT_WriteOptions: WriteOptions = {
   writeFailed: function() {},
   writeSuccess: function() {},
   maxRetries: 5,
+  maxRetryTime: 180_000,
   maxBufferLines: 32_000,
   // a copy of DEFAULT_RetryDelayStrategyOptions, so that DEFAULT_WriteOptions could be tree-shaken
   retryJitter: 200,

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -24,7 +24,7 @@ export const DEFAULT_ConnectionOptions: Partial<ConnectionOptions> = {
  * Options that configure strategy for retrying failed requests.
  */
 export interface RetryDelayStrategyOptions {
-  /** add `random(retryJitter)` milliseconds when retrying HTTP calls */
+  /** add `random(retryJitter)` milliseconds delay when retrying HTTP calls */
   retryJitter: number
   /** minimum delay when retrying write (milliseconds) */
   minRetryDelay: number

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -33,13 +33,13 @@ export interface RetryDelayStrategyOptions {
   /** base for the exponential retry delay */
   exponentialBase: number
   /**
-   * Randomize indicates whether the next retry delay is deterministic (false) or random (true).
+   * randomRetry indicates whether the next retry delay is deterministic (false) or random (true).
    * The deterministic delay starts with `minRetryDelay * exponentialBase` and it is multiplied
    * by `exponentialBase` until it exceeds `maxRetryDelay`.
    * When random is `true`, the next delay is computed as a random number between next retry attempt (upper)
    * and the lower number in the deterministic sequence. `random(retryJitter)` is added to every returned value.
    */
-  randomize: boolean
+  randomRetry: boolean
 }
 
 /**
@@ -97,7 +97,7 @@ export const DEFAULT_RetryDelayStrategyOptions = {
   minRetryDelay: 5000,
   maxRetryDelay: 180000,
   exponentialBase: 5,
-  randomize: false,
+  randomRetry: true,
 }
 
 /** default writeOptions */
@@ -106,15 +106,15 @@ export const DEFAULT_WriteOptions: WriteOptions = {
   flushInterval: 60000,
   writeFailed: function() {},
   writeSuccess: function() {},
-  maxRetries: 3,
+  maxRetries: 5,
   maxBufferLines: 32_000,
   // a copy of DEFAULT_RetryDelayStrategyOptions, so that DEFAULT_WriteOptions could be tree-shaken
   retryJitter: 200,
   minRetryDelay: 5000,
-  maxRetryDelay: 180000,
-  exponentialBase: 5,
+  maxRetryDelay: 125000,
+  exponentialBase: 2,
   gzipThreshold: 1000,
-  randomize: false,
+  randomRetry: true,
 }
 
 /**

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -24,14 +24,22 @@ export const DEFAULT_ConnectionOptions: Partial<ConnectionOptions> = {
  * Options that configure strategy for retrying failed requests.
  */
 export interface RetryDelayStrategyOptions {
-  /** include random milliseconds when retrying HTTP calls */
+  /** add `random(retryJitter)` milliseconds when retrying HTTP calls */
   retryJitter: number
   /** minimum delay when retrying write (milliseconds) */
   minRetryDelay: number
   /** maximum delay when retrying write (milliseconds) */
   maxRetryDelay: number
-  /** base for the exponential retry delay, the next delay is computed as `minRetryDelay * exponentialBase^(attempts-1) + random(retryJitter)` */
+  /** base for the exponential retry delay */
   exponentialBase: number
+  /**
+   * Randomize indicates whether the next retry delay is deterministic (false) or random (true).
+   * The deterministic delay starts with `minRetryDelay * exponentialBase` and it is multiplied
+   * by `exponentialBase` until it exceeds `maxRetryDelay`.
+   * When random is `true`, the next delay is computed as a random number between next retry attempt (upper)
+   * and the lower number in the deterministic sequence. `random(retryJitter)` is added to every returned value.
+   */
+  randomize: boolean
 }
 
 /**
@@ -89,6 +97,7 @@ export const DEFAULT_RetryDelayStrategyOptions = {
   minRetryDelay: 5000,
   maxRetryDelay: 180000,
   exponentialBase: 5,
+  randomize: false,
 }
 
 /** default writeOptions */
@@ -105,6 +114,7 @@ export const DEFAULT_WriteOptions: WriteOptions = {
   maxRetryDelay: 180000,
   exponentialBase: 5,
   gzipThreshold: 1000,
+  randomize: false,
 }
 
 /**

--- a/packages/core/test/unit/WriteApi.test.ts
+++ b/packages/core/test/unit/WriteApi.test.ts
@@ -302,6 +302,7 @@ describe('WriteApi', () => {
       useSubject({
         flushInterval: 5,
         maxRetries: 1,
+        randomRetry: false,
         batchSize: 10,
         writeSuccess: writeCounters.writeSuccess,
       })
@@ -369,6 +370,7 @@ describe('WriteApi', () => {
       useSubject({
         flushInterval: 5,
         maxRetries: 1,
+        randomRetry: false,
         batchSize: 10,
         writeSuccess: writeCounters.writeSuccess,
         gzipThreshold: 0,

--- a/packages/core/test/unit/WriteApi.test.ts
+++ b/packages/core/test/unit/WriteApi.test.ts
@@ -218,7 +218,7 @@ describe('WriteApi', () => {
       expect(logs.warn).has.length(0)
       expect(count).equals(1)
     })
-    it('implementation uses default notifiers', () => {
+    it('implementation uses expected defaults', () => {
       useSubject({})
       const writeOptions = (subject as any).writeOptions as WriteOptions
       expect(writeOptions.writeFailed).equals(DEFAULT_WriteOptions.writeFailed)
@@ -227,6 +227,7 @@ describe('WriteApi', () => {
       )
       expect(writeOptions.writeSuccess).to.not.throw()
       expect(writeOptions.writeFailed).to.not.throw()
+      expect(writeOptions.randomRetry).equals(true)
     })
   })
   describe('convert point time to line protocol', () => {

--- a/packages/core/test/unit/impl/RetryBuffer.test.ts
+++ b/packages/core/test/unit/impl/RetryBuffer.test.ts
@@ -21,13 +21,13 @@ describe('RetryBuffer', () => {
     })
     for (let i = 0; i < 10; i++) {
       input.push([['a' + i], i])
-      subject.addLines(['a' + i], i, 2)
+      subject.addLines(['a' + i], i, 2, Date.now() + 1000)
     }
     await waitForCondition(() => output.length >= 10)
     expect(output).length.is.greaterThan(0)
-    subject.addLines([], 1, 1) // shall be ignored
+    subject.addLines([], 1, 1, Date.now() + 1000) // shall be ignored
     subject.close()
-    subject.addLines(['x'], 1, 1) // shall be ignored
+    subject.addLines(['x'], 1, 1, Date.now() + 1000) // shall be ignored
     await subject.flush()
     expect(input).deep.equals(output)
   })
@@ -40,12 +40,24 @@ describe('RetryBuffer', () => {
     })
     for (let i = 0; i < 10; i++) {
       if (i >= 5) input.push([['a' + i], i])
-      subject.addLines(['a' + i], i, 100)
+      subject.addLines(['a' + i], i, 100, Date.now() + 1000)
     }
     await subject.flush()
     expect(subject.close()).equals(0)
     expect(logs.error).length.is.greaterThan(0) // 5 entries over limit
     expect(output).length.is.lessThan(6) // at most 5 items will be written
+  })
+  it('ignores previous lines on big chunks', async () => {
+    const output = [] as Array<[string[], number]>
+    const subject = new RetryBuffer(2, (lines, countdown) => {
+      output.push([lines, countdown])
+      return Promise.resolve()
+    })
+    subject.addLines(['1', '2', '3'], 1, 100, Date.now() + 1000)
+    subject.addLines(['4', '5', '6'], 1, 100, Date.now() + 1000)
+    await subject.flush()
+    expect(logs.error).length.is.greaterThan(0) // 3 entries over limit
+    expect(output).deep.equals([[['4', '5', '6'], 1]]) // at most 5 items will be written
   })
   it('retries does not fail after flush', async () => {
     const output = [] as Array<[string[], number]>
@@ -53,7 +65,7 @@ describe('RetryBuffer', () => {
       output.push([lines, countdown])
       return Promise.resolve()
     })
-    subject.addLines(['a'], 1, 20)
+    subject.addLines(['a'], 1, 20, Date.now() + 1000)
     await subject.flush()
     await new Promise<void>(
       (resolve, _reject) => setTimeout(() => resolve(), 21) // let scheduled retry finish
@@ -71,15 +83,15 @@ describe('RetryBuffer', () => {
     })
     for (let i = 0; i < 10; i++) {
       input.push([['a' + i], i])
-      subject.addLines(['a' + i], i, 2)
+      subject.addLines(['a' + i], i, 2, Date.now() + 1000)
     }
     await new Promise<void>((resolve, _reject) =>
       setTimeout(() => resolve(), 10)
     )
     expect(output).length.is.greaterThan(0)
-    subject.addLines([], 1, 1) // shall be ignored
+    subject.addLines([], 1, 1, Date.now() + 1000) // shall be ignored
     subject.close()
-    subject.addLines(['x'], 1, 1) // shall be ignored
+    subject.addLines(['x'], 1, 1, Date.now() + 1000) // shall be ignored
     succeed = true
     await subject.flush()
     expect(input).deep.equals(output)

--- a/packages/core/test/unit/impl/retryStrategy.test.ts
+++ b/packages/core/test/unit/impl/retryStrategy.test.ts
@@ -64,13 +64,12 @@ describe('RetryStrategyImpl', () => {
       }
     })
   })
-  it('generates exponential data from min to max for state data', () => {
+  it('generates exponential data from min to max from state data', () => {
     const subject = new RetryStrategyImpl({
       minRetryDelay: 100,
       maxRetryDelay: 1000,
       retryJitter: 0,
       exponentialBase: 2,
-      randomize: false,
     })
     const values = [1, 2, 3, 4, 5, 6].reduce((acc, _val) => {
       acc.push(subject.nextDelay())
@@ -86,8 +85,8 @@ describe('RetryStrategyImpl', () => {
         minRetryDelay: 100,
         maxRetryDelay: 2000,
         retryJitter: 20,
-        // exponentialBase: 5, 5 by default
-        randomize: false,
+        exponentialBase: 5,
+        randomRetry: false,
       })
       const values = [1, 2, 3, 4, 5, 6].reduce((acc, _val, index) => {
         acc.push(subject.nextDelay(undefined, index + 1))
@@ -110,7 +109,7 @@ describe('RetryStrategyImpl', () => {
         minRetryDelay: 100,
         maxRetryDelay: 1000,
         retryJitter: 10,
-        randomize: false,
+        randomRetry: false,
       })
       const values = [1, 2, 3, 4, 5, 6].reduce((acc, val) => {
         acc.push(subject.nextDelay(new Error(), val))
@@ -134,7 +133,7 @@ describe('RetryStrategyImpl', () => {
         maxRetryDelay: 1000,
         retryJitter: 100,
         exponentialBase: 2,
-        randomize: true,
+        randomRetry: true,
       })
       const values = [1, 2, 3, 4, 5].reduce((acc, _val, index) => {
         acc.push(subject.nextDelay(undefined, index + 1))

--- a/packages/core/test/unit/impl/retryStrategy.test.ts
+++ b/packages/core/test/unit/impl/retryStrategy.test.ts
@@ -17,44 +17,6 @@ describe('RetryStrategyImpl', () => {
       .property('options')
       .is.deep.equal(DEFAULT_RetryDelayStrategyOptions)
   })
-  it('generates exponential data from min to max for unknown delays', () => {
-    const subject = new RetryStrategyImpl({
-      minRetryDelay: 100,
-      maxRetryDelay: 1000,
-      retryJitter: 0,
-      exponentialBase: 2,
-    })
-    const values = [1, 2, 3, 4, 5, 6].reduce((acc, _val) => {
-      acc.push(subject.nextDelay())
-      return acc
-    }, [] as number[])
-    expect(values).to.be.deep.equal([100, 200, 400, 800, 1000, 1000])
-    subject.success()
-    expect(subject.nextDelay()).equals(100)
-  })
-  it('generates exponential data from min to max for unknown delays', () => {
-    const subject = new RetryStrategyImpl({
-      minRetryDelay: 100,
-      maxRetryDelay: 2000,
-      retryJitter: 20,
-      // exponentialBase: 5, 5 by default
-    })
-    const values = [1, 2, 3, 4, 5, 6].reduce((acc, _val, index) => {
-      acc.push(subject.nextDelay(undefined, index + 1))
-      return acc
-    }, [] as number[])
-    // truncate values to ignore jittering
-    expect(values.map(x => Math.trunc(x / 100) * 100)).to.be.deep.equal([
-      100,
-      500,
-      2000,
-      2000,
-      2000,
-      2000,
-    ])
-    subject.success()
-    expect(Math.trunc(subject.nextDelay() / 100) * 100).equals(100)
-  })
   it('generates the delays according to errors', () => {
     const subject = new RetryStrategyImpl({
       minRetryDelay: 100,
@@ -83,26 +45,6 @@ describe('RetryStrategyImpl', () => {
       expect(x).to.not.be.greaterThan(1000)
     })
   })
-  it('generates exponential delays with failedAttempts', () => {
-    const subject = new RetryStrategyImpl({
-      minRetryDelay: 100,
-      maxRetryDelay: 1000,
-      retryJitter: 10,
-    })
-    const values = [1, 2, 3, 4, 5, 6].reduce((acc, val) => {
-      acc.push(subject.nextDelay(new Error(), val))
-      return acc
-    }, [] as number[])
-    expect(values).to.have.length(6)
-    values.forEach((x, i) => {
-      if (i > 0) {
-        expect(Math.max(Math.trunc(x / 100), 10)).to.not.be.lessThan(
-          Math.max(Math.trunc(values[i - 1] / 100), 10)
-        )
-      }
-      expect(x).to.not.be.greaterThan(1000 + 10)
-    })
-  })
   it('generates default jittered delays', () => {
     const subject = new RetryStrategyImpl({
       minRetryDelay: 100,
@@ -120,6 +62,103 @@ describe('RetryStrategyImpl', () => {
       if (i > 0) {
         expect(x).to.not.be.lessThan(values[i - 1])
       }
+    })
+  })
+  it('generates exponential data from min to max for state data', () => {
+    const subject = new RetryStrategyImpl({
+      minRetryDelay: 100,
+      maxRetryDelay: 1000,
+      retryJitter: 0,
+      exponentialBase: 2,
+      randomize: false,
+    })
+    const values = [1, 2, 3, 4, 5, 6].reduce((acc, _val) => {
+      acc.push(subject.nextDelay())
+      return acc
+    }, [] as number[])
+    expect(values).to.be.deep.equal([100, 200, 400, 800, 1000, 1000])
+    subject.success()
+    expect(subject.nextDelay()).equals(100)
+  })
+  describe('deterministic interval', () => {
+    it('generates exponential data from min to max', () => {
+      const subject = new RetryStrategyImpl({
+        minRetryDelay: 100,
+        maxRetryDelay: 2000,
+        retryJitter: 20,
+        // exponentialBase: 5, 5 by default
+        randomize: false,
+      })
+      const values = [1, 2, 3, 4, 5, 6].reduce((acc, _val, index) => {
+        acc.push(subject.nextDelay(undefined, index + 1))
+        return acc
+      }, [] as number[])
+      // truncate values to ignore jittering
+      expect(values.map(x => Math.trunc(x / 100) * 100)).to.be.deep.equal([
+        100,
+        500,
+        2000,
+        2000,
+        2000,
+        2000,
+      ])
+      subject.success()
+      expect(Math.trunc(subject.nextDelay() / 100) * 100).equals(100)
+    })
+    it('generates exponential delays with failedAttempts', () => {
+      const subject = new RetryStrategyImpl({
+        minRetryDelay: 100,
+        maxRetryDelay: 1000,
+        retryJitter: 10,
+        randomize: false,
+      })
+      const values = [1, 2, 3, 4, 5, 6].reduce((acc, val) => {
+        acc.push(subject.nextDelay(new Error(), val))
+        return acc
+      }, [] as number[])
+      expect(values).to.have.length(6)
+      values.forEach((x, i) => {
+        if (i > 0) {
+          expect(Math.max(Math.trunc(x / 100), 10)).to.not.be.lessThan(
+            Math.max(Math.trunc(values[i - 1] / 100), 10)
+          )
+        }
+        expect(x).to.not.be.greaterThan(1000 + 10)
+      })
+    })
+  })
+  describe('random interval', () => {
+    it('generates exponential data from randomized windows', () => {
+      const subject = new RetryStrategyImpl({
+        minRetryDelay: 100,
+        maxRetryDelay: 1000,
+        retryJitter: 100,
+        exponentialBase: 2,
+        randomize: true,
+      })
+      const values = [1, 2, 3, 4, 5].reduce((acc, _val, index) => {
+        acc.push(subject.nextDelay(undefined, index + 1))
+        return acc
+      }, [] as number[])
+      const intervals = [
+        [100, 200],
+        [200, 400],
+        [400, 800],
+        [800, 1000],
+        [800, 1000],
+      ]
+      for (let i = 0; i < values.length; i++) {
+        expect(values[i]).is.gte(
+          intervals[i][0],
+          `${i} number ${values[i]} failed`
+        )
+        expect(values[i]).is.lte(
+          intervals[i][1] + subject.options.retryJitter,
+          `${i} number ${values[i]} failed`
+        )
+      }
+      subject.success()
+      expect(Math.trunc(subject.nextDelay() / 100) * 100).equals(100)
     })
   })
 })


### PR DESCRIPTION
This PR aligns retry strategy implementations across all official InfluxDB client libraries so that a delay for the next retry delay is a random value in the interval `minRetryInterval * exponentialBase^(attempts)` and `minRetryInterval * exponentialBase^(attempts+1)` increased by a random(jitter).

The defaults were changed to `minRetryInterval=5_000, exponentialBase=2, maxRetryDelay=125_000, maxRetries=5`

Retry delays are by default randomly distributed within the ranges of [5_000-10_000, 10_000-20_000, 20_000-40_000, 40_000-80_000, 80_000-125_000] + random(200). When an overall time spent by retrying exceeds a configurable `maxRetryTime` (180_000 millis by default), the write is not retried and fails.


- [x] CHANGELOG.md updated
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
