### PR TITLE
fix(core): rxjs7 compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.16.0 [unreleased]
 
+### Features
+
+1. [#346](https://github.com/influxdata/influxdb-client-js/pull/346): Make QueryApi compatible with rxjs7.
+
 ## 1.15.0 [2021-07-09]
 
 ### Features

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -79,7 +79,7 @@
     "rxjs": "^7.2.0",
     "sinon": "^7.5.0",
     "ts-node": "^8.5.4",
-    "typescript": "^4.1.2",
+    "typescript": "^4.3.5",
     "version-bump-prompt": "^5.0.6"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -76,7 +76,7 @@
     "rollup-plugin-gzip": "^2.2.0",
     "rollup-plugin-terser": "^7.0.0",
     "rollup-plugin-typescript2": "^0.27.2",
-    "rxjs": "^6.5.5",
+    "rxjs": "^7.2.0",
     "sinon": "^7.5.0",
     "ts-node": "^8.5.4",
     "typescript": "^4.1.2",

--- a/packages/core/src/impl/ObservableQuery.ts
+++ b/packages/core/src/impl/ObservableQuery.ts
@@ -86,4 +86,8 @@ export default class ObservableQuery<T> implements Observable<T> {
   public [symbolObservable](): this {
     return this
   }
+
+  // this makes sure we satisfy the interface, while using a possibly polyfilled
+  // [symbolObservable] above for the actual implementation
+  public declare [Symbol.observable]: () => this
 }

--- a/packages/core/src/impl/browser/FetchTransport.ts
+++ b/packages/core/src/impl/browser/FetchTransport.ts
@@ -123,7 +123,7 @@ export default class FetchTransport implements Transport {
         } else {
           if (response.body) {
             const reader = response.body.getReader()
-            let chunk: ReadableStreamReadResult<Uint8Array>
+            let chunk: ReadableStreamDefaultReadResult<Uint8Array>
             do {
               chunk = await reader.read()
               observer.next(chunk.value)

--- a/packages/core/src/observable/types.ts
+++ b/packages/core/src/observable/types.ts
@@ -12,6 +12,10 @@ export interface Observer<T> {
   complete: ObserverComplete
 }
 
+export interface Subscribable<T> {
+  subscribe(observer: Partial<Observer<T>>): Subscription
+}
+
 /**
  * An observable that aligns with the
  * {@link https://github.com/tc39/proposal-observable | TC39 observable proposal} and
@@ -27,9 +31,7 @@ export interface Observable<T> {
     error?: ObserverError,
     complete?: ObserverComplete
   ): Subscription
-  // this is actually implemented, but we cant add it the interface, because we
-  // use `./symbol#symbolObservable` as the key, in case Symbol isnt available
-  /* [Symbol.observable](): Observable<T> */
+  [Symbol.observable](): Subscribable<T>
 }
 
 /** Subscription mimics Subscription from ECMAScript TC39 Observable proposal */

--- a/packages/core/test/unit/Influxdb.test.ts
+++ b/packages/core/test/unit/Influxdb.test.ts
@@ -1,5 +1,5 @@
 import {expect} from 'chai'
-import {InfluxDB, ClientOptions} from '../../src'
+import {InfluxDB, ClientOptions, Transport} from '../../src'
 
 describe('InfluxDB', () => {
   describe('constructor', () => {

--- a/packages/giraffe/package.json
+++ b/packages/giraffe/package.json
@@ -73,7 +73,6 @@
     "rollup-plugin-gzip": "^2.2.0",
     "rollup-plugin-terser": "^7.0.0",
     "rollup-plugin-typescript2": "^0.27.2",
-    "rxjs": "^6.5.5",
     "sinon": "^7.5.0",
     "ts-node": "^8.5.4",
     "typescript": "^4.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4745,7 +4745,7 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
+minimist@>=1.2.2, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -7032,14 +7032,19 @@ typedarray@^0.0.6:
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 typescript@^3.7.4:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+  version "3.9.10"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
+  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
 typescript@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
   integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
+
+typescript@^4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
 typescript@~4.1.3:
   version "4.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4745,7 +4745,7 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@>=1.2.2, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
+minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -6152,12 +6152,19 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rxjs@^6.4.0, rxjs@^6.5.5, rxjs@^6.6.0:
+rxjs@^6.4.0, rxjs@^6.6.0:
   version "6.6.2"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.2.tgz#8096a7ac03f2cc4fe5860ef6e572810d9e01c0d2"
   integrity sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==
   dependencies:
     tslib "^1.9.0"
+
+rxjs@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.2.0.tgz#5cd12409639e9514a71c9f5f9192b2c4ae94de31"
+  integrity sha512-aX8w9OpKrQmiPKfT1bqETtUr9JygIz6GZ+gql8v7CijClsP0laoFUdKzxFAoWuRdSlOdU2+crss+cMf+cqMTnw==
+  dependencies:
+    tslib "~2.1.0"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.1"
@@ -6950,6 +6957,11 @@ tslib@^1.8.1, tslib@^1.9.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+
+tslib@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
+  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
 tsutils@^3.17.1:
   version "3.17.1"


### PR DESCRIPTION
## Proposed Changes

The typings used around ObservableQuery are not compatible with rxjs7. This fixes that so they are now compatible with rxjs 6 & 7. Also the tests now use rxjs7

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
