### PR TITLE
fix: parsing infinite numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 1. [#346](https://github.com/influxdata/influxdb-client-js/pull/346): Make QueryApi compatible with rxjs7.
 
+### Bug Fixes
+
+1. [#347](https://github.com/influxdata/influxdb-client-js/pull/347): Parsing infinite numbers
+
 ## 1.15.0 [2021-07-09]
 
 ### Features

--- a/packages/core/src/results/FluxTableMetaData.ts
+++ b/packages/core/src/results/FluxTableMetaData.ts
@@ -10,7 +10,18 @@ export const typeSerializers: Record<ColumnType, (val: string) => any> = {
   boolean: (x: string): any => x === 'true',
   unsignedLong: (x: string): any => (x === '' ? null : +x),
   long: (x: string): any => (x === '' ? null : +x),
-  double: (x: string): any => (x === '' ? null : +x),
+  double(x: string): any {
+    switch (x) {
+      case '':
+        return null
+      case '+Inf':
+        return Number.POSITIVE_INFINITY
+      case '-Inf':
+        return Number.NEGATIVE_INFINITY
+      default:
+        return +x
+    }
+  },
   string: identity,
   base64Binary: identity,
   duration: (x: string): any => (x === '' ? null : x),

--- a/packages/core/test/unit/results/FluxTableMetaData.test.ts
+++ b/packages/core/test/unit/results/FluxTableMetaData.test.ts
@@ -58,6 +58,8 @@ describe('FluxTableMetaData', () => {
     ['long', '', null],
     ['double', '1', 1],
     ['double', '', null],
+    ['double', '+Inf', Number.POSITIVE_INFINITY],
+    ['double', '-Inf', -Number.POSITIVE_INFINITY],
     ['string', '1', '1'],
     ['base64Binary', '1', '1'],
     ['dateTime', '1', '1'],
@@ -75,7 +77,9 @@ describe('FluxTableMetaData', () => {
         }),
       ]
       const subject = createFluxTableMetaData(columns)
-      expect(subject.toObject([entry[1]])).to.deep.equal({a: entry[2]})
+      const val = subject.toObject([entry[1]])
+      const entryElement = entry[2]
+      expect(val).to.deep.equal({a: entryElement})
     })
   }
   describe('custom serialization', () => {


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-java/issues/239

## Proposed Changes

Fixed parsing `Inf+` for [histogram() function](https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/histogram/).

#### Response example
```csv
#group,false,false,true,true,true,true,true,true,true,true,false,false
#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,string,string,double,double
#default,_result,,,,,,,,,,,
,result,table,_start,_stop,_field,_measurement,language,license,name,owner,le,_value
,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,0,0
,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,10,0
,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,20,0
,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,30,0
,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,40,0
,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,50,0
,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,60,0
,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,70,0
,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,80,0
,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,90,0
,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,+Inf,15
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
