### PR TITLE
fix: use configured bucket in query examples.

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -121,9 +121,9 @@
       })
       const queryInput = document.getElementById('query');
       const fluxQueryParam = new URLSearchParams(window.location.search).get('fluxQuery');
-      if (fluxQueryParam){
-        queryInput.value = fluxQueryParam
-      }
+      const exampleQuery = `from(bucket:"${bucket || 'my-bucket'}") |> range(start: -1d) |> filter(fn: (r) => r._measurement == "temperature")`
+      queryInput.value = fluxQueryParam ? fluxQueryParam : exampleQuery;
+      queryInput.textContent = queryInput.value;
       document.getElementById('queryButton').addEventListener('click', () => {
         queryExample(queryInput.value)
       })

--- a/examples/query.ts
+++ b/examples/query.ts
@@ -4,11 +4,11 @@
 //////////////////////////////////////////
 
 import {InfluxDB, FluxTableMetaData} from '@influxdata/influxdb-client'
-import {url, token, org} from './env'
+import {url, token, org, bucket} from './env'
 
 const queryApi = new InfluxDB({url, token}).getQueryApi(org)
 const fluxQuery =
-  'from(bucket:"my-bucket") |> range(start: 0) |> filter(fn: (r) => r._measurement == "temperature")'
+  `from(bucket:"${bucket || 'my-bucket'}") |> range(start: 0) |> filter(fn: (r) => r._measurement == "temperature")`
 
 console.log('*** QUERY ROWS ***')
 // Execute query and receive table metadata and rows.

--- a/examples/queryWithParams.ts
+++ b/examples/queryWithParams.ts
@@ -9,12 +9,12 @@ import {
   flux,
   fluxDuration,
 } from '@influxdata/influxdb-client'
-import {url, token, org} from './env'
+import {url, token, org, bucket} from './env'
 
 const queryApi = new InfluxDB({url, token}).getQueryApi(org)
 const start = fluxDuration('-1m')
 const measurement = 'temperature'
-const fluxQuery = flux`from(bucket:"my-bucket") 
+const fluxQuery = flux`from(bucket:"${bucket || 'my-bucket'}") 
   |> range(start: ${start}) 
   |> filter(fn: (r) => r._measurement == ${measurement})`
 console.log('query:', fluxQuery)


### PR DESCRIPTION
## Proposed Changes

Use the configured bucket from .env files in query examples.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
