### PR TITLE
fix: explanation of bucket configuration in browser examples.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -27,8 +27,7 @@ This directory contains javascript and typescript examples for node.js, browser,
   - [writeAdvanced.js](./writeAdvanced.js)
     Shows how to control the way of how data points are written to InfluxDB.
 - Browser examples
-  - Change `url` in [env.js](./env.js) to match your influxDB instance
-  - Change `token, org, bucket, username, password` variables in [./env_browser.js](env_browser.js) to match your influxDB instance
+  - Change `token, org, bucket, username, password` variables in [./env_browser.js](env_browser.js) to match your InfluxDB instance
   - Run `npm run browser`
     It starts a local HTTP server and opens [index.html](./index.html) that contains client examples.
     The local HTTP server serves all files from this git repository and also proxies requests

--- a/examples/env_browser.js
+++ b/examples/env_browser.js
@@ -1,16 +1,23 @@
 // eslint-disable-next-line no-undef
+/** 
+ * The following configuration is used in the browser examples
+ * (index.html and giraffe.html).
+ *
+ * Replace the values with your own InfluxDB values.
+ */
 window.INFLUX_ENV = {
   /** InfluxDB v2 URL, '/influxdb' relies upon proxy to forward to the target influxDB */
-  url: '/influx', //'http://localhost:8086'
+  url: '/influx', //'http://localhost:8086',
   /** InfluxDB authorization token */
   token: 'my-token',
-  /** Organization within InfluxDB  */
+  /** InfluxDB organization */
   org: 'my-org',
-  /**InfluxDB bucket used in examples  */
+  /** InfluxDB bucket used for onboarding and write requests. */
   bucket: 'my-bucket',
-  // ONLY onboarding example
-  /**InfluxDB user  */
+
+  /** The following properties are used ONLY in the onboarding example */
+  /** InfluxDB user  */
   username: 'my-user',
-  /**InfluxDB password  */
+  /** InfluxDB password  */
   password: 'my-password',
 }

--- a/examples/index.html
+++ b/examples/index.html
@@ -9,7 +9,12 @@
       // import {InfluxDB, Point} from '../packages/core/dist/index.browser.mjs'
       // import {HealthAPI, SetupAPI} from '../packages/apis/dist/index.browser.mjs'
 
-      // ./env_browser.js defines window.INFLUX_ENV with client configuration variables
+      /**
+        * Import the configuration from ./env_browser.js.
+        * The property INFLUX_ENV.bucket is only used in onboardingExample() and writeExample().
+        * To prevent SQL injection attacks, the variable is not used within the Flux query examples.
+        * The query examples assume your InfluxDB bucket is named "my-bucket".
+        */
       import './env_browser.js'
       const {url, token, org, bucket, username, password} = window.INFLUX_ENV
 


### PR DESCRIPTION
## Proposed Changes
Explain where configured bucket is used, and why it's not, in browser examples.
Remove instruction to configure env.js for browser examples.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
