### PR TITLE
feat(core): allow following HTTP redirects in node.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## 1.18.0 [unreleased]
 
+### Features
+
+1. [#365](https://github.com/influxdata/influxdb-client-js/pull/365): Allow following HTTP redirects in node.js.
+
 ## 1.17.0 [2021-08-25]
+
+### Features
 
 1. [#362](https://github.com/influxdata/influxdb-client-js/pull/362): Regenerate APIs from swagger.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -26,6 +26,8 @@ This directory contains javascript and typescript examples for node.js, browser,
     Use [RxJS](https://rxjs.dev/) to query InfluxDB with [Flux](https://v2.docs.influxdata.com/v2.0/query-data/get-started/).
   - [writeAdvanced.js](./writeAdvanced.js)
     Shows how to control the way of how data points are written to InfluxDB.
+  - [follow-redirects.js](./follow-redirects.js)
+    Shows how to configure the client to follow HTTP redirects.
 - Browser examples
   - Change `token, org, bucket, username, password` variables in [./env_browser.js](env_browser.js) to match your InfluxDB instance
   - Run `npm run browser`

--- a/examples/follow-redirects.js
+++ b/examples/follow-redirects.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+/////////////////////////////////////////////////////////////////////////
+// Shows how to configure InfluxDB node.js client to follow redirects. //
+/////////////////////////////////////////////////////////////////////////
+
+const {url: targetUrl, token, org} = require('./env')
+// const {InfluxDB} = require('@influxdata/influxdb-client')
+const {InfluxDB} = require('../packages/core')
+
+// start a simple HTTP server that always redirects to a configured InfluxDB
+const http = require('http')
+const server = http.createServer((req, res) => {
+  const reqUrl = new URL(req.url, `http://${req.headers.host}`)
+  console.info(`Redirecting ${req.method} ${reqUrl} to ${targetUrl + req.url}`)
+  res.writeHead(307, {location: targetUrl + req.url})
+  res.end()
+})
+server.listen(0, 'localhost', () => {
+  const addressInfo = server.address()
+  console.info('Redirection HTTP server started:', addressInfo)
+
+  const url = `http://localhost:${addressInfo.port}`
+  console.info('Executing buckets() query against InfluxDB at', url)
+  const queryApi = new InfluxDB({
+    url,
+    token,
+    transportOptions: {
+      // The following transport option is required in order to follow HTTP redirects in node.js.
+      // Browsers and deno follow redirects OOTB.
+      'follow-redirects': require('follow-redirects'),
+    },
+  }).getQueryApi(org)
+  queryApi
+    .collectRows('buckets()')
+    .then(data => {
+      console.info('Available buckets:')
+      data.forEach(x => console.info('', x.name))
+      console.log('\nQuery SUCCESS')
+    })
+    .catch(error => {
+      console.error(error)
+      console.log('\nQuery ERROR')
+    })
+    .finally(() => {
+      server.close()
+    })
+})

--- a/examples/package.json
+++ b/examples/package.json
@@ -19,6 +19,7 @@
     "@types/express-http-proxy": "^1.5.12",
     "express": "^4.17.1",
     "express-http-proxy": "^1.6.0",
+    "follow-redirects": "^1.14.3",
     "open": "^7.0.0",
     "response-time": "^2.3.2",
     "rxjs": "^6.5.5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,6 +65,7 @@
     "eslint-config-prettier": "^6.7.0",
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-tsdoc": "^0.2.6",
+    "follow-redirects": "^1.14.3",
     "mocha": "^6.2.2",
     "mocha-junit-reporter": "^1.23.1",
     "nock": "^11.7.0",

--- a/packages/core/src/impl/node/NodeHttpTransport.ts
+++ b/packages/core/src/impl/node/NodeHttpTransport.ts
@@ -79,10 +79,10 @@ export class NodeHttpTransport implements Transport {
 
     if (url.protocol === 'http:') {
       this.requestApi =
-        this.defaultOptions['follow-redirects']?.http ?? http.request
+        this.defaultOptions['follow-redirects']?.http?.request ?? http.request
     } else if (url.protocol === 'https:') {
       this.requestApi =
-        this.defaultOptions['follow-redirects']?.https ?? https.request
+        this.defaultOptions['follow-redirects']?.https?.request ?? https.request
     } else {
       throw new Error(
         `Unsupported protocol "${url.protocol} in URL: "${connectionOptions.url}"`

--- a/packages/core/src/impl/node/NodeHttpTransport.ts
+++ b/packages/core/src/impl/node/NodeHttpTransport.ts
@@ -78,9 +78,11 @@ export class NodeHttpTransport implements Transport {
     }
 
     if (url.protocol === 'http:') {
-      this.requestApi = http.request
+      this.requestApi =
+        this.defaultOptions['follow-redirects']?.http ?? http.request
     } else if (url.protocol === 'https:') {
-      this.requestApi = https.request
+      this.requestApi =
+        this.defaultOptions['follow-redirects']?.https ?? https.request
     } else {
       throw new Error(
         `Unsupported protocol "${url.protocol} in URL: "${connectionOptions.url}"`

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -19,6 +19,9 @@ export interface ConnectionOptions {
    * {@link https://www.npmjs.com/package/proxy-http-agent | setup HTTP/HTTPS proxy }
    * in node.js, or a `signal` property that can stop ongoing requests using
    * {@link https://nodejs.org/api/http.html#http_http_request_url_options_callback }.
+   * {@link https://github.com/follow-redirects/follow-redirects | follow-redirects} property can be specified
+   * in order to follow redirects in node.js. Redirects are followed OOTB in browser or deno,
+   * {@link https://developer.mozilla.org/en-US/docs/Web/API/fetch | redirect} property can customize it.
    */
   transportOptions?: {[key: string]: any}
 }

--- a/packages/core/test/unit/Influxdb.test.ts
+++ b/packages/core/test/unit/Influxdb.test.ts
@@ -84,6 +84,23 @@ describe('InfluxDB', () => {
         } as any) as ClientOptions)
       ).has.property('transport')
     })
+    it('creates instance with follow-redirects', () => {
+      const request = (): void => {}
+      const followRedirects = {
+        https: {request},
+      }
+      expect(
+        new InfluxDB({
+          url: 'https://localhost:8086',
+          transportOptions: {
+            'follow-redirects': followRedirects,
+          },
+        })
+      )
+        .has.property('transport')
+        .has.property('requestApi')
+        .is.equal(request)
+    })
   })
   describe('apis', () => {
     const influxDb = new InfluxDB('http://localhost:8086?token=a')

--- a/yarn.lock
+++ b/yarn.lock
@@ -3162,6 +3162,11 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+follow-redirects@^1.14.3:
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.3.tgz#6ada78118d8d24caee595595accdc0ac6abd022e"
+  integrity sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw==
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -4773,7 +4778,7 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@>=1.2.2, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
+minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==


### PR DESCRIPTION
This PR allows configuring the client to use 'follow-redirects' node.js library in order to follow redirects in communication with InfluxDB. Tests, docs, and an example are included.

## Proposed Changes

_Briefly describe your proposed changes:_

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
