### PR TITLE
chore(ci): switch to next-gen CircleCI's convenience images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,13 @@ commands:
       - restore_cache:
           name: Restore Yarn Package Cache
           keys:
-            - yarn-packages-{{ checksum "yarn.lock" }}
+            - yarn-packages-v2-{{ checksum "yarn.lock" }}
       - run:
           name: Install Dependencies
           command: yarn install --frozen-lockfile
       - save_cache:
           name: Save Yarn Package Cache
-          key: yarn-packages-{{ checksum "yarn.lock" }}
+          key: yarn-packages-v2-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,11 @@ commands:
 jobs:
   tests:
     parameters:
-      version:
+      image:
         type: string
+        default: &default-image "cimg/node:14.17.6"
     docker:
-      - image: circleci/node:<< parameters.version >>
+      - image: << parameters.image >>
     steps:
       - checkout
       - init-dependencies
@@ -38,7 +39,7 @@ jobs:
   coverage:
     parameters:
     docker:
-      - image: circleci/node:14
+      - image: *default-image
     steps:
       - checkout
       - init-dependencies
@@ -57,7 +58,7 @@ jobs:
   deploy-preview:
     parameters:
     docker:
-      - image: circleci/node:14
+      - image: *default-image
     steps:
       - run:
           name: Early return if this build is from a forked repository
@@ -79,7 +80,6 @@ workflows:
   build:
     jobs:
       - tests:
-          version: '14'
           filters:
             branches:
               ignore: gh-pages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 1. [#365](https://github.com/influxdata/influxdb-client-js/pull/365): Allow following HTTP redirects in node.js.
 
+### CI
+1. [#366](https://github.com/influxdata/influxdb-client-js/pull/366): Switch to next-gen CircleCI's convenience images
+
 ## 1.17.0 [2021-08-25]
 
 ### Features


### PR DESCRIPTION
## Proposed Changes

The current images are deprecated and no longer supported:

- https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034?mkt_tok=NDg1LVpNSC02MjYAAAF_aZ4aQBMMtwIJatxoGz4de_IMPoNZJOUAhbHY2j7KD_4fR38oMpf0qFjUBd15_QNaVKiHbjM5WE0emhPAvcNcagGm1rnILLJptARAtBWPhtQ
- https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
