### PR TITLE
fix(core): throw error when int/uint/float point field is out of range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.19.0 [unreleased]
 
+### Bug Fixes
+
+1. [#370](https://github.com/influxdata/influxdb-client-js/pull/370): Throw error when int/unit/float point field is out of range.
+
 ## 1.18.0 [2021-09-17]
 
 ### Features
@@ -7,6 +11,7 @@
 1. [#365](https://github.com/influxdata/influxdb-client-js/pull/365): Allow following HTTP redirects in node.js.
 
 ### CI
+
 1. [#366](https://github.com/influxdata/influxdb-client-js/pull/366): Switch to next-gen CircleCI's convenience images
 
 ## 1.17.0 [2021-08-25]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug Fixes
 
-1. [#370](https://github.com/influxdata/influxdb-client-js/pull/370): Throw error when int/unit/float point field is out of range.
+1. [#370](https://github.com/influxdata/influxdb-client-js/pull/370): Throw error when int/uint/float point field is out of range.
 
 ## 1.18.0 [2021-09-17]
 

--- a/packages/core/src/Point.ts
+++ b/packages/core/src/Point.ts
@@ -101,7 +101,7 @@ export class Point {
    */
   public uintField(name: string, value: number | any): Point {
     if (typeof value === 'number') {
-      if (value < 0 || value > Number.MAX_SAFE_INTEGER) {
+      if (isNaN(value) || value < 0 || value > Number.MAX_SAFE_INTEGER) {
         throw new Error(`uint value for field '${name}' out of range: ${value}`)
       }
       this.fields[name] = `${Math.floor(value as number)}u`

--- a/packages/core/src/Point.ts
+++ b/packages/core/src/Point.ts
@@ -75,6 +75,7 @@ export class Point {
    * @param name - field name
    * @param value - field value
    * @returns this
+   * @throws NaN or out of int64 range value is supplied
    */
   public intField(name: string, value: number | any): Point {
     let val: number
@@ -96,6 +97,7 @@ export class Point {
    * @param name - field name
    * @param value - field value
    * @returns this
+   * @throws NaN out of range value is supplied
    */
   public uintField(name: string, value: number | any): Point {
     if (typeof value === 'number') {
@@ -133,6 +135,7 @@ export class Point {
    * @param name - field name
    * @param value - field value
    * @returns this
+   * @throws NaN/Infinity/-Infinity is supplied
    */
   public floatField(name: string, value: number | any): Point {
     let val: number

--- a/packages/core/src/Point.ts
+++ b/packages/core/src/Point.ts
@@ -84,9 +84,7 @@ export class Point {
       val = parseInt(String(value))
     }
     if (isNaN(val) || val <= -9223372036854776e3 || val >= 9223372036854776e3) {
-      throw new Error(
-        `integer value for field '${name}' out of range: '${value}'!`
-      )
+      throw new Error(`invalid integer value for field '${name}': '${value}'!`)
     }
     this.fields[name] = `${Math.floor(val)}i`
     return this
@@ -137,16 +135,17 @@ export class Point {
    * @returns this
    */
   public floatField(name: string, value: number | any): Point {
-    if (typeof value !== 'number') {
-      let val: number
-      if (isNaN((val = parseFloat(value)))) {
-        throw new Error(
-          `Expected float value for field ${name}, but got '${value}'!`
-        )
-      }
-      value = val
+    let val: number
+    if (typeof value === 'number') {
+      val = value
+    } else {
+      val = parseFloat(value)
     }
-    this.fields[name] = String(value)
+    if (!isFinite(val)) {
+      throw new Error(`invalid float value for field '${name}': ${value}`)
+    }
+
+    this.fields[name] = String(val)
     return this
   }
 

--- a/packages/core/src/Point.ts
+++ b/packages/core/src/Point.ts
@@ -77,16 +77,18 @@ export class Point {
    * @returns this
    */
   public intField(name: string, value: number | any): Point {
-    if (typeof value !== 'number') {
-      let val: number
-      if (isNaN((val = parseInt(String(value))))) {
-        throw new Error(
-          `Expected integer value for field ${name}, but got '${value}'!`
-        )
-      }
-      value = val
+    let val: number
+    if (typeof value === 'number') {
+      val = value
+    } else {
+      val = parseInt(String(value))
     }
-    this.fields[name] = `${Math.floor(value as number)}i`
+    if (isNaN(val) || val <= -9223372036854776e3 || val >= 9223372036854776e3) {
+      throw new Error(
+        `expected integer value for field ${name}, but got '${value}'!`
+      )
+    }
+    this.fields[name] = `${Math.floor(val)}i`
     return this
   }
 

--- a/packages/core/src/Point.ts
+++ b/packages/core/src/Point.ts
@@ -85,7 +85,7 @@ export class Point {
     }
     if (isNaN(val) || val <= -9223372036854776e3 || val >= 9223372036854776e3) {
       throw new Error(
-        `expected integer value for field ${name}, but got '${value}'!`
+        `integer value for field '${name}' out of range: '${value}'!`
       )
     }
     this.fields[name] = `${Math.floor(val)}i`
@@ -102,7 +102,7 @@ export class Point {
   public uintField(name: string, value: number | any): Point {
     if (typeof value === 'number') {
       if (value < 0 || value > Number.MAX_SAFE_INTEGER) {
-        throw new Error(`uint value out of js unsigned integer range: ${value}`)
+        throw new Error(`uint value for field '${name}' out of range: ${value}`)
       }
       this.fields[name] = `${Math.floor(value as number)}u`
     } else {
@@ -120,7 +120,9 @@ export class Point {
         (strVal.length === 20 &&
           strVal.localeCompare('18446744073709551615') > 0)
       ) {
-        throw new Error(`uint value out of range: ${strVal}`)
+        throw new Error(
+          `uint value for field '${name}' out of range: ${strVal}`
+        )
       }
       this.fields[name] = `${strVal}u`
     }

--- a/packages/core/test/fixture/pointTables.json
+++ b/packages/core/test/fixture/pointTables.json
@@ -67,7 +67,7 @@
   {
     "name": "m6",
     "fields": [["a", "i"]],
-    "throws": "Expected integer"
+    "throws": "expected integer"
   },
   {
     "name": "m7",

--- a/packages/core/test/fixture/pointTables.json
+++ b/packages/core/test/fixture/pointTables.json
@@ -67,7 +67,7 @@
   {
     "name": "m6",
     "fields": [["a", "i"]],
-    "throws": "expected integer"
+    "throws": "out of range"
   },
   {
     "name": "m7",
@@ -141,12 +141,12 @@
   {
     "name": "uintNegativeNumber",
     "fields": [["f", "u", -1]],
-    "throws": "uint value out of js unsigned integer range: -1"
+    "throws": "uint value for field 'f' out of range: -1"
   },
   {
     "name": "uintTooLargeNumber",
     "fields": [["f", "u", 9007199254740992]],
-    "throws": "uint value out of js unsigned integer range: 9007199254740992"
+    "throws": "uint value for field 'f' out of range: 9007199254740992"
   },
   {
     "name": "uintNegativeString",
@@ -156,6 +156,6 @@
   {
     "name": "uintTooLargeString",
     "fields": [["f", "u", "18446744073709551616"]],
-    "throws": "uint value out of range: 18446744073709551616"
+    "throws": "uint value for field 'f' out of range: 18446744073709551616"
   }
 ]

--- a/packages/core/test/fixture/pointTables.json
+++ b/packages/core/test/fixture/pointTables.json
@@ -67,12 +67,12 @@
   {
     "name": "m6",
     "fields": [["a", "i"]],
-    "throws": "out of range"
+    "throws": "invalid integer"
   },
   {
     "name": "m7",
     "fields": [["a", "n"]],
-    "throws": "Expected float"
+    "throws": "invalid float"
   },
   {
     "name": "m8",

--- a/packages/core/test/unit/Point.test.ts
+++ b/packages/core/test/unit/Point.test.ts
@@ -154,4 +154,11 @@ describe('Point', () => {
     expect(() => new Point().intField('a', -9223372036854776e3)).throws()
     expect(() => new Point().intField('a', 9223372036854776e3)).throws()
   })
+  it('throws when invalid uintField is supplied', () => {
+    expect(() => new Point().uintField('a', NaN)).throws()
+    expect(() => new Point().uintField('a', Infinity)).throws()
+    expect(() => new Point().uintField('a', -Infinity)).throws()
+    expect(() => new Point().uintField('a', Number.MAX_VALUE)).throws()
+    expect(() => new Point().uintField('a', -1)).throws()
+  })
 })

--- a/packages/core/test/unit/Point.test.ts
+++ b/packages/core/test/unit/Point.test.ts
@@ -147,4 +147,11 @@ describe('Point', () => {
       expect(point.toLineProtocol()).equals('tst a=1 any')
     })
   })
+  it('throws when invalid intField is supplied', () => {
+    expect(() => new Point().intField('a', NaN)).throws()
+    expect(() => new Point().intField('a', Infinity)).throws()
+    expect(() => new Point().intField('a', -Infinity)).throws()
+    expect(() => new Point().intField('a', -9223372036854776e3)).throws()
+    expect(() => new Point().intField('a', 9223372036854776e3)).throws()
+  })
 })

--- a/packages/core/test/unit/Point.test.ts
+++ b/packages/core/test/unit/Point.test.ts
@@ -161,4 +161,9 @@ describe('Point', () => {
     expect(() => new Point().uintField('a', Number.MAX_VALUE)).throws()
     expect(() => new Point().uintField('a', -1)).throws()
   })
+  it('throws when invalid float is supplied', () => {
+    expect(() => new Point().floatField('a', NaN)).throws()
+    expect(() => new Point().floatField('a', Infinity)).throws()
+    expect(() => new Point().floatField('a', -Infinity)).throws()
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4778,7 +4778,7 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
+minimist@>=1.2.2, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==


### PR DESCRIPTION
Fixes #369

Point's intField/uintField/floatField newly throws when out-of-range or NaN value is supplied. 


<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
