### PR TITLE
chore(core): rename internal Logger to Log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.21.0 [unreleased]
 
+### Bug Fixes
+
+1. [#382](https://github.com/influxdata/influxdb-client-js/pull/382): Rename Logger variable to Log.
+
 ## 1.20.0 [2021-10-26]
 
 ### Features

--- a/packages/core/src/impl/RetryBuffer.ts
+++ b/packages/core/src/impl/RetryBuffer.ts
@@ -1,4 +1,4 @@
-import {Logger} from '../util/logger'
+import {Log} from '../util/logger'
 
 /* interval between successful retries */
 const RETRY_INTERVAL = 1
@@ -57,7 +57,7 @@ export default class RetryBuffer {
           this.last = undefined
         }
       } while (this.first && this.size + lines.length > newSize)
-      Logger.error(
+      Log.error(
         `RetryBuffer: ${origSize -
           this
             .size} oldest lines removed to keep buffer size under the limit of ${

--- a/packages/core/src/impl/WriteApiImpl.ts
+++ b/packages/core/src/impl/WriteApiImpl.ts
@@ -6,7 +6,7 @@ import {
 } from '../options'
 import {Transport, SendOptions} from '../transport'
 import {Headers} from '../results'
-import {Logger} from '../util/logger'
+import {Log} from '../util/logger'
 import {HttpError, RetryDelayStrategy} from '../errors'
 import {Point} from '../Point'
 import {escape} from '../util/escape'
@@ -141,7 +141,7 @@ export default class WriteApiImpl implements WriteApi {
     if (!this.closed && lines.length > 0) {
       if (expires <= Date.now()) {
         const error = new Error('Max retry time exceeded.')
-        Logger.error(
+        Log.error(
           `Write to InfluxDB failed (attempt: ${failedAttempts}).`,
           error
         )
@@ -171,7 +171,7 @@ export default class WriteApiImpl implements WriteApi {
               (!(error instanceof HttpError) ||
                 (error as HttpError).statusCode >= 429)
             ) {
-              Logger.warn(
+              Log.warn(
                 `Write to InfluxDB failed (attempt: ${failedAttempts}).`,
                 error
               )
@@ -184,7 +184,7 @@ export default class WriteApiImpl implements WriteApi {
               reject(error)
               return
             }
-            Logger.error(`Write to InfluxDB failed.`, error)
+            Log.error(`Write to InfluxDB failed.`, error)
             reject(error)
           },
           complete(): void {
@@ -265,7 +265,7 @@ export default class WriteApiImpl implements WriteApi {
     const retVal = this.writeBuffer.flush().finally(() => {
       const remaining = this.retryBuffer.close()
       if (remaining) {
-        Logger.error(
+        Log.error(
           `Retry buffer closed with ${remaining} items that were not written to InfluxDB!`,
           null
         )

--- a/packages/core/src/impl/browser/FetchTransport.ts
+++ b/packages/core/src/impl/browser/FetchTransport.ts
@@ -2,7 +2,7 @@ import {Transport, SendOptions} from '../../transport'
 import {ConnectionOptions} from '../../options'
 import {HttpError} from '../../errors'
 import completeCommunicationObserver from '../completeCommunicationObserver'
-import {Logger} from '../../util/logger'
+import {Log} from '../../util/logger'
 import {
   ChunkCombiner,
   CommunicationObserver,
@@ -50,7 +50,7 @@ export default class FetchTransport implements Transport {
     // don't allow /api/v2 suffix to avoid future problems
     if (this.url.endsWith('/api/v2')) {
       this.url = this.url.substring(0, this.url.length - '/api/v2'.length)
-      Logger.warn(
+      Log.warn(
         `Please remove '/api/v2' context path from InfluxDB base url, using ${this.url} !`
       )
     }
@@ -109,7 +109,7 @@ export default class FetchTransport implements Transport {
               )
             })
             .catch((e: Error) => {
-              Logger.warn('Unable to receive error body', e)
+              Log.warn('Unable to receive error body', e)
               observer.error(
                 new HttpError(
                   response.status,

--- a/packages/core/src/impl/node/NodeHttpTransport.ts
+++ b/packages/core/src/impl/node/NodeHttpTransport.ts
@@ -16,7 +16,7 @@ import nodeChunkCombiner from './nodeChunkCombiner'
 import zlib from 'zlib'
 import completeCommunicationObserver from '../completeCommunicationObserver'
 import {CLIENT_LIB_VERSION} from '../version'
-import {Logger} from '../../util/logger'
+import {Log} from '../../util/logger'
 
 const zlibOptions = {
   flush: zlib.constants.Z_SYNC_FLUSH,
@@ -71,7 +71,7 @@ export class NodeHttpTransport implements Transport {
     // https://github.com/influxdata/influxdb-client-js/issues/263
     // don't allow /api/v2 suffix to avoid future problems
     if (this.contextPath == '/api/v2') {
-      Logger.warn(
+      Log.warn(
         `Please remove '/api/v2' context path from InfluxDB base url, using ${url.protocol}//${url.hostname}:${url.port} !`
       )
       this.contextPath = ''

--- a/packages/core/src/util/logger.ts
+++ b/packages/core/src/util/logger.ts
@@ -21,7 +21,7 @@ export const consoleLogger: Logger = {
 }
 let provider: Logger = consoleLogger
 
-export const Logger: Logger = {
+export const Log: Logger = {
   error(message, error) {
     provider.error(message, error)
   },

--- a/packages/core/test/unit/WriteApi.test.ts
+++ b/packages/core/test/unit/WriteApi.test.ts
@@ -12,7 +12,7 @@ import {
   PointSettings,
 } from '../../src'
 import {collectLogging, CollectedLogs} from '../util'
-import {Logger} from '../../src/util/logger'
+import {Log} from '../../src/util/logger'
 import {waitForCondition} from './util/waitForCondition'
 import zlib from 'zlib'
 
@@ -189,7 +189,7 @@ describe('WriteApi', () => {
         maxRetries: 3,
         batchSize: 1,
         writeFailed: (error: Error, lines: string[], attempts: number) => {
-          Logger.warn(
+          Log.warn(
             `CUSTOMERRORHANDLING ${!!error} ${lines.length} ${attempts}`,
             undefined
           )

--- a/packages/core/test/unit/util/logger.test.ts
+++ b/packages/core/test/unit/util/logger.test.ts
@@ -1,5 +1,5 @@
 import {expect} from 'chai'
-import {Logger, setLogger, consoleLogger} from '../../../src/util/logger'
+import {Log, setLogger, consoleLogger} from '../../../src/util/logger'
 
 describe('Logger', () => {
   ;[{message: '    hey', error: 'you'}, {message: '    hey'}].forEach(data => {
@@ -15,7 +15,7 @@ describe('Logger', () => {
           consoleLogger.warn(message, error)
         },
       })
-      Logger.error.call(Logger, data.message, data.error)
+      Log.error.call(Log, data.message, data.error)
       expect(args).to.be.deep.equal([data.message, data.error])
     })
     it(`uses custom logger's warn (${Object.keys(data).length})`, () => {
@@ -31,7 +31,7 @@ describe('Logger', () => {
         },
       })
 
-      Logger.warn.call(Logger, data.message, data.error)
+      Log.warn.call(Log, data.message, data.error)
       expect(args).to.be.deep.equal([data.message, data.error])
     })
   })


### PR DESCRIPTION
Fixes #381 , renames `Logger` variable to `Log` in order to avoid conflicts with `Logger` interface in the generated documentation.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
