### PR TITLE
fix(core): do not parse empty JSON response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 1. [#382](https://github.com/influxdata/influxdb-client-js/pull/382): Rename Logger variable to Log.
 1. [#383](https://github.com/influxdata/influxdb-client-js/pull/383): Remove undefined fields from request options.
+1. [#386](https://github.com/influxdata/influxdb-client-js/pull/386): Do not parse empty JSON response.
 
 ## 1.20.0 [2021-10-26]
 

--- a/packages/core/src/impl/node/NodeHttpTransport.ts
+++ b/packages/core/src/impl/node/NodeHttpTransport.ts
@@ -161,7 +161,11 @@ export class NodeHttpTransport implements Transport {
           const responseType = options.headers?.accept ?? contentType
           try {
             if (responseType.includes('json')) {
-              resolve(JSON.parse(buffer.toString('utf8')))
+              if (buffer.length) {
+                resolve(JSON.parse(buffer.toString('utf8')))
+              } else {
+                resolve(undefined)
+              }
             } else if (
               responseType.includes('text') ||
               responseType.startsWith('application/csv')

--- a/packages/core/src/impl/node/NodeHttpTransport.ts
+++ b/packages/core/src/impl/node/NodeHttpTransport.ts
@@ -146,6 +146,7 @@ export class NodeHttpTransport implements Transport {
     }
     let buffer = emptyBuffer
     let contentType: string
+    let responseStatusCode: number | undefined
     return new Promise((resolve, reject) => {
       this.send(path, body as string, options, {
         responseStarted(headers: Headers, statusCode?: number) {
@@ -153,6 +154,7 @@ export class NodeHttpTransport implements Transport {
             responseStarted(headers, statusCode)
           }
           contentType = String(headers['content-type'])
+          responseStatusCode = statusCode
         },
         next: (data: Uint8Array): void => {
           buffer = Buffer.concat([buffer, data])
@@ -160,6 +162,10 @@ export class NodeHttpTransport implements Transport {
         complete: (): void => {
           const responseType = options.headers?.accept ?? contentType
           try {
+            if (responseStatusCode === 204) {
+              // ignore body of NO_CONTENT response
+              resolve(undefined)
+            }
             if (responseType.includes('json')) {
               if (buffer.length) {
                 resolve(JSON.parse(buffer.toString('utf8')))

--- a/packages/core/test/unit/impl/node/NodeHttpTransport.test.ts
+++ b/packages/core/test/unit/impl/node/NodeHttpTransport.test.ts
@@ -751,5 +751,20 @@ describe('NodeHttpTransport', () => {
           () => true // OK that it fails
         )
     })
+    it(`return undefined when empty JSON message is received`, async () => {
+      nock(transportOptions.url)
+        .get('/test')
+        .reply(200, '', {
+          'content-type': 'application/json',
+        })
+        .persist()
+      const data = await new NodeHttpTransport({
+        ...transportOptions,
+        timeout: 10000,
+      }).request('/test', '', {
+        method: 'GET',
+      })
+      expect(data).equals(undefined)
+    })
   })
 })

--- a/packages/core/test/unit/impl/node/NodeHttpTransport.test.ts
+++ b/packages/core/test/unit/impl/node/NodeHttpTransport.test.ts
@@ -766,5 +766,20 @@ describe('NodeHttpTransport', () => {
       })
       expect(data).equals(undefined)
     })
+    it(`return undefined with 204 status code`, async () => {
+      nock(transportOptions.url)
+        .get('/test')
+        .reply(204, 'whatever it is', {
+          'content-type': 'text/plain',
+        })
+        .persist()
+      const data = await new NodeHttpTransport({
+        ...transportOptions,
+        timeout: 10000,
+      }).request('/test', '', {
+        method: 'GET',
+      })
+      expect(data).equals(undefined)
+    })
   })
 })


### PR DESCRIPTION
Fixes #385 . The root cause is that InfluxDB server responds with "application/json" content type, 204 HTTP status and an empty body. An empty body then cannot parsed as JSON.

## Proposed Changes

When an empty body with an `application/json` content type recived, `undefined` is returned as a response body.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
