### PR TITLE
fix(core): repair double-escaping of default tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 1. [#383](https://github.com/influxdata/influxdb-client-js/pull/383): Remove undefined fields from request options.
 1. [#386](https://github.com/influxdata/influxdb-client-js/pull/386): Do not parse empty JSON response.
 1. [#388](https://github.com/influxdata/influxdb-client-js/pull/388): Point to InfluxDB v2.1 / cloud documentation.
+1. [#392](https://github.com/influxdata/influxdb-client-js/pull/392): Repair double-escaping of default tags.
 
 ## 1.20.0 [2021-10-26]
 

--- a/packages/core/src/impl/WriteApiImpl.ts
+++ b/packages/core/src/impl/WriteApiImpl.ts
@@ -9,7 +9,6 @@ import {Headers} from '../results'
 import {Log} from '../util/logger'
 import {HttpError, RetryDelayStrategy} from '../errors'
 import {Point} from '../Point'
-import {escape} from '../util/escape'
 import {currentTime, dateToProtocolTimestamp} from '../util/currentTime'
 import {createRetryDelayStrategy} from './retryStrategy'
 import RetryBuffer from './RetryBuffer'
@@ -283,12 +282,7 @@ export default class WriteApiImpl implements WriteApi {
   // PointSettings
   defaultTags: {[key: string]: string} | undefined
   useDefaultTags(tags: {[key: string]: string}): WriteApi {
-    this.defaultTags = undefined
-    Object.keys(tags).forEach((key: string) => {
-      ;(this.defaultTags || (this.defaultTags = {}))[key] = escape.tag(
-        tags[key]
-      )
-    })
+    this.defaultTags = tags
     return this
   }
   convertTime(value: string | number | Date | undefined): string | undefined {

--- a/packages/core/test/unit/WriteApi.test.ts
+++ b/packages/core/test/unit/WriteApi.test.ts
@@ -257,6 +257,37 @@ describe('WriteApi', () => {
       })
     })
   })
+  describe('convert default tags to line protocol', () => {
+    it('works with tags OOTB', () => {
+      const writeAPI = createApi(ORG, BUCKET, 'ms', {
+        retryJitter: 0,
+      })
+      const p = new Point('a').floatField('b', 1).timestamp('')
+      expect(p.toLineProtocol(writeAPI)).equals('a b=1')
+    })
+    it('setups tags using useDefaultTags ', () => {
+      const writeAPI = createApi(ORG, BUCKET, 'ms', {
+        retryJitter: 0,
+      })
+      const p = new Point('a').floatField('b', 1).timestamp('')
+      writeAPI.useDefaultTags({
+        x: 'y z',
+        'a b': 'c',
+      })
+      expect(p.toLineProtocol(writeAPI)).equals('a,a\\ b=c,x=y\\ z b=1')
+    })
+    it('setups tags from configuration', () => {
+      const writeAPI = createApi(ORG, BUCKET, 'ms', {
+        retryJitter: 0,
+        defaultTags: {
+          x: 'y z',
+          'a b': 'c',
+        },
+      })
+      const p = new Point('a').floatField('b', 1).timestamp('')
+      expect(p.toLineProtocol(writeAPI)).equals('a,a\\ b=c,x=y\\ z b=1')
+    })
+  })
   describe('flush on background', () => {
     let subject: WriteApi
     let logs: CollectedLogs


### PR DESCRIPTION
Fixes #391 -  avoid double-escaping of default tags

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] `yarn test` completes successfully
- [ ] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
