### PR TITLE
feat(core): node.js builtin-proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 1.22.0 [unreleased]
 
+### Features
+
+1. [#395](https://github.com/influxdata/influxdb-client-js/pull/395): Allow to add extra HTTP headers.
+1. [#395](https://github.com/influxdata/influxdb-client-js/pull/395): Allow to setup HTTP proxy for node.js.
+
 ## 1.21.0 [2021-11-26]
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ See [examples](./examples/README.md) for more advanced use case like the followi
 - Process InfluxDB query results with RX Observables.
 - Customize the writing of measurement points to InfluxDB.
 - Visualize query results in [Giraffe](https://github.com/influxdata/giraffe).
-- [Setup HTTP/HTTPS proxy](https://github.com/influxdata/influxdb-client-js/issues/319#issuecomment-808154245) in communication with InfluxDB.
 - [Reuse connections](https://github.com/influxdata/influxdb-client-js/issues/393#issuecomment-985272866) in communication with InfluxDB.
 
 JavaScript client API Reference Documentation is available online at https://influxdata.github.io/influxdb-client-js/ .

--- a/packages/core/src/impl/browser/FetchTransport.ts
+++ b/packages/core/src/impl/browser/FetchTransport.ts
@@ -37,6 +37,7 @@ export default class FetchTransport implements Transport {
     this.defaultHeaders = {
       'content-type': 'application/json; charset=utf-8',
       // 'User-Agent': `influxdb-client-js/${CLIENT_LIB_VERSION}`, // user-agent can hardly be customized https://github.com/influxdata/influxdb-client-js/issues/262
+      ...connectionOptions.headers,
     }
     if (this.connectionOptions.token) {
       this.defaultHeaders['Authorization'] =

--- a/packages/core/src/impl/node/NodeHttpTransport.ts
+++ b/packages/core/src/impl/node/NodeHttpTransport.ts
@@ -56,11 +56,12 @@ export class NodeHttpTransport implements Transport {
   constructor(connectionOptions: ConnectionOptions) {
     const {
       url: _url,
+      proxyUrl,
       token,
       transportOptions,
       ...nodeSupportedOptions
     } = connectionOptions
-    const url = parse(_url)
+    const url = parse(proxyUrl || _url)
     this.token = token
     this.defaultOptions = {
       ...DEFAULT_ConnectionOptions,
@@ -70,7 +71,7 @@ export class NodeHttpTransport implements Transport {
       protocol: url.protocol,
       hostname: url.hostname,
     }
-    this.contextPath = url.path ?? ''
+    this.contextPath = proxyUrl ? _url : url.path ?? ''
     if (this.contextPath.endsWith('/')) {
       this.contextPath = this.contextPath.substring(
         0,
@@ -107,6 +108,9 @@ export class NodeHttpTransport implements Transport {
     this.headers = {
       'User-Agent': `influxdb-client-js/${CLIENT_LIB_VERSION}`,
       ...connectionOptions.headers,
+    }
+    if (proxyUrl) {
+      this.headers['host'] = parse(_url).host as string
     }
   }
 

--- a/packages/core/src/impl/node/NodeHttpTransport.ts
+++ b/packages/core/src/impl/node/NodeHttpTransport.ts
@@ -106,6 +106,7 @@ export class NodeHttpTransport implements Transport {
     }
     this.headers = {
       'User-Agent': `influxdb-client-js/${CLIENT_LIB_VERSION}`,
+      ...connectionOptions.headers,
     }
   }
 

--- a/packages/core/src/impl/node/NodeHttpTransport.ts
+++ b/packages/core/src/impl/node/NodeHttpTransport.ts
@@ -110,7 +110,7 @@ export class NodeHttpTransport implements Transport {
       ...connectionOptions.headers,
     }
     if (proxyUrl) {
-      this.headers['host'] = parse(_url).host as string
+      this.headers['Host'] = parse(_url).host as string
     }
   }
 

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -31,6 +31,10 @@ export interface ConnectionOptions {
    * Default HTTP headers to send with every request.
    */
   headers?: Record<string, string>
+  /**
+   * HTTP proxy URL
+   */
+  proxyUrl?: string
 }
 
 /** default connection options */

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -32,7 +32,7 @@ export interface ConnectionOptions {
    */
   headers?: Record<string, string>
   /**
-   * HTTP proxy URL
+   * Full HTTP web proxy URL including schema, for example http://your-proxy:8080.
    */
   proxyUrl?: string
 }

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -27,6 +27,10 @@ export interface ConnectionOptions {
    * {@link https://developer.mozilla.org/en-US/docs/Web/API/fetch | redirect } property can be set to 'error' to abort request if a redirect occurs.
    */
   transportOptions?: {[key: string]: any}
+  /**
+   * Default HTTP headers to send with every request.
+   */
+  headers?: Record<string, string>
 }
 
 /** default connection options */

--- a/packages/core/test/unit/impl/browser/FetchTransport.test.ts
+++ b/packages/core/test/unit/impl/browser/FetchTransport.test.ts
@@ -89,6 +89,27 @@ describe('FetchTransport', () => {
       })
       expect(response).is.deep.equal('{}')
     })
+    it('receives custom headers', async () => {
+      const transport = new FetchTransport({
+        url: 'http://test:8086',
+        headers: {extra: 'yes'},
+      })
+      let options: any
+      emulateFetchApi(
+        {
+          headers: {'content-type': 'text/plain'},
+          body: '{}',
+        },
+        opts => {
+          options = opts
+        }
+      )
+      const response = await transport.request('/whatever', '', {
+        method: 'GET',
+      })
+      expect(response).is.deep.equal('{}')
+      expect(options?.headers?.extra).equals('yes')
+    })
     it('allows to transform requests', async () => {
       let lastRequest: any
       emulateFetchApi(

--- a/packages/core/test/unit/impl/node/NodeHttpTransport.test.ts
+++ b/packages/core/test/unit/impl/node/NodeHttpTransport.test.ts
@@ -58,7 +58,6 @@ describe('NodeHttpTransport', () => {
         port: '8086',
         protocol: 'http:',
         timeout: 10000,
-        url: 'http://test:8086',
       })
       expect(transport.requestApi).to.equal(http.request)
     })
@@ -71,7 +70,6 @@ describe('NodeHttpTransport', () => {
         port: '8086',
         protocol: 'https:',
         timeout: 10000,
-        url: 'https://test:8086',
       })
       expect(transport.requestApi).to.equal(https.request)
     })
@@ -84,7 +82,6 @@ describe('NodeHttpTransport', () => {
         port: '8086',
         protocol: 'http:',
         timeout: 10000,
-        url: 'http://test:8086/influx',
       })
       expect(transport.contextPath).equals('/influx')
     })
@@ -97,7 +94,6 @@ describe('NodeHttpTransport', () => {
         port: '8086',
         protocol: 'http:',
         timeout: 10000,
-        url: 'http://test:8086/influx/',
       })
       expect(transport.contextPath).equals('/influx')
     })
@@ -131,7 +127,6 @@ describe('NodeHttpTransport', () => {
         hostname: 'test',
         port: '8086',
         protocol: 'http:',
-        url: 'http://test:8086',
       })
       expect(transport.requestApi).to.equal(http.request)
     })

--- a/packages/core/test/unit/impl/node/NodeHttpTransport.test.ts
+++ b/packages/core/test/unit/impl/node/NodeHttpTransport.test.ts
@@ -254,7 +254,6 @@ describe('NodeHttpTransport', () => {
       const transportOptions = {
         url: TEST_URL,
         timeout: 100,
-        maxRetries: 0,
       }
       it(`fails silently on server error`, async () => {
         nock(transportOptions.url)
@@ -478,7 +477,6 @@ describe('NodeHttpTransport', () => {
       const transportOptions = {
         url: TEST_URL,
         timeout: 100,
-        maxRetries: 0,
       }
       it(`is cancelled before the response arrives`, async () => {
         nock(transportOptions.url)
@@ -543,7 +541,6 @@ describe('NodeHttpTransport', () => {
     const transportOptions = {
       url: TEST_URL,
       timeout: 100,
-      maxRetries: 0,
     }
     ;([
       [null, ''],

--- a/packages/core/test/unit/impl/node/NodeHttpTransport.test.ts
+++ b/packages/core/test/unit/impl/node/NodeHttpTransport.test.ts
@@ -776,5 +776,32 @@ describe('NodeHttpTransport', () => {
       })
       expect(data).equals(undefined)
     })
+    it(`uses custom headers set to transport`, async () => {
+      let extra: any
+      nock(transportOptions.url)
+        .get('/test')
+        .reply(
+          200,
+          function(_uri, _body, callback) {
+            extra = this.req.headers['extra']
+            callback(null, '..')
+          },
+          {
+            'content-type': 'application/csv',
+          }
+        )
+        .persist()
+      const data = await new NodeHttpTransport({
+        ...transportOptions,
+        timeout: 10000,
+        headers: {
+          extra: 'yes',
+        },
+      }).request('/test', '', {
+        method: 'GET',
+      })
+      expect(data).equals('..')
+      expect(extra).equals('yes')
+    })
   })
 })


### PR DESCRIPTION
This PR allows to set up HTTP proxy using a `proxyUrl` property in InfluxDB configuration object, without the need [to use an extra 3rd party agent](https://github.com/influxdata/influxdb-client-js/issues/319#issuecomment-808154245). Moreover, custom headers for all requests can be also set using the `headers` property in the InfluxDB configuration, this functionality can be used to set up proxy authorization headers.

This feature makes sense only in the context of node.js. Browser code can't control proxy setting,  [deno](deno.land) setups HTTP proxy using env variables.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
