### PR TITLE
fix(core): repair handling of gzipped responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.23.0 [unreleased]
 
+### Bug Fixes
+
+1. [#401](https://github.com/influxdata/influxdb-client-js/pull/401): Repair handling of gzipped responses.
+
 ## 1.22.0 [2022-01-20]
 
 ### Features

--- a/packages/core/src/impl/node/NodeHttpTransport.ts
+++ b/packages/core/src/impl/node/NodeHttpTransport.ts
@@ -348,7 +348,6 @@ export class NodeHttpTransport implements Transport {
     req.on('error', error => {
       listeners.error(error)
     })
-    req.on('close', listeners.complete)
 
     /* istanbul ignore else support older node versions */
     if (requestMessage.body) {


### PR DESCRIPTION
Fixes #303

When GZIP compression is applied to a response, the node's client can effectively close the request before the last piped gunzip happens. This PR makes sure that the results are not closed when results are still available. The response is only completed (successful) if and only if all (possibly none) response data chunks are read.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [ ] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
