### PR TITLE
feat(core): limit write batch maximum size in bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+1. [#402](https://github.com/influxdata/influxdb-client-js/pull/402): Limit write batch maximum size in bytes.
 1. [#403](https://github.com/influxdata/influxdb-client-js/pull/403): Regenerate APIs from swagger.
 
 ### Bug Fixes

--- a/packages/core/src/impl/WriteApiImpl.ts
+++ b/packages/core/src/impl/WriteApiImpl.ts
@@ -41,7 +41,10 @@ class WriteBuffer {
     this.lines[this.length] = record
     this.length++
     this.bytes += size + 1
-    if (this.length >= this.maxChunkRecords) {
+    if (
+      this.length >= this.maxChunkRecords ||
+      this.bytes >= this.maxBatchBytes
+    ) {
       this.flush().catch(_e => {
         // an error is logged in case of failure, avoid UnhandledPromiseRejectionWarning
       })

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -103,7 +103,7 @@ export interface WriteRetryOptions extends RetryDelayStrategyOptions {
  * Options used by {@link WriteApi} .
  */
 export interface WriteOptions extends WriteRetryOptions {
-  /** max number of records to send in a batch   */
+  /** max number of records/lines to send in a batch   */
   batchSize: number
   /** delay between data flushes in milliseconds, at most `batch size` records are sent during flush  */
   flushInterval: number
@@ -113,6 +113,8 @@ export interface WriteOptions extends WriteRetryOptions {
   headers?: {[key: string]: string}
   /** When specified, write bodies larger than the threshold are gzipped  */
   gzipThreshold?: number
+  /** max size of a batch in bytes */
+  maxBatchBytes: number
 }
 
 /** default RetryDelayStrategyOptions */
@@ -127,6 +129,7 @@ export const DEFAULT_RetryDelayStrategyOptions = {
 /** default writeOptions */
 export const DEFAULT_WriteOptions: WriteOptions = {
   batchSize: 1000,
+  maxBatchBytes: 50_000_000, // default max batch size in the cloud
   flushInterval: 60000,
   writeFailed: function() {},
   writeSuccess: function() {},

--- a/packages/core/src/util/utf8Length.ts
+++ b/packages/core/src/util/utf8Length.ts
@@ -1,0 +1,30 @@
+/**
+ * Utf8Length returns an expected length of a string when UTF-8 encoded.
+ * @param s - input string
+ * @returns expected count of bytes
+ */
+export default function utf8Length(s: string): number {
+  let retVal = s.length
+  // extends the size with code points (https://en.wikipedia.org/wiki/UTF-8#Encoding)
+  for (let i = 0; i < s.length; i++) {
+    const code = s.charCodeAt(i)
+    /* istanbul ignore else - JS does not count with 4-bytes UNICODE characters at the moment */
+    if (code < 0x80) {
+      continue
+    } else if (code >= 0x80 && code <= 0x7ff) {
+      retVal++
+    } else if (code >= 0x800 && code <= 0xffff) {
+      if (code >= 0xd800 && code <= 0xdfff) {
+        // node.js represents unicode characters above 0xffff by two UTF-16 surrogate halves
+        // see https://en.wikipedia.org/wiki/UTF-8#Codepage_layout
+        retVal++
+      } else {
+        retVal += 2
+      }
+    } else {
+      // never happens in node.js 14, the situation can vary in the futures or in deno/browsers
+      retVal += 3
+    }
+  }
+  return retVal
+}

--- a/packages/core/test/unit/util/utf8Length.test.ts
+++ b/packages/core/test/unit/util/utf8Length.test.ts
@@ -1,0 +1,17 @@
+import {expect} from 'chai'
+import utf8Length from '../../../src/util/utf8Length'
+
+describe('byteLength', () => {
+  ;[
+    {s: ''},
+    {s: 'hi'},
+    {s: 'šraňka'},
+    {s: 'love\u2665'},
+    {s: '\u{1f0a1}'},
+  ].forEach(({s}) => {
+    const length = new TextEncoder().encode(s).length
+    it(`${s} has length ${length}`, () => {
+      expect(utf8Length(s)).equals(length)
+    })
+  })
+})

--- a/packages/core/test/unit/util/utf8Length.test.ts
+++ b/packages/core/test/unit/util/utf8Length.test.ts
@@ -1,7 +1,7 @@
 import {expect} from 'chai'
 import utf8Length from '../../../src/util/utf8Length'
 
-describe('byteLength', () => {
+describe('utf8Length', () => {
   ;[
     {s: ''},
     {s: 'hi'},


### PR DESCRIPTION
This PR allows limiting write batches to have a maximum length in bytes (50M by default) using a new **maxBatchBytes** write option.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
