### PR TITLE
chore(core): test failed write when maxBatchBytes is exceeded

### DIFF
--- a/packages/core/test/unit/WriteApi.test.ts
+++ b/packages/core/test/unit/WriteApi.test.ts
@@ -541,7 +541,8 @@ describe('WriteApi', () => {
         })
         .persist()
       subject.writeRecord('test value=1')
-      // flushes the previous record by writing a next one so that batch is greater than maxBatchBytes
+      // flushes the previous record by writing a next one
+      // that would exceed 15 maxBatchBytes
       subject.writeRecord('test value=2')
       await waitForCondition(() => writeCounters.failedLineCount == 1)
       expect(logs.error).has.length(1)


### PR DESCRIPTION
This PR enhances tests so that it makes sure that UnhandledPromiseRejection is not thrown even when a batch write is initialized by exceeding the max (bytes) size of batch.

- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
