### PR TITLE
fix(apis): make basic authentication optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 1. [#401](https://github.com/influxdata/influxdb-client-js/pull/401): Repair handling of gzipped responses.
 1. [#405](https://github.com/influxdata/influxdb-client-js/pull/405): Add missing PermissionResources from Cloud API definition
+1. [#411](https://github.com/influxdata/influxdb-client-js/pull/411): Make basic authentication optional.
 
 ## 1.22.0 [2022-01-20]
 

--- a/packages/apis/generator/generateApi.ts
+++ b/packages/apis/generator/generateApi.ts
@@ -52,7 +52,7 @@ function generateTypes(operation: Operation): string {
   }
 
   if (operation.basicAuth) {
-    retVal += '  auth: {user: string, password: string}\n'
+    retVal += '  auth?: {user: string, password: string}\n'
   }
   if (operation.bodyParam) {
     if (operation.bodyParam.description) {

--- a/packages/apis/src/generated/MeAPI.ts
+++ b/packages/apis/src/generated/MeAPI.ts
@@ -4,7 +4,7 @@ import {PasswordResetBody, UserResponse} from './types'
 
 export interface GetMeRequest {}
 export interface PutMePasswordRequest {
-  auth: {user: string; password: string}
+  auth?: {user: string; password: string}
   /** New password */
   body: PasswordResetBody
 }

--- a/packages/apis/src/generated/SigninAPI.ts
+++ b/packages/apis/src/generated/SigninAPI.ts
@@ -2,7 +2,7 @@ import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 
 export interface PostSigninRequest {
-  auth: {user: string; password: string}
+  auth?: {user: string; password: string}
 }
 /**
  * Signin API

--- a/packages/apis/src/generated/UsersAPI.ts
+++ b/packages/apis/src/generated/UsersAPI.ts
@@ -5,7 +5,7 @@ import {PasswordResetBody, User, UserResponse, Users} from './types'
 export interface PostUsersIDPasswordRequest {
   /** The user ID. */
   userID: string
-  auth: {user: string; password: string}
+  auth?: {user: string; password: string}
   /** New password */
   body: PasswordResetBody
 }


### PR DESCRIPTION
Fixes #410

This PR changes the generator and the generated API to make basic authentication optional, it is in fact.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `yarn test` completes successfully
