### PR TITLE
feat(core/query): simplify retrieval of particular row values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.24.0 [unreleased]
 
+### Features
+
+1. [#416](https://github.com/influxdata/influxdb-client-js/pull/416): Simplify retrieval of particular row values.
+
 ## 1.23.0 [2022-02-18]
 
 ### Features

--- a/examples/query.ts
+++ b/examples/query.ts
@@ -3,7 +3,8 @@
 // Shows how to use InfluxDB query API. //
 //////////////////////////////////////////
 
-import {InfluxDB, FluxTableMetaData} from '@influxdata/influxdb-client'
+// import {InfluxDB, FluxTableMetaData} from '@influxdata/influxdb-client'
+import {InfluxDB, FluxTableMetaData} from '../packages/core'
 import {url, token, org} from './env'
 
 const queryApi = new InfluxDB({url, token}).getQueryApi(org)
@@ -11,15 +12,29 @@ const fluxQuery =
   'from(bucket:"my-bucket") |> range(start: -1d) |> filter(fn: (r) => r._measurement == "temperature")'
 
 console.log('*** QUERY ROWS ***')
-// Execute query and receive table metadata and rows.
+// There are more ways of how to receive results,
+// the essential ones are shown/commented below. See also rxjs-query.ts .
+//
+// Execute query and receive table metadata and rows as they arrive from the server.
 // https://docs.influxdata.com/influxdb/v2.1/reference/syntax/annotated-csv/
 queryApi.queryRows(fluxQuery, {
   next(row: string[], tableMeta: FluxTableMetaData) {
+    // the following line creates an object for each row
     const o = tableMeta.toObject(row)
     // console.log(JSON.stringify(o, null, 2))
     console.log(
       `${o._time} ${o._measurement} in '${o.location}' (${o.example}): ${o._field}=${o._value}`
     )
+
+    // alternatively, you can get only a specific column value without
+    // the need to create an object for every row
+    // console.log(tableMeta.get(row, '_time'))
+
+    // or you can create a proxy to get column values on demand
+    // const p = tableMeta.toProxy(row)
+    // console.log(
+    //  `${p._time} ${p._measurement} in '${p.location}' (${p.example}): ${p._field}=${p._value}`
+    // )
   },
   error(error: Error) {
     console.error(error)
@@ -29,19 +44,6 @@ queryApi.queryRows(fluxQuery, {
     console.log('\nFinished SUCCESS')
   },
 })
-
-// // Execute query and return the whole result as a string.
-// // Use with caution, it copies the whole stream of results into memory.
-// queryApi
-//   .queryRaw(fluxQuery)
-//   .then(result => {
-//     console.log(result)
-//     console.log('\nQueryRaw SUCCESS')
-//   })
-//   .catch(error => {
-//     console.error(error)
-//     console.log('\nQueryRaw ERROR')
-//   })
 
 // // Execute query and collect result rows in a Promise.
 // // Use with caution, it copies the whole stream of results into memory.
@@ -54,6 +56,19 @@ queryApi.queryRows(fluxQuery, {
 //   .catch(error => {
 //     console.error(error)
 //     console.log('\nCollect ROWS ERROR')
+//   })
+
+// // Execute query and return the whole result as a string.
+// // Use with caution, it copies the whole stream of results into memory.
+// queryApi
+//   .queryRaw(fluxQuery)
+//   .then(result => {
+//     console.log(result)
+//     console.log('\nQueryRaw SUCCESS')
+//   })
+//   .catch(error => {
+//     console.error(error)
+//     console.log('\nQueryRaw ERROR')
 //   })
 
 // Execute query and receive result lines in annotated csv format

--- a/examples/query.ts
+++ b/examples/query.ts
@@ -3,8 +3,7 @@
 // Shows how to use InfluxDB query API. //
 //////////////////////////////////////////
 
-// import {InfluxDB, FluxTableMetaData} from '@influxdata/influxdb-client'
-import {InfluxDB, FluxTableMetaData} from '../packages/core'
+import {InfluxDB, FluxTableMetaData} from '@influxdata/influxdb-client'
 import {url, token, org} from './env'
 
 const queryApi = new InfluxDB({url, token}).getQueryApi(org)
@@ -31,7 +30,7 @@ queryApi.queryRows(fluxQuery, {
     // console.log(tableMeta.get(row, '_time'))
 
     // or you can create a proxy to get column values on demand
-    // const p = tableMeta.toProxy(row)
+    // const p = new Proxy<Record<string, any>>(row, tableMeta)
     // console.log(
     //  `${p._time} ${p._measurement} in '${p.location}' (${p.example}): ${p._field}=${p._value}`
     // )

--- a/examples/rxjs-query.ts
+++ b/examples/rxjs-query.ts
@@ -11,7 +11,7 @@ import {url, token, org} from './env'
 const queryApi = new InfluxDB({url, token}).getQueryApi(org)
 
 const fluxQuery =
-  'from(bucket:"my-bucket") |> range(start: 0) |> filter(fn: (r) => r._measurement == "temperature")'
+  'from(bucket:"my-bucket") |> range(start: -1d) |> filter(fn: (r) => r._measurement == "temperature")'
 
 console.log('*** QUERY ROWS ***')
 // performs query and receive line table metadata and rows

--- a/packages/core/src/results/FluxTableColumn.ts
+++ b/packages/core/src/results/FluxTableColumn.ts
@@ -94,6 +94,14 @@ class FluxTableColumnImpl implements FluxTableColumn {
     return (typeSerializers[this.dataType] ?? identity)(val)
   }
 }
+export const UNKNOWN_COLUMN: FluxTableColumn = Object.freeze({
+  label: '',
+  dataType: '',
+  group: false,
+  defaultValue: '',
+  index: Number.MAX_SAFE_INTEGER,
+  get: () => undefined,
+})
 
 /**
  * Creates a new flux table column.

--- a/packages/core/src/results/FluxTableColumn.ts
+++ b/packages/core/src/results/FluxTableColumn.ts
@@ -88,7 +88,7 @@ class FluxTableColumnImpl implements FluxTableColumn {
   index: number
   public get(row: string[]): any {
     let val = row[this.index]
-    if (val === '' && this.defaultValue) {
+    if ((val === '' || val === undefined) && this.defaultValue) {
       val = this.defaultValue
     }
     return (typeSerializers[this.dataType] ?? identity)(val)

--- a/packages/core/src/results/FluxTableColumn.ts
+++ b/packages/core/src/results/FluxTableColumn.ts
@@ -42,8 +42,8 @@ export interface FluxTableColumn {
   index: number
 
   /**
-   * ToObject returns a JavaScript object of this columns in the supplied result row, using default deserializers.
-   * @param row - a row with data for each available column
+   * Get returns a JavaScript object of this column in the supplied result row, using default deserializers.
+   * @param row - a data row
    * @returns column value
    */
   get: (row: string[]) => any

--- a/packages/core/src/results/FluxTableColumn.ts
+++ b/packages/core/src/results/FluxTableColumn.ts
@@ -13,7 +13,7 @@ export type ColumnType =
   | string
 
 /**
- * Column metadata class of a {@link http://bit.ly/flux-spec#table | flux table} column.
+ * FluxTableColumn describes {@link http://bit.ly/flux-spec#table | flux table} column.
  */
 export interface FluxTableColumn {
   /**
@@ -40,6 +40,41 @@ export interface FluxTableColumn {
    * Index of this column in a row array.
    */
   index: number
+
+  /**
+   * ToObject returns a JavaScript object of this columns in the supplied result row, using default deserializers.
+   * @param row - a row with data for each available column
+   * @returns column value
+   */
+  get: (row: string[]) => any
+}
+
+const identity = (x: string): any => x
+
+/**
+ * A dictionary of serializers of particular types returned by a flux query.
+ * See {@link https://docs.influxdata.com/influxdb/v2.1/reference/syntax/annotated-csv/#data-types }
+ */
+export const typeSerializers: Record<ColumnType, (val: string) => any> = {
+  boolean: (x: string): any => x === 'true',
+  unsignedLong: (x: string): any => (x === '' ? null : +x),
+  long: (x: string): any => (x === '' ? null : +x),
+  double(x: string): any {
+    switch (x) {
+      case '':
+        return null
+      case '+Inf':
+        return Number.POSITIVE_INFINITY
+      case '-Inf':
+        return Number.NEGATIVE_INFINITY
+      default:
+        return +x
+    }
+  },
+  string: identity,
+  base64Binary: identity,
+  duration: (x: string): any => (x === '' ? null : x),
+  'dateTime:RFC3339': (x: string): any => (x === '' ? null : x),
 }
 
 /**
@@ -51,6 +86,13 @@ class FluxTableColumnImpl implements FluxTableColumn {
   group: boolean
   defaultValue: string
   index: number
+  public get(row: string[]): any {
+    let val = row[this.index]
+    if (val === '' && this.defaultValue) {
+      val = this.defaultValue
+    }
+    return (typeSerializers[this.dataType] ?? identity)(val)
+  }
 }
 
 /**

--- a/packages/core/src/results/FluxTableMetaData.ts
+++ b/packages/core/src/results/FluxTableMetaData.ts
@@ -55,10 +55,25 @@ export interface FluxTableMetaData {
   column(label: string, errorOnMissingColumn?: boolean): FluxTableColumn
 
   /**
-   * Creates an object out of the supplied row values with the help of column descriptors.
+   * Creates an object out of the supplied row with the help of column descriptors.
    * @param row - a row with data for each column
    */
   toObject(row: string[]): {[key: string]: any}
+
+  /**
+   * Creates a javascript Proxy out of the supplied row with the help of column descriptors.
+   * @param row - a row with data for each column
+   * @returns a proxy instance that returns column values, undefined is returned for unknown columns
+   */
+  toProxy(row: string[]): Record<string, any>
+
+  /**
+   * Gets column values out of the supplied row.
+   * @param row - a row with data for each column
+   * @param column - column name
+   * @returns column value, undefined for unknown column
+   */
+  get(row: string[], column: string): any
 }
 
 /**
@@ -87,6 +102,9 @@ class FluxTableMetaDataImpl implements FluxTableMetaData {
       acc[column.label] = column.get(row)
     }
     return acc
+  }
+  toProxy(row: string[]): {[key: string]: any} {
+    return new Proxy(row, this)
   }
   get(row: string[], column: string): any {
     return this.column(column, false).get(row)

--- a/packages/core/src/results/FluxTableMetaData.ts
+++ b/packages/core/src/results/FluxTableMetaData.ts
@@ -1,4 +1,8 @@
-import {FluxTableColumn, typeSerializers} from './FluxTableColumn'
+import {
+  FluxTableColumn,
+  UNKNOWN_COLUMN,
+  typeSerializers,
+} from './FluxTableColumn'
 import {IllegalArgumentError} from '../errors'
 
 /**
@@ -44,10 +48,11 @@ export interface FluxTableMetaData {
   /**
    * Gets columns by name
    * @param label - column label
+   * @param noErrorOnMissingColumn - throw error on missing column, true by default
    * @returns table column
    * @throws IllegalArgumentError if column is not found
    **/
-  column(label: string): FluxTableColumn
+  column(label: string, errorOnMissingColumn?: boolean): FluxTableColumn
 
   /**
    * Creates an object out of the supplied row values with the help of column descriptors.
@@ -65,12 +70,15 @@ class FluxTableMetaDataImpl implements FluxTableMetaData {
     columns.forEach((col, i) => (col.index = i))
     this.columns = columns
   }
-  column(label: string): FluxTableColumn {
+  column(label: string, errorOnMissingColumn = true): FluxTableColumn {
     for (let i = 0; i < this.columns.length; i++) {
       const col = this.columns[i]
       if (col.label === label) return col
     }
-    throw new IllegalArgumentError(`Column ${label} not found!`)
+    if (errorOnMissingColumn) {
+      throw new IllegalArgumentError(`Column ${label} not found!`)
+    }
+    return UNKNOWN_COLUMN
   }
   toObject(row: string[]): {[key: string]: any} {
     const acc: any = {}
@@ -79,6 +87,9 @@ class FluxTableMetaDataImpl implements FluxTableMetaData {
       acc[column.label] = column.get(row)
     }
     return acc
+  }
+  get(row: string[], column: string): any {
+    return this.column(column, false).get(row)
   }
 }
 

--- a/packages/core/src/results/FluxTableMetaData.ts
+++ b/packages/core/src/results/FluxTableMetaData.ts
@@ -48,7 +48,7 @@ export interface FluxTableMetaData {
   /**
    * Gets columns by name
    * @param label - column label
-   * @param noErrorOnMissingColumn - throw error on missing column, true by default
+   * @param errorOnMissingColumn - throw error on missing column (by default), return UNKNOWN_COLUMN when false
    * @returns table column
    * @throws IllegalArgumentError if column is not found
    **/

--- a/packages/core/src/results/FluxTableMetaData.ts
+++ b/packages/core/src/results/FluxTableMetaData.ts
@@ -61,13 +61,6 @@ export interface FluxTableMetaData {
   toObject(row: string[]): {[key: string]: any}
 
   /**
-   * Creates a javascript Proxy out of the supplied row with the help of column descriptors.
-   * @param row - a row with data for each column
-   * @returns a proxy instance that returns column values, undefined is returned for unknown columns
-   */
-  toProxy(row: string[]): Record<string, any>
-
-  /**
    * Gets column values out of the supplied row.
    * @param row - a row with data for each column
    * @param column - column name
@@ -102,9 +95,6 @@ class FluxTableMetaDataImpl implements FluxTableMetaData {
       acc[column.label] = column.get(row)
     }
     return acc
-  }
-  toProxy(row: string[]): {[key: string]: any} {
-    return new Proxy(row, this)
   }
   get(row: string[], column: string): any {
     return this.column(column, false).get(row)

--- a/packages/core/test/unit/results/FluxTableMetaData.test.ts
+++ b/packages/core/test/unit/results/FluxTableMetaData.test.ts
@@ -77,7 +77,7 @@ describe('FluxTableMetaData', () => {
     expect(subject.get(['4'], 'c')).is.undefined
     expect(subject.get([], 'a')).equals(1)
   })
-  it('creates proxies', () => {
+  it('works with proxies', () => {
     const columns: FluxTableColumn[] = [
       createFluxTableColumn({
         label: 'a',
@@ -91,23 +91,26 @@ describe('FluxTableMetaData', () => {
       }),
     ]
     const subject = createFluxTableMetaData(columns)
-    const fromProxy = (p: Record<string, any>): Record<string, any> =>
-      ['a', 'b', 'c'].reduce((acc, val) => {
+    const useProxy = (row: string[]): Record<string, any> => {
+      const p = new Proxy<Record<string, any>>(row, subject)
+      return ['a', 'b', 'c'].reduce((acc, val) => {
         if (p[val] !== undefined) {
           acc[val] = p[val]
         }
         return acc
       }, {} as Record<string, any>)
-    expect(fromProxy(subject.toProxy(['', '']))).to.deep.equal({a: 1, b: ''})
-    expect(fromProxy(subject.toObject(['2', 'y']))).to.deep.equal({
+    }
+    expect(useProxy(['', ''])).to.deep.equal({a: 1, b: ''})
+    expect(useProxy(['2', 'y'])).to.deep.equal({
       a: 2,
       b: 'y',
     })
-    expect(fromProxy(subject.toObject(['3', 'y', 'z']))).to.deep.equal({
+    expect(useProxy(['3', 'y', 'z'])).to.deep.equal({
       a: 3,
       b: 'y',
     })
-    expect(fromProxy(subject.toObject(['4']))).to.deep.equal({a: 4})
+    expect(useProxy(['4'])).to.deep.equal({a: 4})
+    expect(useProxy([])).to.deep.equal({a: 1})
   })
   const serializationTable: Array<[ColumnType | undefined, string, any]> = [
     ['boolean', 'false', false],

--- a/packages/core/test/unit/results/FluxTableMetaData.test.ts
+++ b/packages/core/test/unit/results/FluxTableMetaData.test.ts
@@ -49,6 +49,66 @@ describe('FluxTableMetaData', () => {
     expect(subject.toObject(['3', 'y', 'z'])).to.deep.equal({a: 3, b: 'y'})
     expect(subject.toObject(['4'])).to.deep.equal({a: 4})
   })
+  it('get values', () => {
+    const columns: FluxTableColumn[] = [
+      createFluxTableColumn({
+        label: 'a',
+        defaultValue: '1',
+        dataType: 'long',
+        group: false,
+      }),
+      createFluxTableColumn({
+        label: 'b',
+        index: 2, // index can be possibly set, but it gets overriden during createFluxTableMetaData
+      }),
+    ]
+    const subject = createFluxTableMetaData(columns)
+    expect(subject.get(['', ''], 'a')).equals(1)
+    expect(subject.get(['', ''], 'b')).equals('')
+    expect(subject.get(['', ''], 'c')).is.undefined
+    expect(subject.get(['2', 'y'], 'a')).equals(2)
+    expect(subject.get(['2', 'y'], 'b')).equals('y')
+    expect(subject.get(['2', 'y'], 'c')).is.undefined
+    expect(subject.get(['3', 'y', 'z'], 'a')).equals(3)
+    expect(subject.get(['3', 'y', 'z'], 'b')).equals('y')
+    expect(subject.get(['3', 'y', 'z'], 'c')).is.undefined
+    expect(subject.get(['4'], 'a')).equals(4)
+    expect(subject.get(['4'], 'b')).is.undefined
+    expect(subject.get(['4'], 'c')).is.undefined
+    expect(subject.get([], 'a')).equals(1)
+  })
+  it('creates proxies', () => {
+    const columns: FluxTableColumn[] = [
+      createFluxTableColumn({
+        label: 'a',
+        defaultValue: '1',
+        dataType: 'long',
+        group: false,
+      }),
+      createFluxTableColumn({
+        label: 'b',
+        index: 2, // index can be possibly set, but it gets overriden during createFluxTableMetaData
+      }),
+    ]
+    const subject = createFluxTableMetaData(columns)
+    const fromProxy = (p: Record<string, any>): Record<string, any> =>
+      ['a', 'b', 'c'].reduce((acc, val) => {
+        if (p[val] !== undefined) {
+          acc[val] = p[val]
+        }
+        return acc
+      }, {} as Record<string, any>)
+    expect(fromProxy(subject.toProxy(['', '']))).to.deep.equal({a: 1, b: ''})
+    expect(fromProxy(subject.toObject(['2', 'y']))).to.deep.equal({
+      a: 2,
+      b: 'y',
+    })
+    expect(fromProxy(subject.toObject(['3', 'y', 'z']))).to.deep.equal({
+      a: 3,
+      b: 'y',
+    })
+    expect(fromProxy(subject.toObject(['4']))).to.deep.equal({a: 4})
+  })
   const serializationTable: Array<[ColumnType | undefined, string, any]> = [
     ['boolean', 'false', false],
     ['boolean', 'true', true],


### PR DESCRIPTION
This PR simplifies retrieval of particular row values so that
 - there is no need to create a JS object to get selected (and possibly unknown) columns from results, it is simpler and more efficient to use tableMeta.get(row, column)
 - a JS Proxy can be used to transform the row to an object with properties representing column names.

The existing `query.ts` is modified to show it.

## Proposed Changes

_Briefly describe your proposed changes:_

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
