### PR TITLE
feat(core): enhance writeFailed callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 1. [#416](https://github.com/influxdata/influxdb-client-js/pull/416): Simplify retrieval of particular row values.
+1. [#421](https://github.com/influxdata/influxdb-client-js/pull/421): Enhance writeFailed callback.
 
 ## 1.23.0 [2022-02-18]
 

--- a/packages/core/src/impl/WriteApiImpl.ts
+++ b/packages/core/src/impl/WriteApiImpl.ts
@@ -155,6 +155,16 @@ export default class WriteApiImpl implements WriteApi {
     if (!this.closed && lines.length > 0) {
       if (expires <= Date.now()) {
         const error = new Error('Max retry time exceeded.')
+        const onRetry = self.writeOptions.writeFailed.call(
+          self,
+          error,
+          lines,
+          failedAttempts,
+          expires
+        )
+        if (onRetry) {
+          return onRetry
+        }
         Log.error(
           `Write to InfluxDB failed (attempt: ${failedAttempts}).`,
           error

--- a/packages/core/src/impl/WriteApiImpl.ts
+++ b/packages/core/src/impl/WriteApiImpl.ts
@@ -173,7 +173,8 @@ export default class WriteApiImpl implements WriteApi {
               self,
               error,
               lines,
-              failedAttempts
+              failedAttempts,
+              expires
             )
             if (onRetry) {
               onRetry.then(resolve, reject)

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -93,7 +93,7 @@ export interface WriteRetryOptions extends RetryDelayStrategyOptions {
    */
   writeSuccess(this: WriteApi, lines: Array<string>): void
 
-  /** max number of write attempts when the write fails */
+  /** max number of retry attempts when the write fails */
   maxRetries: number
   /** max time (millis) that can be spent with retries */
   maxRetryTime: number

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -93,7 +93,7 @@ export interface WriteRetryOptions extends RetryDelayStrategyOptions {
    */
   writeSuccess(this: WriteApi, lines: Array<string>): void
 
-  /** max number of retry attempts when the write fails */
+  /** max count of retries after the first write fails */
   maxRetries: number
   /** max time (millis) that can be spent with retries */
   maxRetryTime: number

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -73,7 +73,7 @@ export interface WriteRetryOptions extends RetryDelayStrategyOptions {
    * @param this - the instance of the API that failed
    * @param error - write error
    * @param lines - failed lines
-   * @param attempt - count of already failed attempts to write the lines (1 ... maxRetries+1)
+   * @param attempts - count of already failed attempts to write the lines (1 ... maxRetries+1)
    * @param expires - expiration time for the lines to be retried in millis since epoch
    * @returns a Promise to force the API to use it as a result of the flush operation,
    * void/undefined to continue with default retry mechanism

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -73,7 +73,7 @@ export interface WriteRetryOptions extends RetryDelayStrategyOptions {
    * @param this - the instance of the API that failed
    * @param error - write error
    * @param lines - failed lines
-   * @param attempts - a number of failed attempts to write the lines
+   * @param attempt - count of already failed attempts to write the lines (1 ... maxRetries+1)
    * @param expires - expiration time for the lines to be retried in millis since epoch
    * @returns a Promise to force the API to use it as a result of the flush operation,
    * void/undefined to continue with default retry mechanism

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -74,6 +74,7 @@ export interface WriteRetryOptions extends RetryDelayStrategyOptions {
    * @param error - write error
    * @param lines - failed lines
    * @param attempts - a number of failed attempts to write the lines
+   * @param expires - expiration time for the lines to be retried in millis since epoch
    * @returns a Promise to force the API to use it as a result of the flush operation,
    * void/undefined to continue with default retry mechanism
    */
@@ -81,7 +82,8 @@ export interface WriteRetryOptions extends RetryDelayStrategyOptions {
     this: WriteApi,
     error: Error,
     lines: Array<string>,
-    attempts: number
+    attempts: number,
+    expires: number
   ): Promise<void> | void
 
   /**

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -73,7 +73,7 @@ export interface WriteRetryOptions extends RetryDelayStrategyOptions {
    * @param this - the instance of the API that failed
    * @param error - write error
    * @param lines - failed lines
-   * @param attempts - count of already failed attempts to write the lines (1 ... maxRetries+1)
+   * @param attempt - count of already failed attempts to write the lines (1 ... maxRetries+1)
    * @param expires - expiration time for the lines to be retried in millis since epoch
    * @returns a Promise to force the API to use it as a result of the flush operation,
    * void/undefined to continue with default retry mechanism
@@ -82,7 +82,7 @@ export interface WriteRetryOptions extends RetryDelayStrategyOptions {
     this: WriteApi,
     error: Error,
     lines: Array<string>,
-    attempts: number,
+    attempt: number,
     expires: number
   ): Promise<void> | void
 

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -91,7 +91,7 @@ export interface WriteRetryOptions extends RetryDelayStrategyOptions {
    */
   writeSuccess(this: WriteApi, lines: Array<string>): void
 
-  /** max number of retries when write fails */
+  /** max number of write attempts when the write fails */
   maxRetries: number
   /** max time (millis) that can be spent with retries */
   maxRetryTime: number


### PR DESCRIPTION
This PR
- improves documentation to address #420
- adds tests to verify write attempts
- adds `expires` parameter to `writeFailed` together with a test
- simplifies the implementation

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
