### PR TITLE
test: quotes are escaped

### DIFF
--- a/packages/core/test/unit/query/flux.test.ts
+++ b/packages/core/test/unit/query/flux.test.ts
@@ -144,6 +144,14 @@ describe('Flux Tagged Template', () => {
       'from(bucket:"my-bucket") |> range(start: 0) |> filter(fn: (r) => r._measurement == "temperature")'
     )
   })
+  it('escapes double-quotes', () => {
+    const injection = 'temperature") |> foo'
+    expect(
+      flux`from(bucket:${'my-bucket'}) |> filter(fn: (r) => r._measurement == "${injection}")`.toString()
+    ).equals(
+      'from(bucket:"my-bucket") |> filter(fn: (r) => r._measurement == "temperature\\") |> foo")'
+    )
+  })
   it('interpolates a wrapped string', () => {
     expect(flux`from(bucket:"${'my-bucket'}")`.toString()).equals(
       'from(bucket:"my-bucket")'


### PR DESCRIPTION
## Proposed Changes

Just adds a single test. I was investigating how to use `flux` but couldn't see if this escapes and prevents injection attacks.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated < *I guess adding a test isn't really something worth mentioning there*
- [x] Rebased/mergeable < *I guess so?*
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [ ] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed) < *Dude, just take it or leave it. I'm not interested in spending an hour trying to decipher this legal lingo for this. I don't care about having any rights about those 8 lines of code or whatever. I give this to you.*
