### PR TITLE
chore(core): improve flux function tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 1. [#431](https://github.com/influxdata/influxdb-client-js/pull/431): Regenerate APIs from swagger.
 
+### Other
+
+1. [#429](https://github.com/influxdata/influxdb-client-js/pull/429): Improve query examples.
+1. [#430](https://github.com/influxdata/influxdb-client-js/pull/430): Upgrade dependencies.
+1. [#433](https://github.com/influxdata/influxdb-client-js/pull/433): Improve flux function tests.
+
 ## 1.24.0 [2022-03-18]
 
 ### Features

--- a/packages/core/test/unit/query/flux.test.ts
+++ b/packages/core/test/unit/query/flux.test.ts
@@ -187,4 +187,79 @@ describe('Flux Tagged Template', () => {
       'from(bucket:"my-bucket")'
     )
   })
+  it('interpolates parameter with escaping', () => {
+    const pairs: Array<{value: any; flux: string}> = [
+      {value: flux`${null}`, flux: 'null'},
+      {value: flux`${false}`, flux: 'false'},
+      {value: flux`${1}`, flux: '1'},
+      {value: flux`${1.1}`, flux: '1.1'},
+      {value: flux`${-1.1}`, flux: '-1.1'},
+      {value: flux`${'a'}`, flux: '"a"'},
+      {
+        value: flux`${new Date(1589521447471)}`,
+        flux: '2020-05-15T05:44:07.471Z',
+      },
+      {value: flux`${/abc/}`, flux: 'regexp.compile(v: "/abc/")'},
+      {
+        value: flux`${{
+          toString: function(): string {
+            return 'whatever'
+          },
+        }}`,
+        flux: '"whatever"',
+      },
+      {value: flux`${fluxExpression('1ms')}`, flux: '1ms'},
+      {value: flux`${'abc\n\r\t\\"def'}`, flux: '"abc\\n\\r\\t\\\\\\"def"'},
+      {value: flux`${'abc${val}def'}`, flux: '"abc\\${val}def"'},
+      {value: flux`${'abc$'}`, flux: '"abc$"'},
+      {value: flux`${'a"$d'}`, flux: '"a\\"$d"'},
+      {value: flux`${[]}`, flux: '[]'},
+      {value: flux`${['a"$d']}`, flux: '["a\\"$d"]'},
+      {
+        value: flux`${Symbol('thisSym')}`,
+        flux: `"${Symbol('thisSym').toString()}"`,
+      },
+    ]
+    pairs.forEach(pair => {
+      expect(pair.value.toString()).equals(pair.flux)
+    })
+  })
+  it('interpolates double quoted parameter with escaping', () => {
+    const pairs: Array<{value: any; flux: string}> = [
+      {value: flux`"${null}"`, flux: '""'},
+      {value: flux`"${undefined}"`, flux: '""'},
+      {value: flux`"${false}"`, flux: '"false"'},
+      {value: flux`"${1}"`, flux: '"1"'},
+      {value: flux`"${1.1}"`, flux: '"1.1"'},
+      {value: flux`"${-1.1}"`, flux: '"-1.1"'},
+      {value: flux`"${'a'}"`, flux: '"a"'},
+      {
+        value: flux`"${new Date(1589521447471)}"`,
+        flux: `"${new Date(1589521447471)}"`,
+      },
+      {value: flux`"${/abc/}"`, flux: `"${/abc/.toString()}"`},
+      {
+        value: flux`"${{
+          toString: function(): string {
+            return 'whatever'
+          },
+        }}"`,
+        flux: '"whatever"',
+      },
+      {value: flux`"${fluxExpression('1ms')}"`, flux: '"1ms"'},
+      {value: flux`"${'abc\n\r\t\\"def'}"`, flux: '"abc\\n\\r\\t\\\\\\"def"'},
+      {value: flux`"${'abc${val}def'}"`, flux: '"abc\\${val}def"'},
+      {value: flux`"${'abc$'}"`, flux: '"abc$"'},
+      {value: flux`"${'a"$d'}"`, flux: '"a\\"$d"'},
+      {value: flux`"${[]}"`, flux: `""`},
+      {value: flux`"${['a"$d']}"`, flux: `"a\\"$d"`},
+      {
+        value: flux`"${Symbol('thisSym')}"`,
+        flux: `"${Symbol('thisSym').toString()}"`,
+      },
+    ]
+    pairs.forEach(pair => {
+      expect(pair.value.toString()).equals(pair.flux)
+    })
+  })
 })


### PR DESCRIPTION
This PR adds tests for parameter escaping in a flux tagged template, given the feedback from #432.

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
