### PR TITLE
feat(core): allow to specify write consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 1. [#431](https://github.com/influxdata/influxdb-client-js/pull/431): Regenerate APIs from swagger.
+1. [#434](https://github.com/influxdata/influxdb-client-js/pull/434): Support write consistency query parameter.
 
 ## 1.24.0 [2022-03-18]
 

--- a/packages/core/src/impl/WriteApiImpl.ts
+++ b/packages/core/src/impl/WriteApiImpl.ts
@@ -89,6 +89,11 @@ export default class WriteApiImpl implements WriteApi {
     this.httpPath = `/api/v2/write?org=${encodeURIComponent(
       org
     )}&bucket=${encodeURIComponent(bucket)}&precision=${precision}`
+    if (writeOptions?.consistency) {
+      this.httpPath += `&consistency=${encodeURIComponent(
+        writeOptions.consistency
+      )}`
+    }
     this.writeOptions = {
       ...DEFAULT_WriteOptions,
       ...writeOptions,

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -117,6 +117,8 @@ export interface WriteOptions extends WriteRetryOptions {
   gzipThreshold?: number
   /** max size of a batch in bytes */
   maxBatchBytes: number
+  /** InfluxDB Enterprise write consistency as explained in https://docs.influxdata.com/enterprise_influxdb/v1.9/concepts/clustering/#write-consistency */
+  consistency?: 'any' | 'one' | 'quorum' | 'all'
 }
 
 /** default RetryDelayStrategyOptions */

--- a/packages/core/test/unit/WriteApi.test.ts
+++ b/packages/core/test/unit/WriteApi.test.ts
@@ -648,5 +648,23 @@ describe('WriteApi', () => {
       expect(logs.warn).deep.equals([])
       expect(authorization).equals(`Token customToken`)
     })
+    it('sends consistency param when specified', async () => {
+      useSubject({
+        consistency: 'quorum',
+      })
+      let uri: any
+      nock(clientOptions.url)
+        .post(/.*/)
+        .reply(function(_uri, _requestBody) {
+          uri = this.req.path
+          return [204, '', {}]
+        })
+        .persist()
+      subject.writePoint(new Point('test').floatField('value', 1))
+      await subject.close()
+      expect(logs.error).has.length(0)
+      expect(logs.warn).deep.equals([])
+      expect(uri).match(/.*&consistency=quorum$/)
+    })
   })
 })


### PR DESCRIPTION
This PR adds write consistency parameter that could be set when writing to InfluxDB Enteprise, as explained in https://docs.influxdata.com/enterprise_influxdb/v1.9/concepts/clustering/#write-consistency .

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
