### PR TITLE
chore: use 2.x version in descriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@influxdata/influx",
-  "description": "InfluxDB 2.1 client",
+  "description": "InfluxDB 2.x client",
   "workspaces": {
     "packages": [
       "packages/core",

--- a/packages/apis/package.json
+++ b/packages/apis/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@influxdata/influxdb-client-apis",
   "version": "1.25.0",
-  "description": "InfluxDB 2.1 generated APIs",
+  "description": "InfluxDB 2.x generated APIs",
   "scripts": {
     "apidoc:extract": "api-extractor run",
     "build": "yarn run clean && yarn run lint && rollup -c",

--- a/packages/core-browser/package.json
+++ b/packages/core-browser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@influxdata/influxdb-client-browser",
   "version": "1.25.0",
-  "description": "InfluxDB 2.1 client for browser",
+  "description": "InfluxDB 2.x client for browser",
   "scripts": {
     "apidoc:extract": "echo \"Nothing to do\"",
     "test": "echo \"Nothing to do\"",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@influxdata/influxdb-client",
   "version": "1.25.0",
-  "description": "InfluxDB 2.1 client",
+  "description": "InfluxDB 2.x client",
   "scripts": {
     "apidoc:extract": "api-extractor run",
     "build": "yarn run clean && rollup -c",

--- a/packages/giraffe/package.json
+++ b/packages/giraffe/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@influxdata/influxdb-client-giraffe",
   "version": "1.25.0",
-  "description": "InfluxDB 2.1 client - giraffe integration",
+  "description": "InfluxDB 2.x client - giraffe integration",
   "scripts": {
     "apidoc:extract": "api-extractor run",
     "build": "yarn run clean && rollup -c",


### PR DESCRIPTION
This PR changes the descriptions to reference InfluxDB `2.x` version. It was `2.1` before this PR.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
