### PR TITLE
chore: rename InvocableScripts to InvokableScripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## 1.26.0 [unreleased]
 
+### Features
+
+1. [#442](https://github.com/influxdata/influxdb-client-js/pull/442): Regenerate APIs from swagger.
+
+### Other
+
+1. [#442](https://github.com/influxdata/influxdb-client-js/pull/442): Rename `InvocableScripts` to `InvokableScripts`.
+
 ## 1.25.0 [2022-04-19]
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@
 ### Features
 
 1. [#387](https://github.com/influxdata/influxdb-client-js/pull/387): Add FluxScriptInvocationAPI.
-1. [#387](https://github.com/influxdata/influxdb-client-js/pull/387): Add invocableScript.js example.
+1. [#387](https://github.com/influxdata/influxdb-client-js/pull/387): Add invokableScript.js example.
 1. [#390](https://github.com/influxdata/influxdb-client-js/pull/390): Add delete.ts example to show how to delete data from a bucket.
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@
 ### Features
 
 1. [#387](https://github.com/influxdata/influxdb-client-js/pull/387): Add FluxScriptInvocationAPI.
-1. [#387](https://github.com/influxdata/influxdb-client-js/pull/387): Add invokableScript.js example.
+1. [#387](https://github.com/influxdata/influxdb-client-js/pull/387): Add invocableScript.js example.
 1. [#390](https://github.com/influxdata/influxdb-client-js/pull/390): Add delete.ts example to show how to delete data from a bucket.
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Other
 
-1. [#442](https://github.com/influxdata/influxdb-client-js/pull/442): Rename `InvocableScripts` to `InvokableScripts`.
+1. [#442](https://github.com/influxdata/influxdb-client-js/pull/442): Demonstrate invokable scripts in `invokableScripts.js` example.
 
 ## 1.25.0 [2022-04-19]
 

--- a/examples/invokableScripts.js
+++ b/examples/invokableScripts.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /*
-This example shows how to use API-invocable scripts. See also
-https://docs.influxdata.com/influxdb/cloud/api-guide/api-invocable-scripts/ .
+This example shows how to use API-invokable scripts. See also
+https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/ .
 */
 
 const {InfluxDB, HttpError} = require('@influxdata/influxdb-client')
@@ -108,7 +108,7 @@ example()
   .catch(error => {
     if (error instanceof HttpError && error.statusCode === 404) {
       console.error(
-        `API invocable scripts are not supported by InfluxDB at ${url} .`
+        `API invokable scripts are not supported by InfluxDB at ${url} .`
       )
       console.error('Modify env.js with InfluxDB Cloud URL and token.')
     } else {

--- a/packages/apis/resources/cloud.yml
+++ b/packages/apis/resources/cloud.yml
@@ -7,15 +7,47 @@ info:
 servers:
   - url: /api/v2
 tags:
+  - name: Authorizations
+    description: |
+      Create and manage API tokens.
+      An **authorization** associates a list of permissions to an
+      **organization** and provides a token for API access.
+      Optionally, you can restrict an authorization and its token to a specific user.
+
+      ### Related guides
+
+        - [Authorize API requests](https://docs.influxdata.com/influxdb/cloud/api-guide/api_intro/#authentication).
+        - [Manage API tokens](https://docs.influxdata.com/influxdb/cloud/security/tokens/).
+        - [Assign a token to a specific user](https://docs.influxdata.com/influxdb/cloud/security/tokens/create-token/).
+  - name: Invokable Scripts
+    description: |
+      Manage and execute scripts as API endpoints in InfluxDB.
+
+      An API Invokable Script assigns your custom Flux script to a new
+      InfluxDB API endpoint for your organization.
+      Invokable scripts let you execute your script as an HTTP request to the endpoint.
+
+      Invokable scripts accept parameters.
+      Add parameter references in your script as `params.myparameter`.
+      When you `invoke` your script, you send parameters as key-value pairs in the `params` object.
+      Then, InfluxDB executes your script with the key-value pairs as arguments, and returns the result.
+
+      ### Related guides
+
+      - [Invoke custom scripts](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/).
+  - name: Query
+    description: |
+      Retrieve data, analyze queries, and get query suggestions.
+  - name: Write
+    description: |
+      Write time series data to buckets.
   - name: Authentication
     description: |
-      The InfluxDB `/api/v2` API requires authentication for all requests.
-      Use InfluxDB API tokens to authenticate requests to the `/api/v2` API.
+      Use one of the following schemes to authenticate to the InfluxDB API:
 
-
-      For more information, see
-      [Token authentication](#section/Authentication/TokenAuthentication)
-
+      - [Token authentication](#section/Authentication/TokenAuthentication)
+      - [Basic authentication](#section/Authentication/BasicAuthentication)
+      - [Querystring authentication](#section/Authentication/QuerystringAuthentication)
       <!-- ReDoc-Inject: <security-definitions> -->
     x-traitTag: true
   - name: Quick start
@@ -24,6 +56,22 @@ tags:
       See the [**API Quick Start**](https://docs.influxdata.com/influxdb/cloud/api-guide/api_intro/) to get up and running authenticating with tokens, writing to buckets, and querying data.
 
       [**InfluxDB API client libraries**](https://docs.influxdata.com/influxdb/cloud/api-guide/client-libraries/) are available for popular languages and ready to import into your application.
+  - name: Headers
+    x-traitTag: true
+    description: |
+      InfluxDB API endpoints use standard HTTP request and response headers.
+
+      **Note**: Not all operations support all headers.
+
+      ### Request headers
+
+      | Header                   | Value type            | Description                                |
+      |:------------------------ |:--------------------- |:-------------------------------------------|
+      | `Accept`                 | string                | The content type that the client can understand. |
+      | `Authorization`          | string                | The authorization scheme and credential. |
+      | `Content-Encoding`       | string                | The compression applied to the line protocol in the request payload. |
+      | `Content-Length`         | integer               | The size of the entity-body, in bytes, sent to the database. |
+      | `Content-Type`           | string                | The format of the data in the request body. |
   - name: Response codes
     x-traitTag: true
     description: |
@@ -44,30 +92,19 @@ tags:
       | `429`       | Too many requests        | API token is temporarily over the request quota. The `Retry-After` header describes when to try the request again. |
       | `500`       | Internal server error    |                       |
       | `503`       | Service unavailable      | Server is temporarily unavailable to process the request. The `Retry-After` header describes when to try the request again. |
-  - name: Query
-    description: |
-      Retrieve data, analyze queries, and get query suggestions.
-  - name: Write
-    description: |
-      Write time series data to buckets.
-  - name: Authorizations
-    description: |
-      Create and manage API tokens. An **authorization** associates a list of permissions to an **organization** and provides a token for API access. Optionally, you can restrict an authorization and its token to a specific user.
-
-      For more information and examples, see the following:
-        - [Authorize API requests](https://docs.influxdata.com/influxdb/cloud/api-guide/api_intro/#authentication).
-        - [Manage API tokens](https://docs.influxdata.com/influxdb/cloud/security/tokens/).
-        - [Assign a token to a specific user](https://docs.influxdata.com/influxdb/cloud/security/tokens/create-token/).
 x-tagGroups:
   - name: Overview
     tags:
       - Quick start
       - Authentication
+      - Headers
       - Response codes
   - name: Data I/O endpoints
     tags:
       - Write
       - Query
+      - Invokable Scripts
+      - Tasks
   - name: Resource endpoints
     tags:
       - Buckets
@@ -84,41 +121,7 @@ x-tagGroups:
       - Ping
       - Routes
   - name: All endpoints
-    tags:
-      - Annotations
-      - Authorizations
-      - Buckets
-      - Cells
-      - Checks
-      - DBRPs
-      - Dashboards
-      - Delete
-      - Invocable Scripts
-      - Labels
-      - Limits
-      - NotificationEndpoints
-      - NotificationRules
-      - OAuth
-      - Organizations
-      - Ping
-      - Public Flags
-      - Query
-      - Resources
-      - Routes
-      - Rules
-      - Secrets
-      - Setup
-      - Signin
-      - Signout
-      - Streams
-      - Tasks
-      - Telegraf Plugins
-      - Telegrafs
-      - Templates
-      - Usage
-      - Users
-      - Variables
-      - Write
+    tags: []
 paths:
   /signin:
     post:
@@ -179,14 +182,17 @@ paths:
   /ping:
     get:
       operationId: GetPing
-      summary: Checks the status of InfluxDB instance and version of InfluxDB.
+      summary: Get the status and version of the instance
+      description: Returns the status and InfluxDB version of the instance.
       servers:
         - url: ''
       tags:
         - Ping
       responses:
         '204':
-          description: OK
+          description: |
+            OK.
+            Headers contain InfluxDB version information.
           headers:
             X-Influxdb-Build:
               schema:
@@ -198,14 +204,17 @@ paths:
               description: The version of InfluxDB.
     head:
       operationId: HeadPing
-      summary: Checks the status of InfluxDB instance and version of InfluxDB.
+      summary: Get the status and version of the instance
+      description: Returns the status and InfluxDB version of the instance.
       servers:
         - url: ''
       tags:
         - Ping
       responses:
         '204':
-          description: OK
+          description: |
+            OK.
+            Headers contain InfluxDB version information.
           headers:
             X-Influxdb-Build:
               schema:
@@ -1021,40 +1030,62 @@ paths:
       description: |
         Writes data to a bucket.
 
-        To write data into InfluxDB, you need the following:
+        Use this endpoint to send data in [line protocol](https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol/) format to InfluxDB.
+        InfluxDB parses and validates line protocol in the request body,
+        responds with success or failure, and then handles the write asynchronously.
 
-        - **organization name or ID** – _See [View organizations](https://docs.influxdata.com/influxdb/cloud/organizations/view-orgs/#view-your-organization-id) for instructions on viewing your organization ID._
-        - **bucket** – _See [View buckets](https://docs.influxdata.com/influxdb/cloud/organizations/buckets/view-buckets/) for
-         instructions on viewing your bucket ID._
-        - **API token** – _See [View tokens](https://docs.influxdata.com/influxdb/cloud/security/tokens/view-tokens/)
-         for instructions on viewing your API token._
-        - **InfluxDB URL** – _See [InfluxDB URLs](https://docs.influxdata.com/influxdb/cloud/reference/urls/)_.
-        - data in [line protocol](https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol) format.
+        #### Required permissions
 
-        InfluxDB Cloud enforces rate and size limits different from InfluxDB OSS. For details, see Responses.
+        - `write-buckets` or `write-bucket BUCKET_ID`
 
-        For more information and examples, see the following:
+        `BUCKET_ID` is the ID of the destination bucket.
+
+        #### Rate limits (with InfluxDB Cloud)
+
+        `write` rate limits apply.
+        For more information, see [limits and adjustable quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/).
+
+        #### Related guides
+
         - [Write data with the InfluxDB API](https://docs.influxdata.com/influxdb/cloud/write-data/developer-tools/api).
         - [Optimize writes to InfluxDB](https://docs.influxdata.com/influxdb/cloud/write-data/best-practices/optimize-writes/).
         - [Troubleshoot issues writing data](https://docs.influxdata.com/influxdb/cloud/write-data/troubleshoot/)
       requestBody:
-        description: Data in line protocol format.
+        description: |
+          Data in line protocol format.
+
+          To send compressed data, do the following:
+
+            1. Use [GZIP](https://www.gzip.org/) to compress the line protocol data.
+            2. In your request, send the compressed data and the
+               `Content-Encoding: gzip` header.
+
+          #### Related guides
+
+          - [Best practices for optimizing writes](https://docs.influxdata.com/influxdb/cloud/write-data/best-practices/optimize-writes/).
         required: true
         content:
           text/plain:
             schema:
               type: string
               format: byte
+            examples:
+              plain-utf8:
+                value: |
+                  airSensors,sensor_id=TLM0201 temperature=73.97038159354763,humidity=35.23103248356096,co=0.48445310567793615 1630424257000000000
+                  airSensors,sensor_id=TLM0202 temperature=75.30007505999716,humidity=35.651929918691714,co=0.5141876544505826 1630424257000000000
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: header
           name: Content-Encoding
           description: |
-            The value tells InfluxDB what compression is applied to the line protocol in the request payload.
-            To make an API request with a GZIP payload, send `Content-Encoding: gzip` as a request header.
+            The compression applied to the line protocol in the request payload.
+            To send a GZIP payload, pass `Content-Encoding: gzip` header.
           schema:
             type: string
-            description: 'Content coding. Use `gzip` for compressed data or `identity` for unmodified, uncompressed data.'
+            description: |
+              Content coding.
+              Use `gzip` for compressed data or `identity` for unmodified, uncompressed data.
             default: identity
             enum:
               - gzip
@@ -1062,8 +1093,8 @@ paths:
         - in: header
           name: Content-Type
           description: |
-            Format of the data in the request body.
-            To make an API request with a line protocol payload, send `Content-Type: text/plain; charset=utf-8` as a request header.
+            The format of the data in the request body.
+            To send a line protocol payload, pass `Content-Type: text/plain; charset=utf-8`.
           schema:
             type: string
             description: |
@@ -1074,24 +1105,31 @@ paths:
               - text/plain; charset=utf-8
         - in: header
           name: Content-Length
-          description: 'Size of the entity-body, in bytes, sent to the database. If the length is greater than the database''s `max body` configuration option, the server responds with status code `413`.'
+          description: |
+            The size of the entity-body, in bytes, sent to InfluxDB.
+            If the length is greater than the `max body` configuration option,
+            the server responds with status code `413`.
           schema:
             type: integer
             description: The length in decimal number of octets.
         - in: header
           name: Accept
           description: |
-            Content type that the client can understand. Writes only return a response body if they fail, e.g. due to a formatting problem or quota limit.
-            #### InfluxDB Cloud
-              - returns only `application/json` for format and limit errors.
-              - returns only `text/html` for some quota limit errors.
+            The content type that the client can understand.
+            Writes only return a response body if they fail--for example,
+            due to a formatting problem or quota limit.
 
+            #### InfluxDB Cloud
+
+              - Returns only `application/json` for format and limit errors.
+              - Returns only `text/html` for some quota limit errors.
 
             #### InfluxDB OSS
-              - returns only `application/json` for format and limit errors.
 
+              - Returns only `application/json` for format and limit errors.
 
-            For more information about write errors, see how to [troubleshoot issues writing data](https://docs.influxdata.com/influxdb/cloud/write-data/troubleshoot/).
+            #### Related guides
+              - [Troubleshoot issues writing data](https://docs.influxdata.com/influxdb/cloud/write-data/troubleshoot/).
           schema:
             type: string
             description: Error content type.
@@ -1100,33 +1138,48 @@ paths:
               - application/json
         - in: query
           name: org
-          description: 'Destination organization for writes. The database writes all points in the batch to this organization. If you provide both `orgID` and `org` parameters, `org` takes precedence.'
+          description: |
+            The destination organization for writes.
+            The database writes all points in the batch to this organization.
+            If you provide both `orgID` and `org` parameters, `org` takes precedence.
           required: true
           schema:
             type: string
-            description: Organization name or ID.
+            description: The organization name or ID.
         - in: query
           name: orgID
-          description: 'ID of the destination organization for writes. If both `orgID` and `org` are specified, `org` takes precedence.'
+          description: |
+            The ID of the destination organization for writes.
+            If both `orgID` and `org` are specified, `org` takes precedence.
           schema:
             type: string
         - in: query
           name: bucket
-          description: Destination bucket for writes.
+          description: The destination bucket for writes.
           required: true
           schema:
             type: string
-            description: All points within batch are written to this bucket.
+            description: InfluxDB writes all points in the batch to this bucket.
         - in: query
           name: precision
-          description: Precision for unix timestamps in the line protocol of the request payload.
+          description: The precision for unix timestamps in the line protocol batch.
           schema:
             $ref: '#/components/schemas/WritePrecision'
       responses:
         '204':
-          description: 'InfluxDB validated the request data format and accepted the data for writing to the bucket. Because data is written to InfluxDB asynchronously, data may not yet be written to a bucket. If some of your data didn’t write to the bucket, see [how to check for write errors](https://docs.influxdata.com/influxdb/cloud/write-data/troubleshoot/).'
+          description: |
+            Success. InfluxDB validated the request and the data format and
+            accepted the data for writing to the bucket.
+            Because data is written to InfluxDB asynchronously, data may not yet be written to a bucket.
+
+            #### Related guides
+
+            - [How to check for write errors](https://docs.influxdata.com/influxdb/cloud/write-data/troubleshoot/).
         '400':
-          description: Bad request. Line protocol data in the request is malformed. The response body contains the first malformed line in the data. InfluxDB rejected the batch and did not write any data.
+          description: |
+            Bad request. The line protocol data in the request is malformed.
+            The response body contains the first malformed line in the data.
+            InfluxDB rejected the batch and did not write any data.
           content:
             application/json:
               schema:
@@ -1167,14 +1220,18 @@ paths:
                     message: bucket "air_sensor" not found
         '413':
           description: |
-            The request payload is too large. InfluxDB rejected the batch and did not write any data.
+            The request payload is too large.
+            InfluxDB rejected the batch and did not write any data.
+
             #### InfluxDB Cloud:
-              - returns this error if the request exceeds the maximum [global limit](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#global-limits).
-              - returns `Content-Type: text/html` for this error.
+
+             - Returns this error if the payload exceeds the 50MB size limit.
+             - Returns `Content-Type: text/html` for this error.
 
             #### InfluxDB OSS:
-              - returns this error only if the [Go (golang) `ioutil.ReadAll()`](https://pkg.go.dev/io/ioutil#ReadAll) function raises an error.
-              - returns `Content-Type: application/json` for this error.
+
+             - Returns this error only if the [Go (golang) `ioutil.ReadAll()`](https://pkg.go.dev/io/ioutil#ReadAll) function raises an error.
+             - Returns `Content-Type: application/json` for this error.
           content:
             application/json:
               schema:
@@ -1201,15 +1258,19 @@ paths:
                     </html>
         '429':
           description: |
-            #### InfluxDB Cloud:
-              - returns this error if a **read** or **write** request exceeds your
+            Too many requests.
+
+            #### InfluxDB Cloud
+
+              - Returns this error if a **read** or **write** request exceeds your
                 plan's [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas)
                 or if a **delete** request exceeds the maximum
                 [global limit](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#global-limits).
-              - returns `Retry-After` header that describes when to try the write again.
+              - Returns `Retry-After` header that describes when to try the write again.
 
-            #### InfluxDB OSS:
-              - doesn't return this error.
+            #### InfluxDB OSS
+
+              - Doesn't return this error.
           headers:
             Retry-After:
               description: Non-negative decimal integer indicating seconds to wait before retrying the request.
@@ -1229,15 +1290,19 @@ paths:
                     code: internal error
         '503':
           description: |
-            #### InfluxDB Cloud:
-              - returns this error if series cardinality exceeds your plan's
+            Service unavailable.
+
+            #### InfluxDB Cloud
+
+              - Returns this error if series cardinality exceeds your plan's
                 [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas).
                 See [how to resolve high series cardinality](https://docs.influxdata.com/influxdb/cloud/write-data/best-practices/resolve-high-cardinality/).
 
-            #### InfluxDB OSS:
-              - returns this error if
+            #### InfluxDB OSS
+
+              - Returns this error if
                 the server is temporarily unavailable to accept writes.
-              - returns `Retry-After` header that describes when to try the write again.
+              - Returns `Retry-After` header that describes when to try the write again.
           headers:
             Retry-After:
               description: Non-negative decimal integer indicating seconds to wait before retrying the request.
@@ -1461,7 +1526,7 @@ paths:
       operationId: GetDashboardsID
       tags:
         - Dashboards
-      summary: Retrieve a Dashboard
+      summary: Retrieve a dashboard
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -1477,7 +1542,7 @@ paths:
             type: string
             enum:
               - properties
-          description: Includes the cell view properties in the response if set to `properties`
+          description: 'If `properties`, includes the cell view properties in the response.'
       responses:
         '200':
           description: Retrieve a single dashboard
@@ -7030,6 +7095,11 @@ components:
           type: string
         description:
           type: string
+        users:
+          type: array
+          description: An optional list of email address's to be invited to the organization
+          items:
+            type: string
       required:
         - name
     PatchOrganizationRequest:
@@ -8697,6 +8767,8 @@ components:
         - stacked
         - bar
         - monotoneX
+        - stepBefore
+        - stepAfter
     BandViewProperties:
       type: object
       required:

--- a/packages/apis/resources/invocable-scripts.yml
+++ b/packages/apis/resources/invocable-scripts.yml
@@ -1,18 +1,18 @@
 openapi: 3.0.0
 info:
-  title: InfluxData Invocable Scripts API
+  title: InfluxData Invokable Scripts API
   version: 0.1.0
   description: |
     Manage and execute scripts as API endpoints in InfluxDB.
 
-    An API Invocable Script assigns your custom Flux script to a new InfluxDB API endpoint for your organization.
-    Invocable scripts let you execute your script as an HTTP request to the endpoint.
+    An API Invokable Script assigns your custom Flux script to a new InfluxDB API endpoint for your organization.
+    Invokable scripts let you execute your script as an HTTP request to the endpoint.
 
-    Invocable scripts accept parameters. Add parameter references in your script as `params.myparameter`.
+    Invokable scripts accept parameters. Add parameter references in your script as `params.myparameter`.
     When you `invoke` your script, you send parameters as key-value pairs in the `params` object.
     InfluxDB executes your script with the key-value pairs as arguments and returns the result.
 
-    For more information and examples, see [Invoke custom scripts](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invocable-scripts).
+    For more information and examples, see [Invoke custom scripts](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/).
 servers:
   - url: /api/v2
 paths:
@@ -20,7 +20,7 @@ paths:
     get:
       operationId: GetScripts
       tags:
-        - Invocable Scripts
+        - Invokable Scripts
       summary: List scripts
       parameters:
         - in: query
@@ -48,7 +48,7 @@ paths:
     post:
       operationId: PostScripts
       tags:
-        - Invocable Scripts
+        - Invokable Scripts
       summary: Create a script
       requestBody:
         description: The script to create.
@@ -71,9 +71,9 @@ paths:
     get:
       operationId: GetScriptsID
       tags:
-        - Invocable Scripts
+        - Invokable Scripts
       summary: Retrieve a script
-      description: Uses script ID to retrieve details of an invocable script.
+      description: Uses script ID to retrieve details of an invokable script.
       parameters:
         - in: path
           name: scriptID
@@ -94,10 +94,10 @@ paths:
     patch:
       operationId: PatchScriptsID
       tags:
-        - Invocable Scripts
+        - Invokable Scripts
       summary: Update a script
       description: |
-        Updates properties (`name`, `description`, and `script`) of an invocable script.
+        Updates properties (`name`, `description`, and `script`) of an invokable script.
       requestBody:
         description: Script update to apply
         required: true
@@ -125,7 +125,7 @@ paths:
     delete:
       operationId: DeleteScriptsID
       tags:
-        - Invocable Scripts
+        - Invokable Scripts
       summary: Delete a script
       description: Deletes a script and all associated records.
       parameters:
@@ -145,7 +145,7 @@ paths:
     post:
       operationId: PostScriptsIDInvoke
       tags:
-        - Invocable Scripts
+        - Invokable Scripts
       summary: Invoke a script
       description: Invokes a script and substitutes `params` keys referenced in the script with `params` key-values sent in the request body.
       parameters:

--- a/packages/apis/resources/operations.json
+++ b/packages/apis/resources/operations.json
@@ -107,7 +107,7 @@
     "operation": "get",
     "operationId": "GetPing",
     "basicAuth": false,
-    "summary": "Checks the status of InfluxDB instance and version of InfluxDB.",
+    "summary": "Get the status and version of the instance",
     "positionalParams": [],
     "headerParams": [],
     "queryParams": [],
@@ -115,7 +115,7 @@
     "responses": [
       {
         "code": "204",
-        "description": "OK",
+        "description": "OK.\nHeaders contain InfluxDB version information.\n",
         "mediaTypes": []
       }
     ]
@@ -1445,51 +1445,51 @@
       },
       {
         "name": "Content-Encoding",
-        "description": "The value tells InfluxDB what compression is applied to the line protocol in the request payload.\nTo make an API request with a GZIP payload, send `Content-Encoding: gzip` as a request header.\n",
+        "description": "The compression applied to the line protocol in the request payload.\nTo send a GZIP payload, pass `Content-Encoding: gzip` header.\n",
         "type": "string"
       },
       {
         "name": "Content-Type",
-        "description": "Format of the data in the request body.\nTo make an API request with a line protocol payload, send `Content-Type: text/plain; charset=utf-8` as a request header.\n",
+        "description": "The format of the data in the request body.\nTo send a line protocol payload, pass `Content-Type: text/plain; charset=utf-8`.\n",
         "type": "string"
       },
       {
         "name": "Content-Length",
-        "description": "Size of the entity-body, in bytes, sent to the database. If the length is greater than the database's `max body` configuration option, the server responds with status code `413`.",
+        "description": "The size of the entity-body, in bytes, sent to InfluxDB.\nIf the length is greater than the `max body` configuration option,\nthe server responds with status code `413`.\n",
         "type": "number"
       },
       {
         "name": "Accept",
-        "description": "Content type that the client can understand. Writes only return a response body if they fail, e.g. due to a formatting problem or quota limit.\n#### InfluxDB Cloud\n  - returns only `application/json` for format and limit errors.\n  - returns only `text/html` for some quota limit errors.\n\n\n#### InfluxDB OSS\n  - returns only `application/json` for format and limit errors.\n\n\nFor more information about write errors, see how to [troubleshoot issues writing data](https://docs.influxdata.com/influxdb/v2.1/write-data/troubleshoot/).\n",
+        "description": "The content type that the client can understand.\nWrites only return a response body if they fail--for example,\ndue to a formatting problem or quota limit.\n\n#### InfluxDB Cloud\n\n  - Returns only `application/json` for format and limit errors.\n  - Returns only `text/html` for some quota limit errors.\n\n#### InfluxDB OSS\n\n  - Returns only `application/json` for format and limit errors.\n\n#### Related guides\n  - [Troubleshoot issues writing data](https://docs.influxdata.com/influxdb/v2.2/write-data/troubleshoot/).\n",
         "type": "string"
       }
     ],
     "queryParams": [
       {
         "name": "org",
-        "description": "Destination organization for writes. The database writes all points in the batch to this organization. If you provide both `orgID` and `org` parameters, `org` takes precedence.",
+        "description": "The destination organization for writes.\nThe database writes all points in the batch to this organization.\nIf you provide both `orgID` and `org` parameters, `org` takes precedence.\n",
         "required": true,
         "type": "string"
       },
       {
         "name": "orgID",
-        "description": "ID of the destination organization for writes. If both `orgID` and `org` are specified, `org` takes precedence.",
+        "description": "The ID of the destination organization for writes.\nIf both `orgID` and `org` are specified, `org` takes precedence.\n",
         "type": "string"
       },
       {
         "name": "bucket",
-        "description": "Destination bucket for writes.",
+        "description": "The destination bucket for writes.",
         "required": true,
         "type": "string"
       },
       {
         "name": "precision",
-        "description": "Precision for unix timestamps in the line protocol of the request payload.",
+        "description": "The precision for unix timestamps in the line protocol batch.",
         "type": "any"
       }
     ],
     "bodyParam": {
-      "description": "Data in line protocol format.",
+      "description": "Data in line protocol format.\n\nTo send compressed data, do the following:\n\n  1. Use [GZIP](https://www.gzip.org/) to compress the line protocol data.\n  2. In your request, send the compressed data and the\n     `Content-Encoding: gzip` header.\n\n#### Related guides\n\n- [Best practices for optimizing writes](https://docs.influxdata.com/influxdb/v2.2/write-data/best-practices/optimize-writes/).\n",
       "required": true,
       "mediaType": "text/plain",
       "type": "string"
@@ -1497,12 +1497,12 @@
     "responses": [
       {
         "code": "204",
-        "description": "InfluxDB validated the request data format and accepted the data for writing to the bucket. Because data is written to InfluxDB asynchronously, data may not yet be written to a bucket. If some of your data didn’t write to the bucket, see [how to check for write errors](https://docs.influxdata.com/influxdb/v2.1/write-data/troubleshoot/).",
+        "description": "Success. InfluxDB validated the request and the data format and\naccepted the data for writing to the bucket.\nBecause data is written to InfluxDB asynchronously, data may not yet be written to a bucket.\n\n#### Related guides\n\n- [How to check for write errors](https://docs.influxdata.com/influxdb/v2.2/write-data/troubleshoot/).\n",
         "mediaTypes": []
       },
       {
         "code": "400",
-        "description": "Bad request. Line protocol data in the request is malformed. The response body contains the first malformed line in the data. InfluxDB rejected the batch and did not write any data.",
+        "description": "Bad request. The line protocol data in the request is malformed.\nThe response body contains the first malformed line in the data.\nInfluxDB rejected the batch and did not write any data.\n",
         "mediaTypes": [
           {
             "mediaType": "application/json",
@@ -1532,7 +1532,7 @@
       },
       {
         "code": "413",
-        "description": "The request payload is too large. InfluxDB rejected the batch and did not write any data.\n#### InfluxDB Cloud:\n  - returns this error if the request exceeds the maximum [global limit](https://docs.influxdata.com/influxdb/v2.1/account-management/limits/#global-limits).\n  - returns `Content-Type: text/html` for this error.\n\n#### InfluxDB OSS:\n  - returns this error only if the [Go (golang) `ioutil.ReadAll()`](https://pkg.go.dev/io/ioutil#ReadAll) function raises an error.\n  - returns `Content-Type: application/json` for this error.\n",
+        "description": "The request payload is too large.\nInfluxDB rejected the batch and did not write any data.\n\n#### InfluxDB Cloud:\n\n - Returns this error if the payload exceeds the 50MB size limit.\n - Returns `Content-Type: text/html` for this error.\n\n#### InfluxDB OSS:\n\n - Returns this error only if the [Go (golang) `ioutil.ReadAll()`](https://pkg.go.dev/io/ioutil#ReadAll) function raises an error.\n - Returns `Content-Type: application/json` for this error.\n",
         "mediaTypes": [
           {
             "mediaType": "application/json",
@@ -1546,7 +1546,7 @@
       },
       {
         "code": "429",
-        "description": "#### InfluxDB Cloud:\n  - returns this error if a **read** or **write** request exceeds your\n    plan's [adjustable service quotas](https://docs.influxdata.com/influxdb/v2.1/account-management/limits/#adjustable-service-quotas)\n    or if a **delete** request exceeds the maximum\n    [global limit](https://docs.influxdata.com/influxdb/v2.1/account-management/limits/#global-limits).\n  - returns `Retry-After` header that describes when to try the write again.\n\n#### InfluxDB OSS:\n  - doesn't return this error.\n",
+        "description": "Too many requests.\n\n#### InfluxDB Cloud\n\n  - Returns this error if a **read** or **write** request exceeds your\n    plan's [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas)\n    or if a **delete** request exceeds the maximum\n    [global limit](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#global-limits).\n  - Returns `Retry-After` header that describes when to try the write again.\n\n#### InfluxDB OSS\n\n  - Doesn't return this error.\n",
         "mediaTypes": []
       },
       {
@@ -1561,7 +1561,7 @@
       },
       {
         "code": "503",
-        "description": "#### InfluxDB Cloud:\n  - returns this error if series cardinality exceeds your plan's\n    [adjustable service quotas](https://docs.influxdata.com/influxdb/v2.1/account-management/limits/#adjustable-service-quotas).\n    See [how to resolve high series cardinality](https://docs.influxdata.com/influxdb/v2.1/write-data/best-practices/resolve-high-cardinality/).\n\n#### InfluxDB OSS:\n  - returns this error if\n    the server is temporarily unavailable to accept writes.\n  - returns `Retry-After` header that describes when to try the write again.\n",
+        "description": "Service unavailable.\n\n#### InfluxDB Cloud\n\n  - Returns this error if series cardinality exceeds your plan's\n    [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas).\n    See [how to resolve high series cardinality](https://docs.influxdata.com/influxdb/v2.2/write-data/best-practices/resolve-high-cardinality/).\n\n#### InfluxDB OSS\n\n  - Returns this error if\n    the server is temporarily unavailable to accept writes.\n  - Returns `Retry-After` header that describes when to try the write again.\n",
         "mediaTypes": []
       },
       {
@@ -1924,7 +1924,7 @@
     "operation": "get",
     "operationId": "GetDashboardsID",
     "basicAuth": false,
-    "summary": "Retrieve a Dashboard",
+    "summary": "Retrieve a dashboard",
     "positionalParams": [
       {
         "name": "dashboardID",
@@ -1944,7 +1944,7 @@
     "queryParams": [
       {
         "name": "include",
-        "description": "Includes the cell view properties in the response if set to `properties`",
+        "description": "If `properties`, includes the cell view properties in the response.",
         "required": false,
         "type": "string"
       }
@@ -3188,7 +3188,7 @@
       },
       {
         "code": "429",
-        "description": "#### InfluxDB Cloud:\n  - returns this error if a **read** or **write** request exceeds your\n    plan's [adjustable service quotas](https://docs.influxdata.com/influxdb/v2.1/account-management/limits/#adjustable-service-quotas)\n    or if a **delete** request exceeds the maximum\n    [global limit](https://docs.influxdata.com/influxdb/v2.1/account-management/limits/#global-limits)\n  - returns `Retry-After` header that describes when to try the write again.\n\n#### InfluxDB OSS:\n  - doesn't return this error.\n",
+        "description": "#### InfluxDB Cloud:\n  - returns this error if a **read** or **write** request exceeds your\n    plan's [adjustable service quotas](https://docs.influxdata.com/influxdb/v2.2/account-management/limits/#adjustable-service-quotas)\n    or if a **delete** request exceeds the maximum\n    [global limit](https://docs.influxdata.com/influxdb/v2.2/account-management/limits/#global-limits)\n  - returns `Retry-After` header that describes when to try the write again.\n\n#### InfluxDB OSS:\n  - doesn't return this error.\n",
         "mediaTypes": []
       },
       {
@@ -7901,7 +7901,7 @@
     "operation": "get",
     "operationId": "GetDebugPprofAllProfiles",
     "basicAuth": false,
-    "summary": "Get all runtime profiles",
+    "summary": "Retrieve all runtime profiles",
     "positionalParams": [],
     "headerParams": [
       {
@@ -7914,7 +7914,7 @@
     "queryParams": [
       {
         "name": "cpu",
-        "description": "Collects and returns CPU profiling data for the specified [duration](https://docs.influxdata.com/influxdb/v2.1/reference/glossary/#duration).\n",
+        "description": "Collects and returns CPU profiling data for the specified [duration](https://docs.influxdata.com/influxdb/v2.2/reference/glossary/#duration).\n",
         "type": "string"
       }
     ],
@@ -7948,7 +7948,7 @@
     "operation": "get",
     "operationId": "GetDebugPprofAllocs",
     "basicAuth": false,
-    "summary": "Get the memory allocations runtime profile",
+    "summary": "Retrieve the memory allocations runtime profile",
     "positionalParams": [],
     "headerParams": [
       {
@@ -8004,7 +8004,7 @@
     "operation": "get",
     "operationId": "GetDebugPprofBlock",
     "basicAuth": false,
-    "summary": "Get the block runtime profile",
+    "summary": "Retrieve the block runtime profile",
     "positionalParams": [],
     "headerParams": [
       {
@@ -8060,7 +8060,7 @@
     "operation": "get",
     "operationId": "GetDebugPprofCmdline",
     "basicAuth": false,
-    "summary": "Get the command line invocation",
+    "summary": "Retrieve the command line invocation",
     "positionalParams": [],
     "headerParams": [
       {
@@ -8101,7 +8101,7 @@
     "operation": "get",
     "operationId": "GetDebugPprofGoroutine",
     "basicAuth": false,
-    "summary": "Get the goroutines runtime profile",
+    "summary": "Retrieve the goroutines runtime profile",
     "positionalParams": [],
     "headerParams": [
       {
@@ -8114,7 +8114,7 @@
     "queryParams": [
       {
         "name": "debug",
-        "description": "- `0`: (Default) Return the report as a gzip-compressed protocol buffer.\n- `1`: Return a response body with the report formatted as human-readable text.\n  The report contains comments that translate addresses to function names and line numbers for debugging.\n\n`debug=1` is mutually exclusive with the `seconds` query parameter.\n",
+        "description": "- `0`: (Default) Return the report as a gzip-compressed protocol buffer.\n- `1`: Return a response body with the report formatted as\n       human-readable text with comments that translate addresses to\n       function names and line numbers for debugging.\n\n`debug=1` is mutually exclusive with the `seconds` query parameter.\n",
         "type": "number"
       },
       {
@@ -8157,7 +8157,7 @@
     "operation": "get",
     "operationId": "GetDebugPprofHeap",
     "basicAuth": false,
-    "summary": "Get the heap runtime profile",
+    "summary": "Retrieve the heap runtime profile",
     "positionalParams": [],
     "headerParams": [
       {
@@ -8218,7 +8218,7 @@
     "operation": "get",
     "operationId": "GetDebugPprofMutex",
     "basicAuth": false,
-    "summary": "Get the mutual exclusion (mutex) runtime profile",
+    "summary": "Retrieve the mutual exclusion (mutex) runtime profile",
     "positionalParams": [],
     "headerParams": [
       {
@@ -8274,7 +8274,7 @@
     "operation": "get",
     "operationId": "GetDebugPprofProfile",
     "basicAuth": false,
-    "summary": "Get the CPU runtime profile",
+    "summary": "Retrieve the CPU runtime profile",
     "positionalParams": [],
     "headerParams": [
       {
@@ -8321,7 +8321,7 @@
     "operation": "get",
     "operationId": "GetDebugPprofThreadCreate",
     "basicAuth": false,
-    "summary": "Get the threadcreate runtime profile",
+    "summary": "Retrieve the threadcreate runtime profile",
     "positionalParams": [],
     "headerParams": [
       {
@@ -8377,7 +8377,7 @@
     "operation": "get",
     "operationId": "GetDebugPprofTrace",
     "basicAuth": false,
-    "summary": "Get the runtime execution trace",
+    "summary": "Retrieve the runtime execution trace",
     "positionalParams": [],
     "headerParams": [
       {
@@ -8424,7 +8424,7 @@
     "operation": "get",
     "operationId": "GetHealth",
     "basicAuth": false,
-    "summary": "Get the health of an instance",
+    "summary": "Retrieve the health of the instance",
     "positionalParams": [],
     "headerParams": [
       {
@@ -8439,7 +8439,7 @@
     "responses": [
       {
         "code": "200",
-        "description": "The instance is healthy.",
+        "description": "The instance is healthy.\nThe response body contains the health check items and status.\n",
         "mediaTypes": [
           {
             "mediaType": "application/json",
@@ -8475,7 +8475,7 @@
     "operation": "get",
     "operationId": "GetMetrics",
     "basicAuth": false,
-    "summary": "Get metrics of an instance",
+    "summary": "Retrieve workload performance metrics",
     "positionalParams": [],
     "headerParams": [
       {
@@ -8490,7 +8490,7 @@
     "responses": [
       {
         "code": "200",
-        "description": "Payload body contains metrics about the InfluxDB instance.\n\nMetrics are formatted in the\nPrometheus [plain-text exposition format](https://prometheus.io/docs/instrumenting/exposition_formats).\nEach metric is identified by its name and a set of optional key-value pairs.\n\nThe following descriptors precede each metric:\n\n- *`HELP`*: description of the metric\n- *`TYPE`*: type of the metric (e.g. `counter`, `gauge`, `histogram`, or `summary`)\n",
+        "description": "Success. The response body contains metrics in\n[Prometheus plain-text exposition format](https://prometheus.io/docs/instrumenting/exposition_formats)\nMetrics contain a name, an optional set of key-value pairs, and a value.\n\nThe following descriptors precede each metric:\n\n- `HELP`: description of the metric\n- `TYPE`: [Prometheus metric type](https://prometheus.io/docs/concepts/metric_types/) (`counter`, `gauge`, `histogram`, or `summary`)\n",
         "mediaTypes": [
           {
             "mediaType": "text/plain",
@@ -11304,7 +11304,7 @@
     "operation": "get",
     "operationId": "GetConfig",
     "basicAuth": false,
-    "summary": "Get the run-time configuration of the instance",
+    "summary": "Retrieve runtime configuration",
     "positionalParams": [],
     "headerParams": [
       {
@@ -11319,7 +11319,7 @@
     "responses": [
       {
         "code": "200",
-        "description": "Payload body contains the run-time configuration of the InfluxDB instance.",
+        "description": "Success.\nThe response body contains the active runtime configuration of the InfluxDB instance.\n",
         "mediaTypes": [
           {
             "mediaType": "application/json",

--- a/packages/apis/resources/oss.yml
+++ b/packages/apis/resources/oss.yml
@@ -7,27 +7,78 @@ info:
 servers:
   - url: /api/v2
 tags:
+  - name: Authorizations
+    description: |
+      Create and manage API tokens.
+      An **authorization** associates a list of permissions to an
+      **organization** and provides a token for API access.
+      Optionally, you can restrict an authorization and its token to a specific user.
+
+      ### Related guides
+
+        - [Authorize API requests](https://docs.influxdata.com/influxdb/v2.2/api-guide/api_intro/#authentication).
+        - [Manage API tokens](https://docs.influxdata.com/influxdb/v2.2/security/tokens/).
+        - [Assign a token to a specific user](https://docs.influxdata.com/influxdb/v2.2/security/tokens/create-token/).
+  - name: Debug
+    description: |
+      Generates profiling and trace reports.
+
+      Use routes under `/debug/pprof` to analyze the Go runtime of InfluxDB.
+      These endpoints generate [Go runtime profiles](https://pkg.go.dev/runtime/pprof)
+      and **trace** reports.
+      **Profiles** are collections of stack traces that show call sequences
+      leading to instances of a particular event, such as allocation.
+
+      For more information about **pprof profile** and **trace** reports,
+      see the following resources:
+        - [Google pprof tool](https://github.com/google/pprof)
+        - [Golang diagnostics](https://go.dev/doc/diagnostics)
+  - name: Query
+    description: |
+      Retrieve data, analyze queries, and get query suggestions.
+  - name: Write
+    description: |
+      Write time series data to buckets.
   - name: Authentication
     description: |
-      The InfluxDB `/api/v2` API requires authentication for all requests.
-      Use InfluxDB API tokens to authenticate requests to the `/api/v2` API.
+      Use one of the following schemes to authenticate to the InfluxDB API:
 
-      For examples and more information, see
-      [Token authentication](#section/Authentication/TokenAuthentication)
-
+      - [Token authentication](#section/Authentication/TokenAuthentication)
+      - [Basic authentication](#section/Authentication/BasicAuthentication)
+      - [Querystring authentication](#section/Authentication/QuerystringAuthentication)
       <!-- ReDoc-Inject: <security-definitions> -->
     x-traitTag: true
   - name: Quick start
     x-traitTag: true
     description: |
-      See the [**API Quick Start**](https://docs.influxdata.com/influxdb/v2.1/api-guide/api_intro/) to get up and running authenticating with tokens, writing to buckets, and querying data.
+      See the [**API Quick Start**](https://docs.influxdata.com/influxdb/v2.2/api-guide/api_intro/)
+      to get up and running authenticating with tokens, writing to buckets, and querying data.
 
-      [**InfluxDB API client libraries**](https://docs.influxdata.com/influxdb/v2.1/api-guide/client-libraries/) are available for popular languages and ready to import into your application.
+      [**InfluxDB API client libraries**](https://docs.influxdata.com/influxdb/v2.2/api-guide/client-libraries/)
+      are available for popular languages and ready to import into your application.
+  - name: Headers
+    x-traitTag: true
+    description: |
+      InfluxDB API endpoints use standard HTTP request and response headers.
+
+      **Note**: Not all operations support all headers.
+
+      ### Request headers
+
+      | Header                   | Value type            | Description                                |
+      |:------------------------ |:--------------------- |:-------------------------------------------|
+      | `Accept`                 | string                | The content type that the client can understand. |
+      | `Authorization`          | string                | The authorization scheme and credential. |
+      | `Content-Encoding`       | string                | The compression applied to the line protocol in the request payload. |
+      | `Content-Length`         | integer               | The size of the entity-body, in bytes, sent to the database. |
+      | `Content-Type`           | string                | The format of the data in the request body. |
   - name: Response codes
     x-traitTag: true
     description: |
-      The InfluxDB API uses standard HTTP status codes for success and failure responses.
-      The response body may include additional details. For details about a specific operation's response, see **Responses** and **Response Samples** for that operation.
+      InfluxDB API endpoints use standard HTTP status codes for success and failure responses.
+      The response body may include additional details.
+      For details about a specific operation's response,
+      see **Responses** and **Response Samples** for that operation.
 
       API operations may return the following HTTP status codes:
 
@@ -43,41 +94,18 @@ tags:
       | `429`       | Too many requests        | API token is temporarily over the request quota. The `Retry-After` header describes when to try the request again. |
       | `500`       | Internal server error    |                       |
       | `503`       | Service unavailable      | Server is temporarily unavailable to process the request. The `Retry-After` header describes when to try the request again. |
-  - name: Query
-    description: |
-      Retrieve data, analyze queries, and get query suggestions.
-  - name: Write
-    description: |
-      Write time series data to buckets.
-  - name: Authorizations
-    description: |
-      Create and manage API tokens. An **authorization** associates a list of permissions to an **organization** and provides a token for API access.
-      Optionally, you can restrict an authorization and its token to a specific user.
-
-      For more information and examples, see the following:
-        - [Authorize API requests](https://docs.influxdata.com/influxdb/v2.1/api-guide/api_intro/#authentication).
-        - [Manage API tokens](https://docs.influxdata.com/influxdb/v2.1/security/tokens/).
-        - [Assign a token to a specific user](https://docs.influxdata.com/influxdb/v2.1/security/tokens/create-token/).
-  - name: Debug
-    description: |
-      Routes under `/debug/pprof` generate profiling and trace reports
-      you can use to analyze the Go runtime of InfluxDB.
-      [Go runtime profiles](https://pkg.go.dev/runtime/pprof) are
-      collections of stack traces that show call sequences
-      leading to instances of a particular event, such as allocation.
-      For more information about **pprof profile** and **trace** reports, see the following resources:
-        - [Google pprof tool](https://github.com/google/pprof)
-        - [Golang diagnostics](https://go.dev/doc/diagnostics)
 x-tagGroups:
   - name: Overview
     tags:
       - Quick start
       - Authentication
+      - Headers
       - Response codes
   - name: Data I/O endpoints
     tags:
       - Write
       - Query
+      - Tasks
   - name: Resource endpoints
     tags:
       - Buckets
@@ -91,51 +119,15 @@ x-tagGroups:
       - Users
   - name: System information endpoints
     tags:
+      - Config
+      - Debug
       - Health
       - Metrics
       - Ping
       - Ready
       - Routes
   - name: All endpoints
-    tags:
-      - Authorizations
-      - Backup
-      - Buckets
-      - Cells
-      - Checks
-      - Config
-      - DBRPs
-      - Dashboards
-      - Delete
-      - Health
-      - Metrics
-      - Labels
-      - Legacy Authorizations
-      - NotificationEndpoints
-      - NotificationRules
-      - Organizations
-      - Ping
-      - Query
-      - Ready
-      - RemoteConnections
-      - Replications
-      - Resources
-      - Restore
-      - Routes
-      - Rules
-      - Scraper Targets
-      - Secrets
-      - Setup
-      - Signin
-      - Signout
-      - Sources
-      - Tasks
-      - Telegraf Plugins
-      - Telegrafs
-      - Templates
-      - Users
-      - Variables
-      - Write
+    tags: []
 paths:
   /signin:
     post:
@@ -196,14 +188,17 @@ paths:
   /ping:
     get:
       operationId: GetPing
-      summary: Checks the status of InfluxDB instance and version of InfluxDB.
+      summary: Get the status and version of the instance
+      description: Returns the status and InfluxDB version of the instance.
       servers:
         - url: ''
       tags:
         - Ping
       responses:
         '204':
-          description: OK
+          description: |
+            OK.
+            Headers contain InfluxDB version information.
           headers:
             X-Influxdb-Build:
               schema:
@@ -215,14 +210,17 @@ paths:
               description: The version of InfluxDB.
     head:
       operationId: HeadPing
-      summary: Checks the status of InfluxDB instance and version of InfluxDB.
+      summary: Get the status and version of the instance
+      description: Returns the status and InfluxDB version of the instance.
       servers:
         - url: ''
       tags:
         - Ping
       responses:
         '204':
-          description: OK
+          description: |
+            OK.
+            Headers contain InfluxDB version information.
           headers:
             X-Influxdb-Build:
               schema:
@@ -1038,40 +1036,62 @@ paths:
       description: |
         Writes data to a bucket.
 
-        To write data into InfluxDB, you need the following:
+        Use this endpoint to send data in [line protocol](https://docs.influxdata.com/influxdb/v2.2/reference/syntax/line-protocol/) format to InfluxDB.
+        InfluxDB parses and validates line protocol in the request body,
+        responds with success or failure, and then handles the write asynchronously.
 
-        - **organization name or ID** – _See [View organizations](https://docs.influxdata.com/influxdb/v2.1/organizations/view-orgs/#view-your-organization-id) for instructions on viewing your organization ID._
-        - **bucket** – _See [View buckets](https://docs.influxdata.com/influxdb/v2.1/organizations/buckets/view-buckets/) for
-         instructions on viewing your bucket ID._
-        - **API token** – _See [View tokens](https://docs.influxdata.com/influxdb/v2.1/security/tokens/view-tokens/)
-         for instructions on viewing your API token._
-        - **InfluxDB URL** – _See [InfluxDB URLs](https://docs.influxdata.com/influxdb/v2.1/reference/urls/)_.
-        - data in [line protocol](https://docs.influxdata.com/influxdb/v2.1/reference/syntax/line-protocol) format.
+        #### Required permissions
 
-        InfluxDB Cloud enforces rate and size limits different from InfluxDB OSS. For details, see Responses.
+        - `write-buckets` or `write-bucket BUCKET_ID`
 
-        For more information and examples, see the following:
-        - [Write data with the InfluxDB API](https://docs.influxdata.com/influxdb/v2.1/write-data/developer-tools/api).
-        - [Optimize writes to InfluxDB](https://docs.influxdata.com/influxdb/v2.1/write-data/best-practices/optimize-writes/).
-        - [Troubleshoot issues writing data](https://docs.influxdata.com/influxdb/v2.1/write-data/troubleshoot/)
+        `BUCKET_ID` is the ID of the destination bucket.
+
+        #### Rate limits (with InfluxDB Cloud)
+
+        `write` rate limits apply.
+        For more information, see [limits and adjustable quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/).
+
+        #### Related guides
+
+        - [Write data with the InfluxDB API](https://docs.influxdata.com/influxdb/v2.2/write-data/developer-tools/api).
+        - [Optimize writes to InfluxDB](https://docs.influxdata.com/influxdb/v2.2/write-data/best-practices/optimize-writes/).
+        - [Troubleshoot issues writing data](https://docs.influxdata.com/influxdb/v2.2/write-data/troubleshoot/)
       requestBody:
-        description: Data in line protocol format.
+        description: |
+          Data in line protocol format.
+
+          To send compressed data, do the following:
+
+            1. Use [GZIP](https://www.gzip.org/) to compress the line protocol data.
+            2. In your request, send the compressed data and the
+               `Content-Encoding: gzip` header.
+
+          #### Related guides
+
+          - [Best practices for optimizing writes](https://docs.influxdata.com/influxdb/v2.2/write-data/best-practices/optimize-writes/).
         required: true
         content:
           text/plain:
             schema:
               type: string
               format: byte
+            examples:
+              plain-utf8:
+                value: |
+                  airSensors,sensor_id=TLM0201 temperature=73.97038159354763,humidity=35.23103248356096,co=0.48445310567793615 1630424257000000000
+                  airSensors,sensor_id=TLM0202 temperature=75.30007505999716,humidity=35.651929918691714,co=0.5141876544505826 1630424257000000000
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: header
           name: Content-Encoding
           description: |
-            The value tells InfluxDB what compression is applied to the line protocol in the request payload.
-            To make an API request with a GZIP payload, send `Content-Encoding: gzip` as a request header.
+            The compression applied to the line protocol in the request payload.
+            To send a GZIP payload, pass `Content-Encoding: gzip` header.
           schema:
             type: string
-            description: 'Content coding. Use `gzip` for compressed data or `identity` for unmodified, uncompressed data.'
+            description: |
+              Content coding.
+              Use `gzip` for compressed data or `identity` for unmodified, uncompressed data.
             default: identity
             enum:
               - gzip
@@ -1079,8 +1099,8 @@ paths:
         - in: header
           name: Content-Type
           description: |
-            Format of the data in the request body.
-            To make an API request with a line protocol payload, send `Content-Type: text/plain; charset=utf-8` as a request header.
+            The format of the data in the request body.
+            To send a line protocol payload, pass `Content-Type: text/plain; charset=utf-8`.
           schema:
             type: string
             description: |
@@ -1091,24 +1111,31 @@ paths:
               - text/plain; charset=utf-8
         - in: header
           name: Content-Length
-          description: 'Size of the entity-body, in bytes, sent to the database. If the length is greater than the database''s `max body` configuration option, the server responds with status code `413`.'
+          description: |
+            The size of the entity-body, in bytes, sent to InfluxDB.
+            If the length is greater than the `max body` configuration option,
+            the server responds with status code `413`.
           schema:
             type: integer
             description: The length in decimal number of octets.
         - in: header
           name: Accept
           description: |
-            Content type that the client can understand. Writes only return a response body if they fail, e.g. due to a formatting problem or quota limit.
-            #### InfluxDB Cloud
-              - returns only `application/json` for format and limit errors.
-              - returns only `text/html` for some quota limit errors.
+            The content type that the client can understand.
+            Writes only return a response body if they fail--for example,
+            due to a formatting problem or quota limit.
 
+            #### InfluxDB Cloud
+
+              - Returns only `application/json` for format and limit errors.
+              - Returns only `text/html` for some quota limit errors.
 
             #### InfluxDB OSS
-              - returns only `application/json` for format and limit errors.
 
+              - Returns only `application/json` for format and limit errors.
 
-            For more information about write errors, see how to [troubleshoot issues writing data](https://docs.influxdata.com/influxdb/v2.1/write-data/troubleshoot/).
+            #### Related guides
+              - [Troubleshoot issues writing data](https://docs.influxdata.com/influxdb/v2.2/write-data/troubleshoot/).
           schema:
             type: string
             description: Error content type.
@@ -1117,33 +1144,48 @@ paths:
               - application/json
         - in: query
           name: org
-          description: 'Destination organization for writes. The database writes all points in the batch to this organization. If you provide both `orgID` and `org` parameters, `org` takes precedence.'
+          description: |
+            The destination organization for writes.
+            The database writes all points in the batch to this organization.
+            If you provide both `orgID` and `org` parameters, `org` takes precedence.
           required: true
           schema:
             type: string
-            description: Organization name or ID.
+            description: The organization name or ID.
         - in: query
           name: orgID
-          description: 'ID of the destination organization for writes. If both `orgID` and `org` are specified, `org` takes precedence.'
+          description: |
+            The ID of the destination organization for writes.
+            If both `orgID` and `org` are specified, `org` takes precedence.
           schema:
             type: string
         - in: query
           name: bucket
-          description: Destination bucket for writes.
+          description: The destination bucket for writes.
           required: true
           schema:
             type: string
-            description: All points within batch are written to this bucket.
+            description: InfluxDB writes all points in the batch to this bucket.
         - in: query
           name: precision
-          description: Precision for unix timestamps in the line protocol of the request payload.
+          description: The precision for unix timestamps in the line protocol batch.
           schema:
             $ref: '#/components/schemas/WritePrecision'
       responses:
         '204':
-          description: 'InfluxDB validated the request data format and accepted the data for writing to the bucket. Because data is written to InfluxDB asynchronously, data may not yet be written to a bucket. If some of your data didn’t write to the bucket, see [how to check for write errors](https://docs.influxdata.com/influxdb/v2.1/write-data/troubleshoot/).'
+          description: |
+            Success. InfluxDB validated the request and the data format and
+            accepted the data for writing to the bucket.
+            Because data is written to InfluxDB asynchronously, data may not yet be written to a bucket.
+
+            #### Related guides
+
+            - [How to check for write errors](https://docs.influxdata.com/influxdb/v2.2/write-data/troubleshoot/).
         '400':
-          description: Bad request. Line protocol data in the request is malformed. The response body contains the first malformed line in the data. InfluxDB rejected the batch and did not write any data.
+          description: |
+            Bad request. The line protocol data in the request is malformed.
+            The response body contains the first malformed line in the data.
+            InfluxDB rejected the batch and did not write any data.
           content:
             application/json:
               schema:
@@ -1184,14 +1226,18 @@ paths:
                     message: bucket "air_sensor" not found
         '413':
           description: |
-            The request payload is too large. InfluxDB rejected the batch and did not write any data.
+            The request payload is too large.
+            InfluxDB rejected the batch and did not write any data.
+
             #### InfluxDB Cloud:
-              - returns this error if the request exceeds the maximum [global limit](https://docs.influxdata.com/influxdb/v2.1/account-management/limits/#global-limits).
-              - returns `Content-Type: text/html` for this error.
+
+             - Returns this error if the payload exceeds the 50MB size limit.
+             - Returns `Content-Type: text/html` for this error.
 
             #### InfluxDB OSS:
-              - returns this error only if the [Go (golang) `ioutil.ReadAll()`](https://pkg.go.dev/io/ioutil#ReadAll) function raises an error.
-              - returns `Content-Type: application/json` for this error.
+
+             - Returns this error only if the [Go (golang) `ioutil.ReadAll()`](https://pkg.go.dev/io/ioutil#ReadAll) function raises an error.
+             - Returns `Content-Type: application/json` for this error.
           content:
             application/json:
               schema:
@@ -1218,15 +1264,19 @@ paths:
                     </html>
         '429':
           description: |
-            #### InfluxDB Cloud:
-              - returns this error if a **read** or **write** request exceeds your
-                plan's [adjustable service quotas](https://docs.influxdata.com/influxdb/v2.1/account-management/limits/#adjustable-service-quotas)
-                or if a **delete** request exceeds the maximum
-                [global limit](https://docs.influxdata.com/influxdb/v2.1/account-management/limits/#global-limits).
-              - returns `Retry-After` header that describes when to try the write again.
+            Too many requests.
 
-            #### InfluxDB OSS:
-              - doesn't return this error.
+            #### InfluxDB Cloud
+
+              - Returns this error if a **read** or **write** request exceeds your
+                plan's [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas)
+                or if a **delete** request exceeds the maximum
+                [global limit](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#global-limits).
+              - Returns `Retry-After` header that describes when to try the write again.
+
+            #### InfluxDB OSS
+
+              - Doesn't return this error.
           headers:
             Retry-After:
               description: Non-negative decimal integer indicating seconds to wait before retrying the request.
@@ -1246,15 +1296,19 @@ paths:
                     code: internal error
         '503':
           description: |
-            #### InfluxDB Cloud:
-              - returns this error if series cardinality exceeds your plan's
-                [adjustable service quotas](https://docs.influxdata.com/influxdb/v2.1/account-management/limits/#adjustable-service-quotas).
-                See [how to resolve high series cardinality](https://docs.influxdata.com/influxdb/v2.1/write-data/best-practices/resolve-high-cardinality/).
+            Service unavailable.
 
-            #### InfluxDB OSS:
-              - returns this error if
+            #### InfluxDB Cloud
+
+              - Returns this error if series cardinality exceeds your plan's
+                [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas).
+                See [how to resolve high series cardinality](https://docs.influxdata.com/influxdb/v2.2/write-data/best-practices/resolve-high-cardinality/).
+
+            #### InfluxDB OSS
+
+              - Returns this error if
                 the server is temporarily unavailable to accept writes.
-              - returns `Retry-After` header that describes when to try the write again.
+              - Returns `Retry-After` header that describes when to try the write again.
           headers:
             Retry-After:
               description: Non-negative decimal integer indicating seconds to wait before retrying the request.
@@ -1478,7 +1532,7 @@ paths:
       operationId: GetDashboardsID
       tags:
         - Dashboards
-      summary: Retrieve a Dashboard
+      summary: Retrieve a dashboard
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -1494,7 +1548,7 @@ paths:
             type: string
             enum:
               - properties
-          description: Includes the cell view properties in the response if set to `properties`
+          description: 'If `properties`, includes the cell view properties in the response.'
       responses:
         '200':
           description: Retrieve a single dashboard
@@ -2251,13 +2305,13 @@ paths:
         Retrieves data from InfluxDB buckets.
 
         To query data, you need the following:
-        - **organization** – _See [View organizations](https://docs.influxdata.com/influxdb/v2.1/organizations/view-orgs/#view-your-organization-id) for instructions on viewing your organization ID._
-        - **API token** – _See [View tokens](https://docs.influxdata.com/influxdb/v2.1/security/tokens/view-tokens/)
+        - **organization** – _See [View organizations](https://docs.influxdata.com/influxdb/v2.2/organizations/view-orgs/#view-your-organization-id) for instructions on viewing your organization ID._
+        - **API token** – _See [View tokens](https://docs.influxdata.com/influxdb/v2.2/security/tokens/view-tokens/)
          for instructions on viewing your API token._
-        - **InfluxDB URL** – _See [InfluxDB URLs](https://docs.influxdata.com/influxdb/v2.1/reference/urls/)_.
+        - **InfluxDB URL** – _See [InfluxDB URLs](https://docs.influxdata.com/influxdb/v2.2/reference/urls/)_.
         - **Flux query** – _See [Flux](https://docs.influxdata.com/flux/v0.x/)._
 
-        For more information and examples, see [Query with the InfluxDB API](https://docs.influxdata.com/influxdb/v2.1/query-data/execute-queries/influx-api/).
+        For more information and examples, see [Query with the InfluxDB API](https://docs.influxdata.com/influxdb/v2.2/query-data/execute-queries/influx-api/).
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: header
@@ -2329,9 +2383,9 @@ paths:
           description: |
             #### InfluxDB Cloud:
               - returns this error if a **read** or **write** request exceeds your
-                plan's [adjustable service quotas](https://docs.influxdata.com/influxdb/v2.1/account-management/limits/#adjustable-service-quotas)
+                plan's [adjustable service quotas](https://docs.influxdata.com/influxdb/v2.2/account-management/limits/#adjustable-service-quotas)
                 or if a **delete** request exceeds the maximum
-                [global limit](https://docs.influxdata.com/influxdb/v2.1/account-management/limits/#global-limits)
+                [global limit](https://docs.influxdata.com/influxdb/v2.2/account-management/limits/#global-limits)
               - returns `Retry-After` header that describes when to try the write again.
 
             #### InfluxDB OSS:
@@ -5208,14 +5262,14 @@ paths:
       operationId: GetDebugPprofAllProfiles
       tags:
         - Debug
-      summary: Get all runtime profiles
+      summary: Retrieve all runtime profiles
       description: |
-        Get reports for the following [Go runtime profiles](https://pkg.go.dev/runtime/pprof):
+        Collects samples and returns reports for the following [Go runtime profiles](https://pkg.go.dev/runtime/pprof):
 
         - **allocs**: All past memory allocations
         - **block**: Stack traces that led to blocking on synchronization primitives
         - **cpu**: (Optional) Program counters sampled from the executing stack.
-          Include by passing the `cpu` query parameter with a [duration](https://docs.influxdata.com/influxdb/v2.1/reference/glossary/#duration) value.
+          Include by passing the `cpu` query parameter with a [duration](https://docs.influxdata.com/influxdb/v2.2/reference/glossary/#duration) value.
           Equivalent to the report from [`GET /debug/pprof/profile?seconds=NUMBER_OF_SECONDS`](#operation/GetDebugPprofProfile).
         - **goroutine**: All current goroutines
         - **heap**: Memory allocations for live objects
@@ -5264,7 +5318,7 @@ paths:
         - in: query
           name: cpu
           description: |
-            Collects and returns CPU profiling data for the specified [duration](https://docs.influxdata.com/influxdb/v2.1/reference/glossary/#duration).
+            Collects and returns CPU profiling data for the specified [duration](https://docs.influxdata.com/influxdb/v2.2/reference/glossary/#duration).
           schema:
             type: string
             format: duration
@@ -5294,9 +5348,9 @@ paths:
       operationId: GetDebugPprofAllocs
       tags:
         - Debug
-      summary: Get the memory allocations runtime profile
+      summary: Retrieve the memory allocations runtime profile
       description: |
-        Get a [Go runtime profile](https://pkg.go.dev/runtime/pprof) report of
+        Returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof) report of
         all past memory allocations.
         **allocs** is the same as the **heap** profile,
         but changes the default [pprof](https://pkg.go.dev/runtime/pprof)
@@ -5379,10 +5433,10 @@ paths:
       operationId: GetDebugPprofBlock
       tags:
         - Debug
-      summary: Get the block runtime profile
+      summary: Retrieve the block runtime profile
       description: |
-        Get a [Go runtime profile](https://pkg.go.dev/runtime/pprof) report of
-        stack traces that led to blocking on synchronization primitives.
+        Collects samples and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof)
+        report of stack traces that led to blocking on synchronization primitives.
       x-codeSamples:
         - lang: Shell
           label: 'Shell: go tool pprof'
@@ -5460,9 +5514,9 @@ paths:
       operationId: GetDebugPprofCmdline
       tags:
         - Debug
-      summary: Get the command line invocation
+      summary: Retrieve the command line invocation
       description: |
-        Get the command line that invoked InfluxDB.
+        Returns the command line that invoked InfluxDB.
       servers:
         - url: ''
       parameters:
@@ -5483,10 +5537,10 @@ paths:
       operationId: GetDebugPprofGoroutine
       tags:
         - Debug
-      summary: Get the goroutines runtime profile
+      summary: Retrieve the goroutines runtime profile
       description: |
-        Get a [Go runtime profile](https://pkg.go.dev/runtime/pprof) report of
-        all current goroutines.
+        Collects statistics and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof)
+        report of all current goroutines.
       x-codeSamples:
         - lang: Shell
           label: 'Shell: go tool pprof'
@@ -5510,8 +5564,9 @@ paths:
           name: debug
           description: |
             - `0`: (Default) Return the report as a gzip-compressed protocol buffer.
-            - `1`: Return a response body with the report formatted as human-readable text.
-              The report contains comments that translate addresses to function names and line numbers for debugging.
+            - `1`: Return a response body with the report formatted as
+                   human-readable text with comments that translate addresses to
+                   function names and line numbers for debugging.
 
             `debug=1` is mutually exclusive with the `seconds` query parameter.
           schema:
@@ -5564,10 +5619,10 @@ paths:
       operationId: GetDebugPprofHeap
       tags:
         - Debug
-      summary: Get the heap runtime profile
+      summary: Retrieve the heap runtime profile
       description: |
-        Get a [Go runtime profile](https://pkg.go.dev/runtime/pprof) report of
-        memory allocations for live objects.
+        Collects statistics and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof)
+        report of memory allocations for live objects.
 
         To run **garbage collection** before sampling,
         pass the `gc` query parameter with a value of `1`.
@@ -5668,9 +5723,9 @@ paths:
       operationId: GetDebugPprofMutex
       tags:
         - Debug
-      summary: Get the mutual exclusion (mutex) runtime profile
+      summary: Retrieve the mutual exclusion (mutex) runtime profile
       description: |
-        Get a [Go runtime profile](https://pkg.go.dev/runtime/pprof) report of
+        Collects statistics and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof) report of
         lock contentions.
         The profile contains stack traces of holders of contended mutual exclusions (mutexes).
       x-codeSamples:
@@ -5750,10 +5805,10 @@ paths:
       operationId: GetDebugPprofProfile
       tags:
         - Debug
-      summary: Get the CPU runtime profile
+      summary: Retrieve the CPU runtime profile
       description: |
-        Get a [Go runtime profile](https://pkg.go.dev/runtime/pprof) report of
-        program counters on the executing stack.
+        Collects statistics and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof)
+        report of program counters on the executing stack.
       x-codeSamples:
         - lang: Shell
           label: 'Shell: go tool pprof'
@@ -5803,10 +5858,10 @@ paths:
       operationId: GetDebugPprofThreadCreate
       tags:
         - Debug
-      summary: Get the threadcreate runtime profile
+      summary: Retrieve the threadcreate runtime profile
       description: |
-        Get a [Go runtime profile](https://pkg.go.dev/runtime/pprof) report of
-        stack traces that led to the creation of new OS threads.
+        Collects statistics and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof)
+        report of stack traces that led to the creation of new OS threads.
       x-codeSamples:
         - lang: Shell
           label: 'Shell: go tool pprof'
@@ -5888,9 +5943,9 @@ paths:
       operationId: GetDebugPprofTrace
       tags:
         - Debug
-      summary: Get the runtime execution trace
+      summary: Retrieve the runtime execution trace
       description: |
-        Trace execution events for the current program.
+        Collects profile data and returns trace execution events for the current program.
       x-codeSamples:
         - lang: Shell
           label: 'Shell: go tool trace'
@@ -5933,14 +5988,17 @@ paths:
       operationId: GetHealth
       tags:
         - Health
-      summary: Get the health of an instance
+      summary: Retrieve the health of the instance
+      description: Returns the health of the instance.
       servers:
         - url: ''
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
       responses:
         '200':
-          description: The instance is healthy.
+          description: |
+            The instance is healthy.
+            The response body contains the health check items and status.
           content:
             application/json:
               schema:
@@ -5959,7 +6017,17 @@ paths:
       operationId: GetMetrics
       tags:
         - Metrics
-      summary: Get metrics of an instance
+      summary: Retrieve workload performance metrics
+      description: |
+        Returns metrics about the workload performance of an InfluxDB instance.
+
+        Use this endpoint to get performance, resource, and usage metrics.
+
+        #### Related guides
+
+        - For the list of metrics categories, see [InfluxDB OSS metrics](https://docs.influxdata.com/influxdb/v2.2/reference/internals/metrics/).
+        - Learn how to use InfluxDB to [scrape Prometheus metrics](https://docs.influxdata.com/influxdb/v2.2write-data/developer-tools/scrape-prometheus-metrics/).
+        - Learn how InfluxDB [parses the Prometheus exposition format](https://docs.influxdata.com/influxdb/v2.2/reference/prometheus-metrics/).
       servers:
         - url: ''
       parameters:
@@ -5967,16 +6035,14 @@ paths:
       responses:
         '200':
           description: |
-            Payload body contains metrics about the InfluxDB instance.
-
-            Metrics are formatted in the
-            Prometheus [plain-text exposition format](https://prometheus.io/docs/instrumenting/exposition_formats).
-            Each metric is identified by its name and a set of optional key-value pairs.
+            Success. The response body contains metrics in
+            [Prometheus plain-text exposition format](https://prometheus.io/docs/instrumenting/exposition_formats)
+            Metrics contain a name, an optional set of key-value pairs, and a value.
 
             The following descriptors precede each metric:
 
-            - *`HELP`*: description of the metric
-            - *`TYPE`*: type of the metric (e.g. `counter`, `gauge`, `histogram`, or `summary`)
+            - `HELP`: description of the metric
+            - `TYPE`: [Prometheus metric type](https://prometheus.io/docs/concepts/metric_types/) (`counter`, `gauge`, `histogram`, or `summary`)
           content:
             text/plain:
               schema:
@@ -7639,12 +7705,23 @@ paths:
       operationId: GetConfig
       tags:
         - Config
-      summary: Get the run-time configuration of the instance
+      summary: Retrieve runtime configuration
+      description: |
+        Returns the active runtime configuration of the InfluxDB instance.
+
+        In InfluxDB v2.2+, use this endpoint to view your active runtime configuration,
+        including flags and environment variables.
+
+        #### Related guides
+
+        - [View your runtime server configuration](https://docs.influxdata.com/influxdb/v2.2/reference/config-options/#view-your-runtime-server-configuration)
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
       responses:
         '200':
-          description: Payload body contains the run-time configuration of the InfluxDB instance.
+          description: |
+            Success.
+            The response body contains the active runtime configuration of the InfluxDB instance.
           content:
             application/json:
               schema:
@@ -9003,6 +9080,11 @@ components:
           type: string
         description:
           type: string
+        users:
+          type: array
+          description: An optional list of email address's to be invited to the organization
+          items:
+            type: string
       required:
         - name
     PatchOrganizationRequest:
@@ -10670,6 +10752,8 @@ components:
         - stacked
         - bar
         - monotoneX
+        - stepBefore
+        - stepAfter
     BandViewProperties:
       type: object
       required:
@@ -14071,8 +14155,8 @@ components:
 
         For more information and examples, see the following:
           - [`/authorizations`](#tag/Authorizations) endpoint.
-          - [Authorize API requests](https://docs.influxdata.com/influxdb/v2.1/api-guide/api_intro/#authentication).
-          - [Manage API tokens](https://docs.influxdata.com/influxdb/v2.1/security/tokens/).
+          - [Authorize API requests](https://docs.influxdata.com/influxdb/v2.2/api-guide/api_intro/#authentication).
+          - [Manage API tokens](https://docs.influxdata.com/influxdb/v2.2/security/tokens/).
     BasicAuthentication:
       type: http
       scheme: basic

--- a/packages/apis/src/generated/ConfigAPI.ts
+++ b/packages/apis/src/generated/ConfigAPI.ts
@@ -18,7 +18,7 @@ export class ConfigAPI {
     this.base = new APIBase(influxDB)
   }
   /**
-   * Get the run-time configuration of the instance.
+   * Retrieve runtime configuration.
    * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetConfig }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options

--- a/packages/apis/src/generated/DashboardsAPI.ts
+++ b/packages/apis/src/generated/DashboardsAPI.ts
@@ -24,7 +24,7 @@ import {
 export interface GetDashboardsIDRequest {
   /** The ID of the dashboard to update. */
   dashboardID: string
-  /** Includes the cell view properties in the response if set to `properties` */
+  /** If `properties`, includes the cell view properties in the response. */
   include?: string
 }
 export interface PatchDashboardsIDRequest {
@@ -166,7 +166,7 @@ export class DashboardsAPI {
     this.base = new APIBase(influxDB)
   }
   /**
-   * Retrieve a Dashboard.
+   * Retrieve a dashboard.
    * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetDashboardsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options

--- a/packages/apis/src/generated/DebugAPI.ts
+++ b/packages/apis/src/generated/DebugAPI.ts
@@ -2,7 +2,7 @@ import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 
 export interface GetDebugPprofAllProfilesRequest {
-  /** Collects and returns CPU profiling data for the specified [duration](https://docs.influxdata.com/influxdb/v2.1/reference/glossary/#duration).
+  /** Collects and returns CPU profiling data for the specified [duration](https://docs.influxdata.com/influxdb/v2.2/reference/glossary/#duration).
    */
   cpu?: string
 }
@@ -37,8 +37,9 @@ export interface GetDebugPprofBlockRequest {
 export interface GetDebugPprofCmdlineRequest {}
 export interface GetDebugPprofGoroutineRequest {
   /** - `0`: (Default) Return the report as a gzip-compressed protocol buffer.
-- `1`: Return a response body with the report formatted as human-readable text.
-  The report contains comments that translate addresses to function names and line numbers for debugging.
+- `1`: Return a response body with the report formatted as
+       human-readable text with comments that translate addresses to
+       function names and line numbers for debugging.
 
 `debug=1` is mutually exclusive with the `seconds` query parameter.
  */
@@ -118,7 +119,7 @@ export class DebugAPI {
     this.base = new APIBase(influxDB)
   }
   /**
-   * Get all runtime profiles.
+   * Retrieve all runtime profiles.
    * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetDebugPprofAllProfiles }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
@@ -136,7 +137,7 @@ export class DebugAPI {
     )
   }
   /**
-   * Get the memory allocations runtime profile.
+   * Retrieve the memory allocations runtime profile.
    * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetDebugPprofAllocs }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
@@ -157,7 +158,7 @@ export class DebugAPI {
     )
   }
   /**
-   * Get the block runtime profile.
+   * Retrieve the block runtime profile.
    * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetDebugPprofBlock }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
@@ -178,7 +179,7 @@ export class DebugAPI {
     )
   }
   /**
-   * Get the command line invocation.
+   * Retrieve the command line invocation.
    * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetDebugPprofCmdline }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
@@ -196,7 +197,7 @@ export class DebugAPI {
     )
   }
   /**
-   * Get the goroutines runtime profile.
+   * Retrieve the goroutines runtime profile.
    * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetDebugPprofGoroutine }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
@@ -217,7 +218,7 @@ export class DebugAPI {
     )
   }
   /**
-   * Get the heap runtime profile.
+   * Retrieve the heap runtime profile.
    * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetDebugPprofHeap }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
@@ -239,7 +240,7 @@ export class DebugAPI {
     )
   }
   /**
-   * Get the mutual exclusion (mutex) runtime profile.
+   * Retrieve the mutual exclusion (mutex) runtime profile.
    * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetDebugPprofMutex }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
@@ -260,7 +261,7 @@ export class DebugAPI {
     )
   }
   /**
-   * Get the CPU runtime profile.
+   * Retrieve the CPU runtime profile.
    * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetDebugPprofProfile }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
@@ -280,7 +281,7 @@ export class DebugAPI {
     )
   }
   /**
-   * Get the threadcreate runtime profile.
+   * Retrieve the threadcreate runtime profile.
    * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetDebugPprofThreadCreate }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
@@ -301,7 +302,7 @@ export class DebugAPI {
     )
   }
   /**
-   * Get the runtime execution trace.
+   * Retrieve the runtime execution trace.
    * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetDebugPprofTrace }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options

--- a/packages/apis/src/generated/HealthAPI.ts
+++ b/packages/apis/src/generated/HealthAPI.ts
@@ -18,7 +18,7 @@ export class HealthAPI {
     this.base = new APIBase(influxDB)
   }
   /**
-   * Get the health of an instance.
+   * Retrieve the health of the instance.
    * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetHealth }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options

--- a/packages/apis/src/generated/MetricsAPI.ts
+++ b/packages/apis/src/generated/MetricsAPI.ts
@@ -17,7 +17,7 @@ export class MetricsAPI {
     this.base = new APIBase(influxDB)
   }
   /**
-   * Get metrics of an instance.
+   * Retrieve workload performance metrics.
    * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetMetrics }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options

--- a/packages/apis/src/generated/PingAPI.ts
+++ b/packages/apis/src/generated/PingAPI.ts
@@ -17,7 +17,7 @@ export class PingAPI {
     this.base = new APIBase(influxDB)
   }
   /**
-   * Checks the status of InfluxDB instance and version of InfluxDB.
+   * Get the status and version of the instance.
    * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetPing }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options

--- a/packages/apis/src/generated/WriteAPI.ts
+++ b/packages/apis/src/generated/WriteAPI.ts
@@ -2,15 +2,31 @@ import {InfluxDB} from '@influxdata/influxdb-client'
 import {APIBase, RequestOptions} from '../APIBase'
 
 export interface PostWriteRequest {
-  /** Data in line protocol format. */
+  /** Data in line protocol format.
+
+To send compressed data, do the following:
+
+  1. Use [GZIP](https://www.gzip.org/) to compress the line protocol data.
+  2. In your request, send the compressed data and the
+     `Content-Encoding: gzip` header.
+
+#### Related guides
+
+- [Best practices for optimizing writes](https://docs.influxdata.com/influxdb/v2.2/write-data/best-practices/optimize-writes/).
+ */
   body: string
-  /** Destination organization for writes. The database writes all points in the batch to this organization. If you provide both `orgID` and `org` parameters, `org` takes precedence. */
+  /** The destination organization for writes.
+The database writes all points in the batch to this organization.
+If you provide both `orgID` and `org` parameters, `org` takes precedence.
+ */
   org: string
-  /** ID of the destination organization for writes. If both `orgID` and `org` are specified, `org` takes precedence. */
+  /** The ID of the destination organization for writes.
+If both `orgID` and `org` are specified, `org` takes precedence.
+ */
   orgID?: string
-  /** Destination bucket for writes. */
+  /** The destination bucket for writes. */
   bucket: string
-  /** Precision for unix timestamps in the line protocol of the request payload. */
+  /** The precision for unix timestamps in the line protocol batch. */
   precision?: any
 }
 /**

--- a/packages/apis/src/generated/types.ts
+++ b/packages/apis/src/generated/types.ts
@@ -540,7 +540,14 @@ export interface XYViewProperties {
  */
 export type ColorMapping = any
 
-export type XYGeom = 'line' | 'step' | 'stacked' | 'bar' | 'monotoneX'
+export type XYGeom =
+  | 'line'
+  | 'step'
+  | 'stacked'
+  | 'bar'
+  | 'monotoneX'
+  | 'stepBefore'
+  | 'stepAfter'
 
 export interface SingleStatViewProperties {
   type: 'single-stat'
@@ -1624,6 +1631,8 @@ export interface Organization {
 export interface PostOrganizationRequest {
   name: string
   description?: string
+  /** An optional list of email address's to be invited to the organization */
+  users?: string[]
 }
 
 export interface PatchOrganizationRequest {


### PR DESCRIPTION
Related to https://github.com/influxdata/openapi/pull/317

## Proposed Changes

- regenerate APIs from swagger
- rename invocable scripts to invokable scripts

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `yarn test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
