### PR TITLE
feat(core): allow custom transport options in a browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 1. [#442](https://github.com/influxdata/influxdb-client-js/pull/442): Regenerate APIs from swagger.
+1. [#447](https://github.com/influxdata/influxdb-client-js/pull/447): Allow custom transport options in a browser.
 
 ### Other
 

--- a/packages/core/src/impl/browser/FetchTransport.ts
+++ b/packages/core/src/impl/browser/FetchTransport.ts
@@ -205,6 +205,8 @@ export default class FetchTransport implements Transport {
         ...headers,
       },
       credentials: 'omit' as 'omit',
+      // override with custom transport options
+      ...this.connectionOptions.transportOptions,
       // allow to specify custom options, such as signal, in SendOptions
       ...other,
     }

--- a/packages/core/test/unit/impl/browser/FetchTransport.test.ts
+++ b/packages/core/test/unit/impl/browser/FetchTransport.test.ts
@@ -284,6 +284,28 @@ describe('FetchTransport', () => {
           }
         )
     })
+    it('uses custom transport options', async () => {
+      let request: any
+      emulateFetchApi(
+        {
+          headers: {'content-type': 'text/plain'},
+          body: '{}',
+        },
+        req => (request = req)
+      )
+      await transport.request('/whatever', '', {
+        method: 'GET',
+      })
+      expect(request?.credentials).is.deep.equal('omit')
+      const custom = new FetchTransport({
+        url: 'http://test:8086',
+        transportOptions: {credentials: 'my-val'},
+      })
+      await custom.request('/whatever', '', {
+        method: 'GET',
+      })
+      expect(request?.credentials).is.deep.equal('my-val')
+    })
   })
   describe('send', () => {
     const transport = new FetchTransport({url: 'http://test:8086'})
@@ -477,6 +499,45 @@ describe('FetchTransport', () => {
         })
       }
     )
+    it('uses custom transport options', async () => {
+      let request: any
+      emulateFetchApi(
+        {
+          headers: {'content-type': 'text/plain'},
+          body: '{}',
+        },
+        req => (request = req)
+      )
+      await new Promise(resolve =>
+        transport.send(
+          'http://test:8086',
+          '',
+          {method: 'POST'},
+          {
+            next: sinon.fake(),
+            complete: () => resolve(0),
+            error: resolve,
+          }
+        )
+      )
+      expect(request?.credentials).is.deep.equal('omit')
+      await new Promise(resolve =>
+        new FetchTransport({
+          url: 'http://test:8086',
+          transportOptions: {credentials: 'my-val'},
+        }).send(
+          'http://test:8086',
+          '',
+          {method: 'POST'},
+          {
+            next: sinon.fake(),
+            complete: () => resolve(0),
+            error: resolve,
+          }
+        )
+      )
+      expect(request?.credentials).is.deep.equal('my-val')
+    })
   })
   describe('chunkCombiner', () => {
     const options = {url: 'http://test:8086'}


### PR DESCRIPTION
Fixes #446 . Custom transport options are herein also accepted in a browser environment. 

For example: to change the [credentials](https://developer.mozilla.org/en-US/docs/Web/API/fetch#credentials) option from a default `omit` to `include` :

```js
new InfluxDB({
  url,
  token,
  transportOptions: {credentials: 'include'},
})
```  
## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
