### PR TITLE
docs: typo in comment of function convertTimeToNanos

### DIFF
--- a/packages/core/src/util/currentTime.ts
+++ b/packages/core/src/util/currentTime.ts
@@ -96,7 +96,7 @@ export const dateToProtocolTimestamp = {
 }
 
 /**
- * convertTimeToNanos converts of Point's timestamp to a string
+ * convertTimeToNanos converts Point's timestamp to a string.
  * @param value - supported timestamp value
  * @returns line protocol value
  */


### PR DESCRIPTION
This commit fixes a typo in the comment for the function `convertTimeToNanos`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `yarn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
