### PR TITLE
feat(core): allow to overwrite default write API HTTP path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.27.0 [unreleased]
 
+### Features
+
+1. [#449](https://github.com/influxdata/influxdb-client-js/pull/449): Allow to overwrite default write API HTTP path.
+
 ## 1.26.0 [2022-05-20]
 
 ### Features

--- a/packages/core/src/WriteApi.ts
+++ b/packages/core/src/WriteApi.ts
@@ -71,5 +71,5 @@ export default interface WriteApi extends PointSettings {
    * automatically initialized to `/api/v2/write?org=...`,
    * but it can be changed after the API is obtained.
    */
-  httpPath: string
+  path: string
 }

--- a/packages/core/src/WriteApi.ts
+++ b/packages/core/src/WriteApi.ts
@@ -65,4 +65,11 @@ export default interface WriteApi extends PointSettings {
    * @returns count of points that were not written to InfluxDB
    */
   dispose(): number
+
+  /**
+   * HTTP path and query parameters of InfluxDB query API. It is
+   * automatically initialized to `/api/v2/write?org=...`,
+   * but it can be changed after the API is obtained.
+   */
+  httpPath: string
 }

--- a/packages/core/src/impl/WriteApiImpl.ts
+++ b/packages/core/src/impl/WriteApiImpl.ts
@@ -67,9 +67,10 @@ class WriteBuffer {
 }
 
 export default class WriteApiImpl implements WriteApi {
+  public httpPath: string
+
   private writeBuffer: WriteBuffer
   private closed = false
-  private httpPath: string
   private writeOptions: WriteOptions
   private sendOptions: SendOptions
   private _timeoutHandle: any = undefined

--- a/packages/core/src/impl/WriteApiImpl.ts
+++ b/packages/core/src/impl/WriteApiImpl.ts
@@ -67,7 +67,7 @@ class WriteBuffer {
 }
 
 export default class WriteApiImpl implements WriteApi {
-  public httpPath: string
+  public path: string
 
   private writeBuffer: WriteBuffer
   private closed = false
@@ -87,11 +87,11 @@ export default class WriteApiImpl implements WriteApi {
     precision: WritePrecisionType,
     writeOptions?: Partial<WriteOptions>
   ) {
-    this.httpPath = `/api/v2/write?org=${encodeURIComponent(
+    this.path = `/api/v2/write?org=${encodeURIComponent(
       org
     )}&bucket=${encodeURIComponent(bucket)}&precision=${precision}`
     if (writeOptions?.consistency) {
-      this.httpPath += `&consistency=${encodeURIComponent(
+      this.path += `&consistency=${encodeURIComponent(
         writeOptions.consistency
       )}`
     }
@@ -238,7 +238,7 @@ export default class WriteApiImpl implements WriteApi {
           },
         }
         this.transport.send(
-          this.httpPath,
+          this.path,
           lines.join('\n'),
           this.sendOptions,
           callbacks

--- a/packages/core/test/unit/WriteApi.test.ts
+++ b/packages/core/test/unit/WriteApi.test.ts
@@ -661,5 +661,24 @@ describe('WriteApi', () => {
       expect(logs.warn).deep.equals([])
       expect(uri).match(/.*&consistency=quorum$/)
     })
+    it('allows to overwrite httpPath', async () => {
+      useSubject({})
+      expect(subject.path).match(/api\/v2\/write\?.*$/)
+      const customPath = '/custom/path?whathever=itis'
+      subject.path = customPath
+      let uri: any
+      nock(clientOptions.url)
+        .post(/.*/)
+        .reply(function(_uri, _requestBody) {
+          uri = this.req.path
+          return [204, '', {}]
+        })
+        .persist()
+      subject.writePoint(new Point('test').floatField('value', 1))
+      await subject.close()
+      expect(logs.error).has.length(0)
+      expect(logs.warn).deep.equals([])
+      expect(uri).equals(customPath)
+    })
   })
 })


### PR DESCRIPTION
This PR allows changing the default HTTP path of InfluxDB write API service so that any endpoint that accepts InfluxDB line protocol data can be used:

```
  const writeAPI = new InfluxDB({url, token}).getWriteApi(org, bucket, precision)
  writeAPI.httpPath = '/api/v1/influxdb/write'
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
