### PR TITLE
docs: typo in comment of function 'next' in interface CommunicationOb…

### DIFF
--- a/packages/core/src/results/CommunicationObserver.ts
+++ b/packages/core/src/results/CommunicationObserver.ts
@@ -16,7 +16,7 @@ export type ResponseStartedFn = (headers: Headers, statusCode?: number) => void
  */
 export interface CommunicationObserver<T> {
   /**
-   * Data chunk received, can be called mupliple times.
+   * Data chunk received, can be called multiple times.
    * @param data - data
    */
   next(data: T): void


### PR DESCRIPTION
This commit fixes a typo in the comment of function `next` in interface `CommunicationObserver`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `yarn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)