### PR TITLE
chore: remove name and version from private packages

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -1,7 +1,5 @@
 {
   "private": true,
-  "name": "@influxdata/influxdb-client-examples",
-  "version": "0.4.0",
   "license": "MIT",
   "scripts": {
     "browser": "node scripts/server.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "private": true,
-  "name": "@influxdata/influx",
   "description": "InfluxDB 2.x client",
   "workspaces": {
     "packages": [


### PR DESCRIPTION
This PR removes `name` and `version` from private package.json files, so they could not be used in any possible Dependency Confusion or supply chain substitution attacks.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
