### PR TITLE
chore(examples): reuse TCP connections in writeAdvanced example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 1. [#449](https://github.com/influxdata/influxdb-client-js/pull/449): Allow to overwrite default write API HTTP path.
 
+### Other
+
+1. [#455](https://github.com/influxdata/influxdb-client-js/pull/455): Improve `writeAdvanced.js` example.
+
 ## 1.26.0 [2022-05-20]
 
 ### Features

--- a/packages/core/src/QueryApi.ts
+++ b/packages/core/src/QueryApi.ts
@@ -111,7 +111,7 @@ export default interface QueryApi {
    * @param query - query
    * @param rowMapper - maps the supplied row to an item that is then collected,
    *  undefined return values are not collected. If no rowMapper is supplied,
-   *  `row => row.tableMeta.toObject(row.values)` is used.
+   *  `row => tableMeta.toObject(row.values)` is used.
    * @returns Promise of mapped results
    */
   collectRows<T>(

--- a/packages/core/src/results/AnnotatedCSVResponse.ts
+++ b/packages/core/src/results/AnnotatedCSVResponse.ts
@@ -38,7 +38,7 @@ export interface AnnotatedCSVResponse {
    *
    * @param rowMapper - maps the supplied row to an item that is then collected,
    *  undefined return values are not collected. If no rowMapper is supplied,
-   *  `row => row.tableMeta.toObject(row.values)` is used.
+   *  `row => tableMeta.toObject(row.values)` is used.
    * @returns Promise of mapped results
    */
   collectRows<T>(


### PR DESCRIPTION
This PR adds TCP connection reuse to writeAdvanced example. It also contains a few doc improvements.


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
