### PR TITLE
feat: add type definitions for typescript 4.7+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.28.0 [unreleased]
 
+### Features
+
+1. [#460](https://github.com/influxdata/influxdb-client-js/pull/460): Add type definitions for typescript 4.7+.
+
 ## 1.27.0 [2022-06-24]
 
 ### Features

--- a/packages/apis/package.json
+++ b/packages/apis/package.json
@@ -23,6 +23,7 @@
   "types": "dist/all.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/all.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "deno": "./dist/index.mjs",

--- a/packages/core-browser/package.json
+++ b/packages/core-browser/package.json
@@ -16,6 +16,7 @@
   "types": "dist/all.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/all.d.ts",
       "import": "./dist/index.browser.mjs",
       "require": "./dist/index.browser.js",
       "deno": "./dist/index.browser.mjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,6 +27,7 @@
   "types": "dist/all.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/all.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "deno": "./dist/index.browser.mjs",

--- a/packages/giraffe/package.json
+++ b/packages/giraffe/package.json
@@ -23,6 +23,7 @@
   "types": "dist/all.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/all.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "default": "./dist/index.js"


### PR DESCRIPTION
Fixes #459

## Proposed Changes
Pointers to type definitions are added to `package.json`'s `exports` section as explained in https://www.typescriptlang.org/docs/handbook/esm-node.html .

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
