### PR TITLE
fix(core): repair sanitizing of numbers and regular expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 1. [#460](https://github.com/influxdata/influxdb-client-js/pull/460): Add type definitions for typescript 4.7+.
 
+### Bug Fixes
+
+1. [#468](https://github.com/influxdata/influxdb-client-js/pull/468): Repair sanitizing of number and regexp values.
+
 ### Other
 
 1. [#462](https://github.com/influxdata/influxdb-client-js/pull/462): Upgrade to typescript 4.7.

--- a/packages/core/src/query/flux.ts
+++ b/packages/core/src/query/flux.ts
@@ -204,7 +204,9 @@ function sanitizeRegExp(value: any): string {
 }
 
 /**
- * Creates flux regexp literal.
+ * Creates flux regexp literal out of a regular expression. See
+ * https://docs.influxdata.com/flux/v0.x/data-types/basic/regexp/#regular-expression-syntax
+ * for details.
  */
 export function fluxRegExp(value: any): FluxParameterLike {
   // let the server decide if it can be parsed

--- a/packages/core/src/query/flux.ts
+++ b/packages/core/src/query/flux.ts
@@ -197,7 +197,10 @@ export function fluxDuration(value: any): FluxParameterLike {
 }
 
 function sanitizeRegExp(value: any): string {
-  return `regexp.compile(v: "${sanitizeString(value)}")`
+  if (value instanceof RegExp) {
+    return value.toString()
+  }
+  return new RegExp(value).toString()
 }
 
 /**

--- a/packages/core/src/query/flux.ts
+++ b/packages/core/src/query/flux.ts
@@ -112,24 +112,26 @@ export function fluxString(value: any): FluxParameterLike {
  * @throws Error if the the value cannot be sanitized
  */
 export function sanitizeFloat(value: any): string {
-  if (typeof value === 'number') {
-    if (!isFinite(value)) {
-      throw new Error(`not a flux float: ${value}`)
+  const val = Number(value)
+  if (!isFinite(val)) {
+    if (typeof value === 'number') {
+      return `float(v: "${val}")`
     }
-    return value.toString()
+    throw new Error(`not a flux float: ${value}`)
   }
-  const val = String(value)
-  let dot = false
-  for (const c of val) {
+  // try to return a flux float literal if possible
+  // https://docs.influxdata.com/flux/v0.x/data-types/basic/float/#float-syntax
+  const strVal = val.toString()
+  let hasDot = false
+  for (const c of strVal) {
+    if ((c >= '0' && c <= '9') || c == '-') continue
     if (c === '.') {
-      if (dot) throw new Error(`not a flux float: ${val}`)
-      dot = !dot
+      hasDot = true
       continue
     }
-    if (c !== '.' && c !== '-' && (c < '0' || c > '9'))
-      throw new Error(`not a flux float: ${val}`)
+    return `float(v: "${strVal}")`
   }
-  return val
+  return hasDot ? strVal : strVal + '.0'
 }
 /**
  * Creates a flux float literal.

--- a/packages/core/src/query/flux.ts
+++ b/packages/core/src/query/flux.ts
@@ -209,7 +209,7 @@ function sanitizeRegExp(value: any): string {
  * for details.
  */
 export function fluxRegExp(value: any): FluxParameterLike {
-  // let the server decide if it can be parsed
+  // let the server decide if a regexp can be parsed
   return new FluxParameter(sanitizeRegExp(value))
 }
 

--- a/packages/core/test/unit/query/flux.test.ts
+++ b/packages/core/test/unit/query/flux.test.ts
@@ -59,12 +59,19 @@ describe('Flux Values', () => {
     const subject = fluxFloat(123.456)
     expect(subject.toString()).equals('123.456')
     expect((subject as any)[FLUX_VALUE]()).equals('123.456')
-    expect(fluxFloat('-123').toString()).equals('-123')
+    expect(fluxFloat('-123').toString()).equals('-123.0')
+    expect(fluxFloat(1e20).toString()).equals('100000000000000000000.0')
+    expect(fluxFloat(1e-2).toString()).equals('0.01')
+    expect(fluxFloat(1e21).toString()).equals('float(v: "1e+21")')
+    expect(fluxFloat(1e-21).toString()).equals('float(v: "1e-21")')
+    expect(fluxFloat(Infinity).toString()).equals('float(v: "Infinity")')
+    expect(fluxFloat(-Infinity).toString()).equals('float(v: "-Infinity")')
+    expect(fluxFloat(NaN).toString()).equals('float(v: "NaN")')
     expect(() => fluxFloat('123..')).to.throw()
     expect(() => fluxFloat('123.a')).to.throw()
-    expect(() => fluxFloat(NaN)).to.throw()
-    expect(() => fluxFloat(Infinity)).to.throw()
-    expect(() => fluxFloat(-Infinity)).to.throw()
+    expect(() => fluxFloat({})).to.throw()
+    expect(() => fluxFloat(undefined)).to.throw()
+    expect(fluxFloat({toString: () => '1'}).toString()).equals('1.0')
   })
   it('creates fluxDuration', () => {
     const subject = fluxDuration('1ms')
@@ -101,6 +108,7 @@ describe('Flux Values', () => {
       {value: 1, flux: '1'},
       {value: 1.1, flux: '1.1'},
       {value: -1.1, flux: '-1.1'},
+      {value: -1e-21, flux: 'float(v: "-1e-21")'},
       {value: 'a', flux: '"a"'},
       {value: new Date(1589521447471), flux: '2020-05-15T05:44:07.471Z'},
       {value: /abc/, flux: 'regexp.compile(v: "/abc/")'},

--- a/packages/core/test/unit/query/flux.test.ts
+++ b/packages/core/test/unit/query/flux.test.ts
@@ -86,10 +86,8 @@ describe('Flux Values', () => {
     expect((subject as any)[FLUX_VALUE]()).equals(fluxValue)
   })
   it('creates fluxRegExp', () => {
-    const subject = fluxRegExp('/abc/')
-    const fluxValue = 'regexp.compile(v: "/abc/")'
-    expect(subject.toString()).equals(fluxValue)
-    expect((subject as any)[FLUX_VALUE]()).equals(fluxValue)
+    expect(fluxRegExp('abc').toString()).equals('/abc/')
+    expect(fluxRegExp(/abc/i).toString()).equals('/abc/i')
   })
   it('creates fluxString', () => {
     const subject = fluxString('abc')
@@ -111,7 +109,7 @@ describe('Flux Values', () => {
       {value: -1e-21, flux: 'float(v: "-1e-21")'},
       {value: 'a', flux: '"a"'},
       {value: new Date(1589521447471), flux: '2020-05-15T05:44:07.471Z'},
-      {value: /abc/, flux: 'regexp.compile(v: "/abc/")'},
+      {value: /abc/, flux: '/abc/'},
       {
         value: {
           toString: function (): string {
@@ -216,7 +214,7 @@ describe('Flux Tagged Template', () => {
         value: flux`${new Date(1589521447471)}`,
         flux: '2020-05-15T05:44:07.471Z',
       },
-      {value: flux`${/abc/}`, flux: 'regexp.compile(v: "/abc/")'},
+      {value: flux`${/abc/}`, flux: '/abc/'},
       {
         value: flux`${{
           toString: function (): string {

--- a/packages/core/test/unit/query/flux.test.ts
+++ b/packages/core/test/unit/query/flux.test.ts
@@ -31,6 +31,15 @@ describe('Flux Values', () => {
     expect(() => fluxInteger(NaN)).to.throw()
     expect(() => fluxInteger(Infinity)).to.throw()
     expect(() => fluxInteger(-Infinity)).to.throw()
+    expect(() => fluxInteger('')).to.throw()
+    expect(fluxInteger('-9223372036854775808').toString()).equals(
+      '-9223372036854775808'
+    )
+    expect(() => fluxInteger('-9223372036854775809').toString()).throws()
+    expect(fluxInteger('9223372036854775807').toString()).equals(
+      '9223372036854775807'
+    )
+    expect(() => fluxInteger('9223372036854775808').toString()).throws()
   })
   it('creates fluxBool', () => {
     expect(fluxBool('true').toString()).equals('true')


### PR DESCRIPTION
Fixes #467

Sanitizing of JS values to flux values is revised herein. 

## Proposed Changes
This PR fixes sanitizing of flux values so that
- a float value is represented as [a flux float literal](https://docs.influxdata.com/flux/v0.x/data-types/basic/float/#float-syntax) if possible or as `float(v: "${value}")` if it is not
- an integer value must strictly match https://docs.influxdata.com/flux/v0.x/data-types/basic/int/
- a regexp value is represented as [a regexp literal](https://docs.influxdata.com/flux/v0.x/data-types/basic/regexp/#regular-expression-syntax)
   - documentation improved with a pointer to flux documentation of regexp

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
