### PR TITLE
feat(core): support bigint in flux tagged template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 1. [#460](https://github.com/influxdata/influxdb-client-js/pull/460): Add type definitions for typescript 4.7+.
+1. [#469](https://github.com/influxdata/influxdb-client-js/pull/469): Support bigint in flux tagged template.
 
 ### Bug Fixes
 

--- a/packages/core/src/query/flux.ts
+++ b/packages/core/src/query/flux.ts
@@ -262,8 +262,10 @@ export function toFluxValue(value: any): string {
     } else if (Array.isArray(value)) {
       return `[${value.map(toFluxValue).join(',')}]`
     }
+  } else if (typeof value === 'bigint') {
+    return `${value}.0`
   }
-  // use toString value for unrecognized object, bigint, symbol
+  // use toString value for unrecognized object, symbol
   return toFluxValue(value.toString())
 }
 

--- a/packages/core/test/unit/query/flux.test.ts
+++ b/packages/core/test/unit/query/flux.test.ts
@@ -40,6 +40,12 @@ describe('Flux Values', () => {
       '9223372036854775807'
     )
     expect(() => fluxInteger('9223372036854775808').toString()).throws()
+    expect(fluxInteger(BigInt('-9223372036854775808')).toString()).equals(
+      '-9223372036854775808'
+    )
+    expect(fluxInteger(BigInt('9223372036854775807')).toString()).equals(
+      '9223372036854775807'
+    )
   })
   it('creates fluxBool', () => {
     expect(fluxBool('true').toString()).equals('true')
@@ -72,6 +78,7 @@ describe('Flux Values', () => {
     expect(() => fluxFloat({})).to.throw()
     expect(() => fluxFloat(undefined)).to.throw()
     expect(fluxFloat({toString: () => '1'}).toString()).equals('1.0')
+    expect(fluxFloat(BigInt('10')).toString()).equals('10.0')
   })
   it('creates fluxDuration', () => {
     const subject = fluxDuration('1ms')
@@ -126,6 +133,10 @@ describe('Flux Values', () => {
       {value: [], flux: '[]'},
       {value: ['a"$d'], flux: '["a\\"$d"]'},
       {value: Symbol('thisSym'), flux: `"${Symbol('thisSym').toString()}"`},
+      {
+        value: BigInt('123456789123456789123456789'),
+        flux: '123456789123456789123456789.0',
+      },
     ]
     pairs.forEach((pair) => {
       it(`converts ${JSON.stringify(String(pair.value))} to '${

--- a/packages/core/test/unit/query/flux.test.ts
+++ b/packages/core/test/unit/query/flux.test.ts
@@ -245,6 +245,10 @@ describe('Flux Tagged Template', () => {
         value: flux`${Symbol('thisSym')}`,
         flux: `"${Symbol('thisSym').toString()}"`,
       },
+      {
+        value: flux`${BigInt('123456789123456789123456789')}`,
+        flux: `123456789123456789123456789.0`,
+      },
     ]
     pairs.forEach((pair) => {
       expect(pair.value.toString()).equals(pair.flux)


### PR DESCRIPTION
This PR adds support for `bigint` values to flux tagged template. Bigint is properly supported in `fluxInteger`, `toFluxValue` and `fluxFloat` flux converters.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
