### PR TITLE
fix(giraffe): repair build to rely upon rollup browser support

### DIFF
--- a/packages/apis/package.json
+++ b/packages/apis/package.json
@@ -24,15 +24,15 @@
   "exports": {
     ".": {
       "types": "./dist/all.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "deno": "./dist/index.mjs",
       "browser": {
         "import": "./dist/index.mjs",
         "require": "./dist/index.js",
         "umd": "./dist/index.browser.js",
         "script": "./dist/influxdbApis.js"
-      }
+      },
+      "deno": "./dist/index.mjs",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
     }
   },
   "homepage": "https://github.com/influxdata/influxdb-client-js",

--- a/packages/apis/package.json
+++ b/packages/apis/package.json
@@ -4,7 +4,7 @@
   "description": "InfluxDB 2.x generated APIs",
   "scripts": {
     "apidoc:extract": "api-extractor run",
-    "build": "yarn run clean && yarn run lint && rollup -c",
+    "build": "yarn run clean && yarn run lint && rollup --failAfterWarnings  -c",
     "clean": "rimraf build doc dist reports",
     "clean:apis": "rimraf src/generated/*API.ts",
     "generate": "yarn ts-node generator && yarn prettier --write src/generated/*.ts",

--- a/packages/core-browser/package.json
+++ b/packages/core-browser/package.json
@@ -17,19 +17,15 @@
   "exports": {
     ".": {
       "types": "./dist/all.d.ts",
-      "import": "./dist/index.browser.mjs",
-      "require": "./dist/index.browser.js",
-      "deno": "./dist/index.browser.mjs",
-      "node": {
-        "import": "./dist/index.mjs",
-        "require": "./dist/index.js"
-      },
       "browser": {
         "import": "./dist/index.browser.mjs",
         "require": "./dist/index.browser.js",
         "script": "./dist/influxdb.js",
         "umd": "./dist/index.browser.js"
-      }
+      },
+      "deno": "./dist/index.browser.mjs",
+      "import": "./dist/index.browser.mjs",
+      "require": "./dist/index.browser.js"
     }
   },
   "homepage": "https://github.com/influxdata/influxdb-client-js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,7 @@
   "description": "InfluxDB 2.x client",
   "scripts": {
     "apidoc:extract": "api-extractor run",
-    "build": "yarn run clean && rollup -c",
+    "build": "yarn run clean && rollup --failAfterWarnings -c",
     "clean": "rimraf dist build coverage .nyc_output doc *.lcov reports",
     "coverage": "nyc mocha --require ts-node/register 'test/**/*.test.ts' --exit",
     "coverage:ci": "yarn run coverage && yarn run coverage:lcov",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,15 +28,15 @@
   "exports": {
     ".": {
       "types": "./dist/all.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "deno": "./dist/index.browser.mjs",
       "browser": {
         "import": "./dist/index.browser.mjs",
         "require": "./dist/index.browser.js",
         "script": "./dist/influxdb.js",
         "default": "./dist/index.browser.js"
-      }
+      },
+      "deno": "./dist/index.browser.mjs",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
     }
   },
   "homepage": "https://github.com/influxdata/influxdb-client-js",

--- a/packages/giraffe/package.json
+++ b/packages/giraffe/package.json
@@ -48,7 +48,6 @@
     "@influxdata/influxdb-client": "^1.27.0",
     "@microsoft/api-extractor": "^7.28.4",
     "@rollup/plugin-node-resolve": "^13.3.0",
-    "@rollup/plugin-replace": "^2.3.0",
     "@types/chai": "^4.2.5",
     "@types/mocha": "^5.2.7",
     "@types/node": "^18",

--- a/packages/giraffe/package.json
+++ b/packages/giraffe/package.json
@@ -4,7 +4,7 @@
   "description": "InfluxDB 2.x client - giraffe integration",
   "scripts": {
     "apidoc:extract": "api-extractor run",
-    "build": "yarn run clean && rollup -c",
+    "build": "yarn run clean && rollup --failAfterWarnings -c",
     "clean": "rimraf dist build coverage .nyc_output doc *.lcov reports",
     "coverage": "nyc mocha --require ts-node/register 'test/**/*.test.ts' --exit",
     "coverage:ci": "yarn run coverage && yarn run coverage:lcov",

--- a/packages/giraffe/rollup.config.js
+++ b/packages/giraffe/rollup.config.js
@@ -23,7 +23,7 @@ function createConfig({format, out, name, target, noTerser}) {
       }),
       // @influxdata/influxdb-client (core) package uses `module:browser`
       // property in its package.json to point to an ES module created for the browser
-      resolve({mainFields: ['module:browser']}),
+      resolve({browser: true}),
       noTerser ? undefined : terser(),
       gzip(),
     ],

--- a/packages/giraffe/rollup.config.js
+++ b/packages/giraffe/rollup.config.js
@@ -21,8 +21,6 @@ function createConfig({format, out, name, target, noTerser}) {
           },
         },
       }),
-      // @influxdata/influxdb-client (core) package uses `module:browser`
-      // property in its package.json to point to an ES module created for the browser
       resolve({browser: true}),
       noTerser ? undefined : terser(),
       gzip(),


### PR DESCRIPTION
This PR repairs `@influxdata/influxdb-client-giraffe` build to produce browser code. 

#473 introduces the newest version of `@rollup/plugin-node-resolve` that prefers `package.json`'s `exports` field to determine the file to use. The old configuration did not work anymore and resulted in importing a node.js bundle with wrong dependencies on node packages.

## Proposed Changes
- giraffe package: rollup resolve config was changed to use `browser: true`
- package.json of 'core', 'apis', 'core-browser' packages was changed so that `exports/browser` is before `exports/import`, which is required for rollup to pickup browser distribution properly ... the order of exports matters, 'import' is always chosen by rollup when found before 'browser' ... which is the root caused that caused the problems
- any rollup warning results in build failure, applied to all packages

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
