### PR TITLE
fix: `Module '"chalk"' has no exported member 'yellow'`

### DIFF
--- a/packages/apis/generator/logger.ts
+++ b/packages/apis/generator/logger.ts
@@ -1,9 +1,9 @@
-import {yellow} from 'chalk'
+import chalk from 'chalk'
 
 /* eslint-disable no-console */
 const logger = {
   warn(message: string, ...otherParameters: any[]): void {
-    message = yellow(message)
+    message = chalk.yellow(message)
     if (otherParameters.length) {
       console.warn(message, ...otherParameters)
     } else {


### PR DESCRIPTION
## Proposed Changes

This PR fix error during `yarn test`:

```
generator/logger.ts:1:9 - error TS2614: Module '"chalk"' has no exported member 'yellow'. Did you mean to use 'import yellow from "chalk"' instead?

1 import {yellow} from 'chalk'
          ~~~~~~


Found 1 error in generator/logger.ts:1

```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `yarn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
