### PR TITLE
fix(ci): add typescript check to test:ci target of api package

### DIFF
--- a/packages/apis/package.json
+++ b/packages/apis/package.json
@@ -10,7 +10,7 @@
     "generate": "yarn ts-node generator && yarn prettier --write src/generated/*.ts",
     "test": "yarn run lint && yarn run typecheck && yarn run test:unit",
     "test:unit": "mocha --require ts-node/register 'test/unit/**/*.test.ts' --exit",
-    "test:ci": "yarn run lint:ci && yarn run test:unit --reporter mocha-junit-reporter --reporter-options mochaFile=../../reports/apis_mocha/test-results.xml",
+    "test:ci": "yarn run typecheck && yarn run lint:ci && yarn run test:unit --reporter mocha-junit-reporter --reporter-options mochaFile=../../reports/apis_mocha/test-results.xml",
     "typecheck": "tsc --noEmit --pretty",
     "lint": "eslint 'src/**/*.ts'",
     "lint:ci": "yarn run lint --format junit --output-file ../../reports/apis_eslint/eslint.xml",


### PR DESCRIPTION
This PR adds typescript checking to `test:ci` target of `api` package. 

Previously https://github.com/influxdata/influxdb-client-js/pull/474 passed, but it introduced a type error that was not triggered by circle CI within the PR, the overall tests should fail. They will fail after this PR. 

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `yarn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
