### PR TITLE
chore: remove direct dependency on chalk

### DIFF
--- a/packages/apis/generator/logger.ts
+++ b/packages/apis/generator/logger.ts
@@ -1,9 +1,7 @@
-import chalk from 'chalk'
-
 /* eslint-disable no-console */
 const logger = {
   warn(message: string, ...otherParameters: any[]): void {
-    message = chalk.yellow(message)
+    message = `\u001b[33m${message}\u001b[0m` // wrap to yellow
     if (otherParameters.length) {
       console.warn(message, ...otherParameters)
     } else {

--- a/packages/apis/package.json
+++ b/packages/apis/package.json
@@ -59,7 +59,6 @@
     "@typescript-eslint/eslint-plugin": "^5.29.0",
     "@typescript-eslint/parser": "^5.29.0",
     "chai": "^4.2.0",
-    "chalk": "^5.0.1",
     "eslint": "^8.18.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2118,11 +2118,6 @@ chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.0.1.tgz#ca57d71e82bb534a296df63bbacc4a1c22b2a4b6"
-  integrity sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==
-
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"


### PR DESCRIPTION
This PR removes chalk from client dev dependencies, it uses simpler code instead. The dependency was removed because it caused collisions during dependabot updates (#508 and #502).

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
