### PR TITLE
fix(apidoc): repair generated links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Other
 
 1. [#511](https://github.com/influxdata/influxdb-client-js/pull/511): Replace rollup with tsup.
+1. [#514](https://github.com/influxdata/influxdb-client-js/pull/514): Repair links in generated API documentation.
 
 ## 1.28.0 [2022-07-29]
 

--- a/examples/delete.ts
+++ b/examples/delete.ts
@@ -1,9 +1,9 @@
 #!./node_modules/.bin/ts-node
 
-///////////////////////////////////////////////////////////////////////
-// Shows how to delete data from InfluxDB. See                       //
-// https://docs.influxdata.com/influxdb/v2.1/write-data/delete-data/ //
-///////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////
+// Shows how to delete data from InfluxDB. See                         //
+// https://docs.influxdata.com/influxdb/latest/write-data/delete-data/ //
+/////////////////////////////////////////////////////////////////////////
 
 import {InfluxDB} from '@influxdata/influxdb-client'
 import {DeleteAPI} from '@influxdata/influxdb-client-apis'
@@ -36,7 +36,7 @@ async function deleteData(): Promise<void> {
     body: {
       start: start.toISOString(),
       stop: stop.toISOString(),
-      // see https://docs.influxdata.com/influxdb/v2.1/reference/syntax/delete-predicate/
+      // see https://docs.influxdata.com/influxdb/latest/reference/syntax/delete-predicate/
       predicate: '_measurement="temperature"',
     },
   })

--- a/examples/query.ts
+++ b/examples/query.ts
@@ -15,7 +15,7 @@ console.log('*** QUERY ROWS ***')
 // the essential ones are shown/commented below. See also rxjs-query.ts .
 //
 // Execute query and receive table metadata and rows as they arrive from the server.
-// https://docs.influxdata.com/influxdb/v2.1/reference/syntax/annotated-csv/
+// https://docs.influxdata.com/influxdb/latest/reference/syntax/annotated-csv/
 queryApi.queryRows(fluxQuery, {
   next: (row: string[], tableMeta: FluxTableMetaData) => {
     // the following line creates an object for each row

--- a/examples/rxjs-query.ts
+++ b/examples/rxjs-query.ts
@@ -15,7 +15,7 @@ const fluxQuery =
 
 console.log('*** QUERY ROWS ***')
 // performs query and receive line table metadata and rows
-// https://docs.influxdata.com/influxdb/v2.1/reference/syntax/annotated-csv/
+// https://docs.influxdata.com/influxdb/latest/reference/syntax/annotated-csv/
 from(queryApi.rows(fluxQuery))
   .pipe(map(({values, tableMeta}) => tableMeta.toObject(values)))
   .subscribe({
@@ -34,5 +34,5 @@ from(queryApi.rows(fluxQuery))
   })
 
 // performs query and receive line results in annotated csv format
-// https://docs.influxdata.com/influxdb/v2.1/reference/syntax/annotated-csv/
+// https://docs.influxdata.com/influxdb/latest/reference/syntax/annotated-csv/
 // from(queryApi.lines(fluxQuery)).forEach(console.log)

--- a/packages/apis/generator/generateApi.ts
+++ b/packages/apis/generator/generateApi.ts
@@ -96,7 +96,7 @@ function apiDocLink(apiName: string, opID: string): string {
   if (CLOUD_APIS.includes(apiName)) {
     return `https://docs.influxdata.com/influxdb/cloud/api/#operation/${opID}`
   }
-  return `https://docs.influxdata.com/influxdb/v2.1/api/#operation/${opID}`
+  return `https://docs.influxdata.com/influxdb/v2.3/api/#operation/${opID}`
 }
 
 function generateClass(

--- a/packages/apis/src/generated/AuthorizationsAPI.ts
+++ b/packages/apis/src/generated/AuthorizationsAPI.ts
@@ -51,7 +51,7 @@ export class AuthorizationsAPI {
   }
   /**
    * List all authorizations.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetAuthorizations }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetAuthorizations }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -74,7 +74,7 @@ export class AuthorizationsAPI {
   }
   /**
    * Create an authorization.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostAuthorizations }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostAuthorizations }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -93,7 +93,7 @@ export class AuthorizationsAPI {
   }
   /**
    * Retrieve an authorization.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetAuthorizationsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetAuthorizationsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -111,7 +111,7 @@ export class AuthorizationsAPI {
   }
   /**
    * Update an authorization to be active or inactive.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PatchAuthorizationsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PatchAuthorizationsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -130,7 +130,7 @@ export class AuthorizationsAPI {
   }
   /**
    * Delete an authorization.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteAuthorizationsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteAuthorizationsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/BackupAPI.ts
+++ b/packages/apis/src/generated/BackupAPI.ts
@@ -26,7 +26,7 @@ export class BackupAPI {
   }
   /**
    * Download snapshot of metadata stored in the server's embedded KV store. Should not be used in versions greater than 2.1.x, as it doesn't include metadata stored in embedded SQL.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetBackupKV }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetBackupKV }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -44,7 +44,7 @@ export class BackupAPI {
   }
   /**
    * Download snapshot of all metadata in the server.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetBackupMetadata }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetBackupMetadata }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -62,7 +62,7 @@ export class BackupAPI {
   }
   /**
    * Download snapshot of all TSM data in a shard.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetBackupShardId }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetBackupShardId }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/BucketsAPI.ts
+++ b/packages/apis/src/generated/BucketsAPI.ts
@@ -112,7 +112,7 @@ export class BucketsAPI {
   }
   /**
    * List all buckets.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetBuckets }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetBuckets }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -138,7 +138,7 @@ export class BucketsAPI {
   }
   /**
    * Create a bucket.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostBuckets }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostBuckets }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -157,7 +157,7 @@ export class BucketsAPI {
   }
   /**
    * Retrieve a bucket.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetBucketsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetBucketsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -175,7 +175,7 @@ export class BucketsAPI {
   }
   /**
    * Update a bucket.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PatchBucketsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PatchBucketsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -194,7 +194,7 @@ export class BucketsAPI {
   }
   /**
    * Delete a bucket.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteBucketsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteBucketsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -212,7 +212,7 @@ export class BucketsAPI {
   }
   /**
    * List all labels for a bucket.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetBucketsIDLabels }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetBucketsIDLabels }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -230,7 +230,7 @@ export class BucketsAPI {
   }
   /**
    * Add a label to a bucket.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostBucketsIDLabels }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostBucketsIDLabels }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -249,7 +249,7 @@ export class BucketsAPI {
   }
   /**
    * Delete a label from a bucket.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteBucketsIDLabelsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteBucketsIDLabelsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -267,7 +267,7 @@ export class BucketsAPI {
   }
   /**
    * List all users with member privileges for a bucket.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetBucketsIDMembers }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetBucketsIDMembers }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -285,7 +285,7 @@ export class BucketsAPI {
   }
   /**
    * Add a member to a bucket.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostBucketsIDMembers }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostBucketsIDMembers }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -304,7 +304,7 @@ export class BucketsAPI {
   }
   /**
    * Remove a member from a bucket.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteBucketsIDMembersID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteBucketsIDMembersID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -322,7 +322,7 @@ export class BucketsAPI {
   }
   /**
    * List all owners of a bucket.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetBucketsIDOwners }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetBucketsIDOwners }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -340,7 +340,7 @@ export class BucketsAPI {
   }
   /**
    * Add an owner to a bucket.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostBucketsIDOwners }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostBucketsIDOwners }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -359,7 +359,7 @@ export class BucketsAPI {
   }
   /**
    * Remove an owner from a bucket.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteBucketsIDOwnersID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteBucketsIDOwnersID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/ChecksAPI.ts
+++ b/packages/apis/src/generated/ChecksAPI.ts
@@ -77,7 +77,7 @@ export class ChecksAPI {
   }
   /**
    * List all checks.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetChecks }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetChecks }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -99,7 +99,7 @@ export class ChecksAPI {
   }
   /**
    * Add new check.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/CreateCheck }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/CreateCheck }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -118,7 +118,7 @@ export class ChecksAPI {
   }
   /**
    * Retrieve a check.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetChecksID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetChecksID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -136,7 +136,7 @@ export class ChecksAPI {
   }
   /**
    * Update a check.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PutChecksID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PutChecksID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -155,7 +155,7 @@ export class ChecksAPI {
   }
   /**
    * Update a check.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PatchChecksID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PatchChecksID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -174,7 +174,7 @@ export class ChecksAPI {
   }
   /**
    * Delete a check.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteChecksID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteChecksID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -192,7 +192,7 @@ export class ChecksAPI {
   }
   /**
    * List all labels for a check.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetChecksIDLabels }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetChecksIDLabels }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -210,7 +210,7 @@ export class ChecksAPI {
   }
   /**
    * Add a label to a check.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostChecksIDLabels }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostChecksIDLabels }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -229,7 +229,7 @@ export class ChecksAPI {
   }
   /**
    * Delete label from a check.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteChecksIDLabelsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteChecksIDLabelsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -247,7 +247,7 @@ export class ChecksAPI {
   }
   /**
    * Retrieve a check query.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetChecksIDQuery }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetChecksIDQuery }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/ConfigAPI.ts
+++ b/packages/apis/src/generated/ConfigAPI.ts
@@ -19,7 +19,7 @@ export class ConfigAPI {
   }
   /**
    * Retrieve runtime configuration.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetConfig }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetConfig }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/DashboardsAPI.ts
+++ b/packages/apis/src/generated/DashboardsAPI.ts
@@ -167,7 +167,7 @@ export class DashboardsAPI {
   }
   /**
    * Retrieve a dashboard.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetDashboardsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetDashboardsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -188,7 +188,7 @@ export class DashboardsAPI {
   }
   /**
    * Update a dashboard.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PatchDashboardsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PatchDashboardsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -207,7 +207,7 @@ export class DashboardsAPI {
   }
   /**
    * Delete a dashboard.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteDashboardsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteDashboardsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -225,7 +225,7 @@ export class DashboardsAPI {
   }
   /**
    * Create a dashboard cell.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostDashboardsIDCells }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostDashboardsIDCells }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -244,7 +244,7 @@ export class DashboardsAPI {
   }
   /**
    * Replace cells in a dashboard.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PutDashboardsIDCells }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PutDashboardsIDCells }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -263,7 +263,7 @@ export class DashboardsAPI {
   }
   /**
    * Update the non-positional information related to a cell.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PatchDashboardsIDCellsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PatchDashboardsIDCellsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -282,7 +282,7 @@ export class DashboardsAPI {
   }
   /**
    * Delete a dashboard cell.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteDashboardsIDCellsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteDashboardsIDCellsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -300,7 +300,7 @@ export class DashboardsAPI {
   }
   /**
    * Retrieve the view for a cell.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetDashboardsIDCellsIDView }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetDashboardsIDCellsIDView }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -318,7 +318,7 @@ export class DashboardsAPI {
   }
   /**
    * Update the view for a cell.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PatchDashboardsIDCellsIDView }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PatchDashboardsIDCellsIDView }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -337,7 +337,7 @@ export class DashboardsAPI {
   }
   /**
    * List all labels for a dashboard.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetDashboardsIDLabels }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetDashboardsIDLabels }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -355,7 +355,7 @@ export class DashboardsAPI {
   }
   /**
    * Add a label to a dashboard.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostDashboardsIDLabels }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostDashboardsIDLabels }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -374,7 +374,7 @@ export class DashboardsAPI {
   }
   /**
    * Delete a label from a dashboard.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteDashboardsIDLabelsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteDashboardsIDLabelsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -392,7 +392,7 @@ export class DashboardsAPI {
   }
   /**
    * List all dashboard members.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetDashboardsIDMembers }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetDashboardsIDMembers }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -410,7 +410,7 @@ export class DashboardsAPI {
   }
   /**
    * Add a member to a dashboard.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostDashboardsIDMembers }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostDashboardsIDMembers }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -429,7 +429,7 @@ export class DashboardsAPI {
   }
   /**
    * Remove a member from a dashboard.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteDashboardsIDMembersID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteDashboardsIDMembersID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -447,7 +447,7 @@ export class DashboardsAPI {
   }
   /**
    * List all dashboard owners.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetDashboardsIDOwners }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetDashboardsIDOwners }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -465,7 +465,7 @@ export class DashboardsAPI {
   }
   /**
    * Add an owner to a dashboard.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostDashboardsIDOwners }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostDashboardsIDOwners }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -484,7 +484,7 @@ export class DashboardsAPI {
   }
   /**
    * Remove an owner from a dashboard.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteDashboardsIDOwnersID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteDashboardsIDOwnersID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -502,7 +502,7 @@ export class DashboardsAPI {
   }
   /**
    * List all dashboards.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetDashboards }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetDashboards }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -529,7 +529,7 @@ export class DashboardsAPI {
   }
   /**
    * Create a dashboard.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostDashboards }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostDashboards }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/DbrpsAPI.ts
+++ b/packages/apis/src/generated/DbrpsAPI.ts
@@ -64,7 +64,7 @@ export class DbrpsAPI {
   }
   /**
    * List database retention policy mappings.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetDBRPs }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetDBRPs }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -90,7 +90,7 @@ export class DbrpsAPI {
   }
   /**
    * Add a database retention policy mapping.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostDBRP }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostDBRP }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -109,7 +109,7 @@ export class DbrpsAPI {
   }
   /**
    * Retrieve a database retention policy mapping.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetDBRPsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetDBRPsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -130,7 +130,7 @@ export class DbrpsAPI {
   }
   /**
    * Update a database retention policy mapping.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PatchDBRPID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PatchDBRPID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -152,7 +152,7 @@ export class DbrpsAPI {
   }
   /**
    * Delete a database retention policy.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteDBRPID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteDBRPID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/DebugAPI.ts
+++ b/packages/apis/src/generated/DebugAPI.ts
@@ -120,7 +120,7 @@ export class DebugAPI {
   }
   /**
    * Retrieve all runtime profiles.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetDebugPprofAllProfiles }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetDebugPprofAllProfiles }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -138,7 +138,7 @@ export class DebugAPI {
   }
   /**
    * Retrieve the memory allocations runtime profile.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetDebugPprofAllocs }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetDebugPprofAllocs }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -159,7 +159,7 @@ export class DebugAPI {
   }
   /**
    * Retrieve the block runtime profile.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetDebugPprofBlock }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetDebugPprofBlock }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -180,7 +180,7 @@ export class DebugAPI {
   }
   /**
    * Retrieve the command line invocation.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetDebugPprofCmdline }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetDebugPprofCmdline }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -198,7 +198,7 @@ export class DebugAPI {
   }
   /**
    * Retrieve the goroutines runtime profile.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetDebugPprofGoroutine }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetDebugPprofGoroutine }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -219,7 +219,7 @@ export class DebugAPI {
   }
   /**
    * Retrieve the heap runtime profile.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetDebugPprofHeap }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetDebugPprofHeap }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -241,7 +241,7 @@ export class DebugAPI {
   }
   /**
    * Retrieve the mutual exclusion (mutex) runtime profile.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetDebugPprofMutex }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetDebugPprofMutex }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -262,7 +262,7 @@ export class DebugAPI {
   }
   /**
    * Retrieve the CPU runtime profile.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetDebugPprofProfile }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetDebugPprofProfile }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -282,7 +282,7 @@ export class DebugAPI {
   }
   /**
    * Retrieve the threadcreate runtime profile.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetDebugPprofThreadCreate }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetDebugPprofThreadCreate }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -303,7 +303,7 @@ export class DebugAPI {
   }
   /**
    * Retrieve the runtime execution trace.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetDebugPprofTrace }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetDebugPprofTrace }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/DeleteAPI.ts
+++ b/packages/apis/src/generated/DeleteAPI.ts
@@ -30,7 +30,7 @@ export class DeleteAPI {
   }
   /**
    * Delete data.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostDelete }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostDelete }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/FlagsAPI.ts
+++ b/packages/apis/src/generated/FlagsAPI.ts
@@ -19,7 +19,7 @@ export class FlagsAPI {
   }
   /**
    * Return the feature flags for the currently authenticated user.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetFlags }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetFlags }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/HealthAPI.ts
+++ b/packages/apis/src/generated/HealthAPI.ts
@@ -19,7 +19,7 @@ export class HealthAPI {
   }
   /**
    * Retrieve the health of the instance.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetHealth }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetHealth }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/LabelsAPI.ts
+++ b/packages/apis/src/generated/LabelsAPI.ts
@@ -45,7 +45,7 @@ export class LabelsAPI {
   }
   /**
    * List all labels.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetLabels }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetLabels }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -63,7 +63,7 @@ export class LabelsAPI {
   }
   /**
    * Create a label.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostLabels }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostLabels }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -82,7 +82,7 @@ export class LabelsAPI {
   }
   /**
    * Retrieve a label.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetLabelsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetLabelsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -100,7 +100,7 @@ export class LabelsAPI {
   }
   /**
    * Update a label.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PatchLabelsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PatchLabelsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -119,7 +119,7 @@ export class LabelsAPI {
   }
   /**
    * Delete a label.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteLabelsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteLabelsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/LegacyAPI.ts
+++ b/packages/apis/src/generated/LegacyAPI.ts
@@ -62,7 +62,7 @@ export class LegacyAPI {
   }
   /**
    * List all legacy authorizations.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetLegacyAuthorizations }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetLegacyAuthorizations }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -87,7 +87,7 @@ export class LegacyAPI {
   }
   /**
    * Create a legacy authorization.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostLegacyAuthorizations }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostLegacyAuthorizations }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -106,7 +106,7 @@ export class LegacyAPI {
   }
   /**
    * Retrieve a legacy authorization.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetLegacyAuthorizationsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetLegacyAuthorizationsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -124,7 +124,7 @@ export class LegacyAPI {
   }
   /**
    * Update a legacy authorization to be active or inactive.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PatchLegacyAuthorizationsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PatchLegacyAuthorizationsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -143,7 +143,7 @@ export class LegacyAPI {
   }
   /**
    * Delete a legacy authorization.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteLegacyAuthorizationsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteLegacyAuthorizationsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -161,7 +161,7 @@ export class LegacyAPI {
   }
   /**
    * Set a legacy authorization password.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostLegacyAuthorizationsIDPassword }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostLegacyAuthorizationsIDPassword }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/MeAPI.ts
+++ b/packages/apis/src/generated/MeAPI.ts
@@ -24,7 +24,7 @@ export class MeAPI {
   }
   /**
    * Retrieve the currently authenticated user.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetMe }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetMe }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -37,7 +37,7 @@ export class MeAPI {
   }
   /**
    * Update a password.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PutMePassword }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PutMePassword }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/MetricsAPI.ts
+++ b/packages/apis/src/generated/MetricsAPI.ts
@@ -18,7 +18,7 @@ export class MetricsAPI {
   }
   /**
    * Retrieve workload performance metrics.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetMetrics }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetMetrics }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/NotificationEndpointsAPI.ts
+++ b/packages/apis/src/generated/NotificationEndpointsAPI.ts
@@ -72,7 +72,7 @@ export class NotificationEndpointsAPI {
   }
   /**
    * List all notification endpoints.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetNotificationEndpoints }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetNotificationEndpoints }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -94,7 +94,7 @@ export class NotificationEndpointsAPI {
   }
   /**
    * Add a notification endpoint.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/CreateNotificationEndpoint }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/CreateNotificationEndpoint }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -113,7 +113,7 @@ export class NotificationEndpointsAPI {
   }
   /**
    * Retrieve a notification endpoint.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetNotificationEndpointsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetNotificationEndpointsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -131,7 +131,7 @@ export class NotificationEndpointsAPI {
   }
   /**
    * Update a notification endpoint.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PutNotificationEndpointsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PutNotificationEndpointsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -150,7 +150,7 @@ export class NotificationEndpointsAPI {
   }
   /**
    * Update a notification endpoint.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PatchNotificationEndpointsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PatchNotificationEndpointsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -169,7 +169,7 @@ export class NotificationEndpointsAPI {
   }
   /**
    * Delete a notification endpoint.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteNotificationEndpointsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteNotificationEndpointsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -187,7 +187,7 @@ export class NotificationEndpointsAPI {
   }
   /**
    * List all labels for a notification endpoint.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetNotificationEndpointsIDLabels }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetNotificationEndpointsIDLabels }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -205,7 +205,7 @@ export class NotificationEndpointsAPI {
   }
   /**
    * Add a label to a notification endpoint.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostNotificationEndpointIDLabels }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostNotificationEndpointIDLabels }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -224,7 +224,7 @@ export class NotificationEndpointsAPI {
   }
   /**
    * Delete a label from a notification endpoint.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteNotificationEndpointsIDLabelsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteNotificationEndpointsIDLabelsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/NotificationRulesAPI.ts
+++ b/packages/apis/src/generated/NotificationRulesAPI.ts
@@ -81,7 +81,7 @@ export class NotificationRulesAPI {
   }
   /**
    * List all notification rules.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetNotificationRules }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetNotificationRules }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -105,7 +105,7 @@ export class NotificationRulesAPI {
   }
   /**
    * Add a notification rule.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/CreateNotificationRule }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/CreateNotificationRule }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -124,7 +124,7 @@ export class NotificationRulesAPI {
   }
   /**
    * Retrieve a notification rule.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetNotificationRulesID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetNotificationRulesID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -142,7 +142,7 @@ export class NotificationRulesAPI {
   }
   /**
    * Update a notification rule.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PutNotificationRulesID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PutNotificationRulesID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -161,7 +161,7 @@ export class NotificationRulesAPI {
   }
   /**
    * Update a notification rule.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PatchNotificationRulesID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PatchNotificationRulesID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -180,7 +180,7 @@ export class NotificationRulesAPI {
   }
   /**
    * Delete a notification rule.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteNotificationRulesID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteNotificationRulesID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -198,7 +198,7 @@ export class NotificationRulesAPI {
   }
   /**
    * List all labels for a notification rule.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetNotificationRulesIDLabels }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetNotificationRulesIDLabels }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -216,7 +216,7 @@ export class NotificationRulesAPI {
   }
   /**
    * Add a label to a notification rule.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostNotificationRuleIDLabels }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostNotificationRuleIDLabels }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -235,7 +235,7 @@ export class NotificationRulesAPI {
   }
   /**
    * Delete label from a notification rule.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteNotificationRulesIDLabelsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteNotificationRulesIDLabelsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -253,7 +253,7 @@ export class NotificationRulesAPI {
   }
   /**
    * Retrieve a notification rule query.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetNotificationRulesIDQuery }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetNotificationRulesIDQuery }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/OrgsAPI.ts
+++ b/packages/apis/src/generated/OrgsAPI.ts
@@ -114,7 +114,7 @@ export class OrgsAPI {
   }
   /**
    * List all organizations.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetOrgs }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetOrgs }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -139,7 +139,7 @@ export class OrgsAPI {
   }
   /**
    * Create an organization.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostOrgs }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostOrgs }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -158,7 +158,7 @@ export class OrgsAPI {
   }
   /**
    * Retrieve an organization.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetOrgsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetOrgsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -176,7 +176,7 @@ export class OrgsAPI {
   }
   /**
    * Update an organization.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PatchOrgsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PatchOrgsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -195,7 +195,7 @@ export class OrgsAPI {
   }
   /**
    * Delete an organization.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteOrgsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteOrgsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -213,7 +213,7 @@ export class OrgsAPI {
   }
   /**
    * List all secret keys for an organization.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetOrgsIDSecrets }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetOrgsIDSecrets }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -231,7 +231,7 @@ export class OrgsAPI {
   }
   /**
    * Update secrets in an organization.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PatchOrgsIDSecrets }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PatchOrgsIDSecrets }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -250,7 +250,7 @@ export class OrgsAPI {
   }
   /**
    * List all members of an organization.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetOrgsIDMembers }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetOrgsIDMembers }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -268,7 +268,7 @@ export class OrgsAPI {
   }
   /**
    * Add a member to an organization.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostOrgsIDMembers }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostOrgsIDMembers }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -287,7 +287,7 @@ export class OrgsAPI {
   }
   /**
    * Remove a member from an organization.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteOrgsIDMembersID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteOrgsIDMembersID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -305,7 +305,7 @@ export class OrgsAPI {
   }
   /**
    * List all owners of an organization.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetOrgsIDOwners }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetOrgsIDOwners }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -323,7 +323,7 @@ export class OrgsAPI {
   }
   /**
    * Add an owner to an organization.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostOrgsIDOwners }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostOrgsIDOwners }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -342,7 +342,7 @@ export class OrgsAPI {
   }
   /**
    * Remove an owner from an organization.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteOrgsIDOwnersID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteOrgsIDOwnersID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -360,7 +360,7 @@ export class OrgsAPI {
   }
   /**
    * Delete secrets from an organization.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostOrgsIDSecrets }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostOrgsIDSecrets }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -379,7 +379,7 @@ export class OrgsAPI {
   }
   /**
    * Delete a secret from an organization.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteOrgsIDSecretsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteOrgsIDSecretsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/PingAPI.ts
+++ b/packages/apis/src/generated/PingAPI.ts
@@ -18,7 +18,7 @@ export class PingAPI {
   }
   /**
    * Get the status and version of the instance.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetPing }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetPing }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/QueryAPI.ts
+++ b/packages/apis/src/generated/QueryAPI.ts
@@ -46,7 +46,7 @@ export class QueryAPI {
   }
   /**
    * Generate an Abstract Syntax Tree (AST) from a query.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostQueryAst }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostQueryAst }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -65,7 +65,7 @@ export class QueryAPI {
   }
   /**
    * Retrieve query suggestions.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetQuerySuggestions }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetQuerySuggestions }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -83,7 +83,7 @@ export class QueryAPI {
   }
   /**
    * Retrieve query suggestions for a branching suggestion.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetQuerySuggestionsName }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetQuerySuggestionsName }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -101,7 +101,7 @@ export class QueryAPI {
   }
   /**
    * Analyze a Flux query.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostQueryAnalyze }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostQueryAnalyze }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -120,7 +120,7 @@ export class QueryAPI {
   }
   /**
    * Query data.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostQuery }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostQuery }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/ReadyAPI.ts
+++ b/packages/apis/src/generated/ReadyAPI.ts
@@ -19,7 +19,7 @@ export class ReadyAPI {
   }
   /**
    * Get the readiness of an instance at startup.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetReady }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetReady }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/RemotesAPI.ts
+++ b/packages/apis/src/generated/RemotesAPI.ts
@@ -44,7 +44,7 @@ export class RemotesAPI {
   }
   /**
    * List all remote connections.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetRemoteConnections }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetRemoteConnections }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -66,7 +66,7 @@ export class RemotesAPI {
   }
   /**
    * Register a new remote connection.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostRemoteConnection }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostRemoteConnection }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -85,7 +85,7 @@ export class RemotesAPI {
   }
   /**
    * Retrieve a remote connection.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetRemoteConnectionByID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetRemoteConnectionByID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -103,7 +103,7 @@ export class RemotesAPI {
   }
   /**
    * Update a remote connection.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PatchRemoteConnectionByID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PatchRemoteConnectionByID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -122,7 +122,7 @@ export class RemotesAPI {
   }
   /**
    * Delete a remote connection.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteRemoteConnectionByID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteRemoteConnectionByID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/ReplicationsAPI.ts
+++ b/packages/apis/src/generated/ReplicationsAPI.ts
@@ -52,7 +52,7 @@ export class ReplicationsAPI {
   }
   /**
    * List all replications.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetReplications }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetReplications }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -75,7 +75,7 @@ export class ReplicationsAPI {
   }
   /**
    * Register a new replication.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostReplication }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostReplication }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -94,7 +94,7 @@ export class ReplicationsAPI {
   }
   /**
    * Retrieve a replication.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetReplicationByID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetReplicationByID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -112,7 +112,7 @@ export class ReplicationsAPI {
   }
   /**
    * Update a replication.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PatchReplicationByID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PatchReplicationByID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -134,7 +134,7 @@ export class ReplicationsAPI {
   }
   /**
    * Delete a replication.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteReplicationByID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteReplicationByID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -152,7 +152,7 @@ export class ReplicationsAPI {
   }
   /**
    * Validate a replication.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostValidateReplicationByID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostValidateReplicationByID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/ResourcesAPI.ts
+++ b/packages/apis/src/generated/ResourcesAPI.ts
@@ -18,7 +18,7 @@ export class ResourcesAPI {
   }
   /**
    * List all known resources.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetResources }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetResources }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/RestoreAPI.ts
+++ b/packages/apis/src/generated/RestoreAPI.ts
@@ -42,7 +42,7 @@ export class RestoreAPI {
   }
   /**
    * Overwrite the embedded KV store on the server with a backed-up snapshot.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostRestoreKV }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostRestoreKV }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -64,7 +64,7 @@ export class RestoreAPI {
   }
   /**
    * Overwrite the embedded SQL store on the server with a backed-up snapshot.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostRestoreSQL }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostRestoreSQL }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -83,7 +83,7 @@ export class RestoreAPI {
   }
   /**
    * Overwrite storage metadata for a bucket with shard info from a backup.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostRestoreBucketID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostRestoreBucketID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -102,7 +102,7 @@ export class RestoreAPI {
   }
   /**
    * Create a new bucket pre-seeded with shard info from a backup.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostRestoreBucketMetadata }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostRestoreBucketMetadata }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -121,7 +121,7 @@ export class RestoreAPI {
   }
   /**
    * Restore a TSM snapshot into a shard.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostRestoreShardId }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostRestoreShardId }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/RootAPI.ts
+++ b/packages/apis/src/generated/RootAPI.ts
@@ -19,7 +19,7 @@ export class RootAPI {
   }
   /**
    * List all top level routes.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetRoutes }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetRoutes }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/ScrapersAPI.ts
+++ b/packages/apis/src/generated/ScrapersAPI.ts
@@ -106,7 +106,7 @@ export class ScrapersAPI {
   }
   /**
    * List all scraper targets.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetScrapers }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetScrapers }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -129,7 +129,7 @@ export class ScrapersAPI {
   }
   /**
    * Create a scraper target.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostScrapers }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostScrapers }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -148,7 +148,7 @@ export class ScrapersAPI {
   }
   /**
    * Retrieve a scraper target.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetScrapersID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetScrapersID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -166,7 +166,7 @@ export class ScrapersAPI {
   }
   /**
    * Update a scraper target.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PatchScrapersID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PatchScrapersID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -185,7 +185,7 @@ export class ScrapersAPI {
   }
   /**
    * Delete a scraper target.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteScrapersID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteScrapersID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -203,7 +203,7 @@ export class ScrapersAPI {
   }
   /**
    * List all labels for a scraper target.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetScrapersIDLabels }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetScrapersIDLabels }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -221,7 +221,7 @@ export class ScrapersAPI {
   }
   /**
    * Add a label to a scraper target.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostScrapersIDLabels }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostScrapersIDLabels }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -240,7 +240,7 @@ export class ScrapersAPI {
   }
   /**
    * Delete a label from a scraper target.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteScrapersIDLabelsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteScrapersIDLabelsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -258,7 +258,7 @@ export class ScrapersAPI {
   }
   /**
    * List all users with member privileges for a scraper target.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetScrapersIDMembers }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetScrapersIDMembers }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -276,7 +276,7 @@ export class ScrapersAPI {
   }
   /**
    * Add a member to a scraper target.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostScrapersIDMembers }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostScrapersIDMembers }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -295,7 +295,7 @@ export class ScrapersAPI {
   }
   /**
    * Remove a member from a scraper target.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteScrapersIDMembersID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteScrapersIDMembersID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -313,7 +313,7 @@ export class ScrapersAPI {
   }
   /**
    * List all owners of a scraper target.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetScrapersIDOwners }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetScrapersIDOwners }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -331,7 +331,7 @@ export class ScrapersAPI {
   }
   /**
    * Add an owner to a scraper target.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostScrapersIDOwners }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostScrapersIDOwners }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -350,7 +350,7 @@ export class ScrapersAPI {
   }
   /**
    * Remove an owner from a scraper target.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteScrapersIDOwnersID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteScrapersIDOwnersID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/SetupAPI.ts
+++ b/packages/apis/src/generated/SetupAPI.ts
@@ -23,7 +23,7 @@ export class SetupAPI {
   }
   /**
    * Check if database has default user, org, bucket.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetSetup }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetSetup }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -36,7 +36,7 @@ export class SetupAPI {
   }
   /**
    * Set up initial user, org and bucket.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostSetup }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostSetup }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/SigninAPI.ts
+++ b/packages/apis/src/generated/SigninAPI.ts
@@ -20,7 +20,7 @@ export class SigninAPI {
   }
   /**
    * Create a user session.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostSignin }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostSignin }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/SignoutAPI.ts
+++ b/packages/apis/src/generated/SignoutAPI.ts
@@ -18,7 +18,7 @@ export class SignoutAPI {
   }
   /**
    * Expire the current UI session.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostSignout }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostSignout }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/SourcesAPI.ts
+++ b/packages/apis/src/generated/SourcesAPI.ts
@@ -50,7 +50,7 @@ export class SourcesAPI {
   }
   /**
    * List all sources.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetSources }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetSources }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -68,7 +68,7 @@ export class SourcesAPI {
   }
   /**
    * Create a source.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostSources }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostSources }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -87,7 +87,7 @@ export class SourcesAPI {
   }
   /**
    * Retrieve a source.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetSourcesID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetSourcesID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -105,7 +105,7 @@ export class SourcesAPI {
   }
   /**
    * Update a Source.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PatchSourcesID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PatchSourcesID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -124,7 +124,7 @@ export class SourcesAPI {
   }
   /**
    * Delete a source.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteSourcesID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteSourcesID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -142,7 +142,7 @@ export class SourcesAPI {
   }
   /**
    * Get the health of a source.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetSourcesIDHealth }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetSourcesIDHealth }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -160,7 +160,7 @@ export class SourcesAPI {
   }
   /**
    * Get buckets in a source.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetSourcesIDBuckets }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetSourcesIDBuckets }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/StacksAPI.ts
+++ b/packages/apis/src/generated/StacksAPI.ts
@@ -64,7 +64,7 @@ export class StacksAPI {
   }
   /**
    * List installed templates.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/ListStacks }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/ListStacks }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -88,7 +88,7 @@ export class StacksAPI {
   }
   /**
    * Create a new stack.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/CreateStack }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/CreateStack }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -107,7 +107,7 @@ export class StacksAPI {
   }
   /**
    * Retrieve a stack.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/ReadStack }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/ReadStack }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -125,7 +125,7 @@ export class StacksAPI {
   }
   /**
    * Update a stack.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/UpdateStack }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/UpdateStack }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -144,7 +144,7 @@ export class StacksAPI {
   }
   /**
    * Delete a stack and associated resources.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteStack }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteStack }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -164,7 +164,7 @@ export class StacksAPI {
   }
   /**
    * Uninstall a stack.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/UninstallStack }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/UninstallStack }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/TasksAPI.ts
+++ b/packages/apis/src/generated/TasksAPI.ts
@@ -166,7 +166,7 @@ export class TasksAPI {
   }
   /**
    * Retrieve a task.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetTasksID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetTasksID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -184,7 +184,7 @@ export class TasksAPI {
   }
   /**
    * Update a task.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PatchTasksID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PatchTasksID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -203,7 +203,7 @@ export class TasksAPI {
   }
   /**
    * Delete a task.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteTasksID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteTasksID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -221,7 +221,7 @@ export class TasksAPI {
   }
   /**
    * List runs for a task.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetTasksIDRuns }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetTasksIDRuns }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -244,7 +244,7 @@ export class TasksAPI {
   }
   /**
    * Manually start a task run, overriding the current schedule.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostTasksIDRuns }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostTasksIDRuns }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -263,7 +263,7 @@ export class TasksAPI {
   }
   /**
    * Retrieve a single run for a task.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetTasksIDRunsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetTasksIDRunsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -281,7 +281,7 @@ export class TasksAPI {
   }
   /**
    * Cancel a running task.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteTasksIDRunsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteTasksIDRunsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -299,7 +299,7 @@ export class TasksAPI {
   }
   /**
    * Retry a task run.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostTasksIDRunsIDRetry }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostTasksIDRunsIDRetry }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -318,7 +318,7 @@ export class TasksAPI {
   }
   /**
    * Retrieve all logs for a task.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetTasksIDLogs }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetTasksIDLogs }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -336,7 +336,7 @@ export class TasksAPI {
   }
   /**
    * Retrieve all logs for a run.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetTasksIDRunsIDLogs }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetTasksIDRunsIDLogs }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -354,7 +354,7 @@ export class TasksAPI {
   }
   /**
    * List all labels for a task.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetTasksIDLabels }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetTasksIDLabels }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -372,7 +372,7 @@ export class TasksAPI {
   }
   /**
    * Add a label to a task.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostTasksIDLabels }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostTasksIDLabels }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -391,7 +391,7 @@ export class TasksAPI {
   }
   /**
    * Delete a label from a task.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteTasksIDLabelsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteTasksIDLabelsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -409,7 +409,7 @@ export class TasksAPI {
   }
   /**
    * List all task members.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetTasksIDMembers }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetTasksIDMembers }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -427,7 +427,7 @@ export class TasksAPI {
   }
   /**
    * Add a member to a task.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostTasksIDMembers }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostTasksIDMembers }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -446,7 +446,7 @@ export class TasksAPI {
   }
   /**
    * Remove a member from a task.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteTasksIDMembersID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteTasksIDMembersID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -464,7 +464,7 @@ export class TasksAPI {
   }
   /**
    * List all owners of a task.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetTasksIDOwners }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetTasksIDOwners }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -482,7 +482,7 @@ export class TasksAPI {
   }
   /**
    * Add an owner to a task.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostTasksIDOwners }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostTasksIDOwners }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -501,7 +501,7 @@ export class TasksAPI {
   }
   /**
    * Remove an owner from a task.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteTasksIDOwnersID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteTasksIDOwnersID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -519,7 +519,7 @@ export class TasksAPI {
   }
   /**
    * List all tasks.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetTasks }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetTasks }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -546,7 +546,7 @@ export class TasksAPI {
   }
   /**
    * Create a new task.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostTasks }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostTasks }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/TelegrafAPI.ts
+++ b/packages/apis/src/generated/TelegrafAPI.ts
@@ -22,7 +22,7 @@ export class TelegrafAPI {
   }
   /**
    * List all Telegraf plugins.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetTelegrafPlugins }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetTelegrafPlugins }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/TelegrafsAPI.ts
+++ b/packages/apis/src/generated/TelegrafsAPI.ts
@@ -100,7 +100,7 @@ export class TelegrafsAPI {
   }
   /**
    * List all Telegraf configurations.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetTelegrafs }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetTelegrafs }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -118,7 +118,7 @@ export class TelegrafsAPI {
   }
   /**
    * Create a Telegraf configuration.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostTelegrafs }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostTelegrafs }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -137,7 +137,7 @@ export class TelegrafsAPI {
   }
   /**
    * Retrieve a Telegraf configuration.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetTelegrafsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetTelegrafsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -155,7 +155,7 @@ export class TelegrafsAPI {
   }
   /**
    * Update a Telegraf configuration.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PutTelegrafsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PutTelegrafsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -174,7 +174,7 @@ export class TelegrafsAPI {
   }
   /**
    * Delete a Telegraf configuration.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteTelegrafsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteTelegrafsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -192,7 +192,7 @@ export class TelegrafsAPI {
   }
   /**
    * List all labels for a Telegraf config.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetTelegrafsIDLabels }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetTelegrafsIDLabels }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -210,7 +210,7 @@ export class TelegrafsAPI {
   }
   /**
    * Add a label to a Telegraf config.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostTelegrafsIDLabels }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostTelegrafsIDLabels }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -229,7 +229,7 @@ export class TelegrafsAPI {
   }
   /**
    * Delete a label from a Telegraf config.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteTelegrafsIDLabelsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteTelegrafsIDLabelsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -247,7 +247,7 @@ export class TelegrafsAPI {
   }
   /**
    * List all users with member privileges for a Telegraf config.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetTelegrafsIDMembers }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetTelegrafsIDMembers }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -265,7 +265,7 @@ export class TelegrafsAPI {
   }
   /**
    * Add a member to a Telegraf config.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostTelegrafsIDMembers }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostTelegrafsIDMembers }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -284,7 +284,7 @@ export class TelegrafsAPI {
   }
   /**
    * Remove a member from a Telegraf config.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteTelegrafsIDMembersID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteTelegrafsIDMembersID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -302,7 +302,7 @@ export class TelegrafsAPI {
   }
   /**
    * List all owners of a Telegraf configuration.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetTelegrafsIDOwners }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetTelegrafsIDOwners }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -320,7 +320,7 @@ export class TelegrafsAPI {
   }
   /**
    * Add an owner to a Telegraf configuration.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostTelegrafsIDOwners }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostTelegrafsIDOwners }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -339,7 +339,7 @@ export class TelegrafsAPI {
   }
   /**
    * Remove an owner from a Telegraf config.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteTelegrafsIDOwnersID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteTelegrafsIDOwnersID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/TemplatesAPI.ts
+++ b/packages/apis/src/generated/TemplatesAPI.ts
@@ -32,7 +32,7 @@ export class TemplatesAPI {
   }
   /**
    * Apply or dry-run a template.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/ApplyTemplate }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/ApplyTemplate }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -51,7 +51,7 @@ export class TemplatesAPI {
   }
   /**
    * Export a new template.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/ExportTemplate }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/ExportTemplate }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/UsersAPI.ts
+++ b/packages/apis/src/generated/UsersAPI.ts
@@ -52,7 +52,7 @@ export class UsersAPI {
   }
   /**
    * Update a password.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostUsersIDPassword }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostUsersIDPassword }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -71,7 +71,7 @@ export class UsersAPI {
   }
   /**
    * List all users.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetUsers }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetUsers }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -95,7 +95,7 @@ export class UsersAPI {
   }
   /**
    * Create a user.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostUsers }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostUsers }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -114,7 +114,7 @@ export class UsersAPI {
   }
   /**
    * Retrieve a user.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetUsersID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetUsersID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -132,7 +132,7 @@ export class UsersAPI {
   }
   /**
    * Update a user.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PatchUsersID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PatchUsersID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -151,7 +151,7 @@ export class UsersAPI {
   }
   /**
    * Delete a user.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteUsersID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteUsersID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/VariablesAPI.ts
+++ b/packages/apis/src/generated/VariablesAPI.ts
@@ -70,7 +70,7 @@ export class VariablesAPI {
   }
   /**
    * List all labels for a variable.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetVariablesIDLabels }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetVariablesIDLabels }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -88,7 +88,7 @@ export class VariablesAPI {
   }
   /**
    * Add a label to a variable.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostVariablesIDLabels }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostVariablesIDLabels }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -107,7 +107,7 @@ export class VariablesAPI {
   }
   /**
    * Delete a label from a variable.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteVariablesIDLabelsID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteVariablesIDLabelsID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -125,7 +125,7 @@ export class VariablesAPI {
   }
   /**
    * List all variables.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetVariables }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetVariables }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -143,7 +143,7 @@ export class VariablesAPI {
   }
   /**
    * Create a variable.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostVariables }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostVariables }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -162,7 +162,7 @@ export class VariablesAPI {
   }
   /**
    * Retrieve a variable.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/GetVariablesID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/GetVariablesID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -180,7 +180,7 @@ export class VariablesAPI {
   }
   /**
    * Replace a variable.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PutVariablesID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PutVariablesID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -199,7 +199,7 @@ export class VariablesAPI {
   }
   /**
    * Update a variable.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PatchVariablesID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PatchVariablesID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response
@@ -218,7 +218,7 @@ export class VariablesAPI {
   }
   /**
    * Delete a variable.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/DeleteVariablesID }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/DeleteVariablesID }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/WriteAPI.ts
+++ b/packages/apis/src/generated/WriteAPI.ts
@@ -45,7 +45,7 @@ export class WriteAPI {
   }
   /**
    * Write data.
-   * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostWrite }
+   * See {@link https://docs.influxdata.com/influxdb/v2.3/api/#operation/PostWrite }
    * @param request - request parameters and body (if supported)
    * @param requestOptions - optional transport options
    * @returns promise of response

--- a/packages/apis/src/generated/types.ts
+++ b/packages/apis/src/generated/types.ts
@@ -2210,16 +2210,16 @@ export interface Task {
   /** Flux script to run for this task. */
   flux: string
   /** Interval at which the task runs. `every` also determines when the task first runs, depending on the specified time.
-Value is a [duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals)). */
+Value is a [duration literal](https://docs.influxdata.com/flux/latest/spec/lexical-elements/#duration-literals)). */
   every?: string
   /** [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview) that defines the schedule on which the task runs. Cron scheduling is based on system time.
 Value is a [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview). */
   cron?: string
-  /** [Duration](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals) to delay execution of the task after the scheduled time has elapsed. `0` removes the offset.
-The value is a [duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals). */
+  /** [Duration](https://docs.influxdata.com/flux/latest/spec/lexical-elements/#duration-literals) to delay execution of the task after the scheduled time has elapsed. `0` removes the offset.
+The value is a [duration literal](https://docs.influxdata.com/flux/latest/spec/lexical-elements/#duration-literals). */
   offset?: string
   /** Timestamp of the latest scheduled and completed run.
-Value is a timestamp in [RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax). */
+Value is a timestamp in [RFC3339 date/time format](https://docs.influxdata.com/flux/latest/data-types/basic/time/#time-syntax). */
   readonly latestCompleted?: string
   readonly lastRunStatus?: 'failed' | 'success' | 'canceled'
   readonly lastRunError?: string

--- a/packages/core/src/QueryApi.ts
+++ b/packages/core/src/QueryApi.ts
@@ -73,7 +73,7 @@ export default interface QueryApi {
 
   /**
    * Executes the query and receives result lines (including empty and annotation lines)
-   * through the supplied consumer. See [annotated-csv](https://docs.influxdata.com/influxdb/v2.1/reference/syntax/annotated-csv/).
+   * through the supplied consumer. See [annotated-csv](https://docs.influxdata.com/influxdb/v2.3/reference/syntax/annotated-csv/).
    *
    * @param query - query
    * @param consumer - csv result lines and error consumer

--- a/packages/core/src/QueryApi.ts
+++ b/packages/core/src/QueryApi.ts
@@ -35,7 +35,7 @@ export interface QueryOptions {
 
 /**
  * Query InfluxDB. Provides methods that notify about result lines of the executed query.
- * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostQuery }
+ * See {@link https://docs.influxdata.com/influxdb/latest/api/#operation/PostQuery }
  */
 export default interface QueryApi {
   /**
@@ -73,7 +73,7 @@ export default interface QueryApi {
 
   /**
    * Executes the query and receives result lines (including empty and annotation lines)
-   * through the supplied consumer. See [annotated-csv](https://docs.influxdata.com/influxdb/v2.3/reference/syntax/annotated-csv/).
+   * through the supplied consumer. See [annotated-csv](https://docs.influxdata.com/influxdb/latest/reference/syntax/annotated-csv/).
    *
    * @param query - query
    * @param consumer - csv result lines and error consumer

--- a/packages/core/src/WriteApi.ts
+++ b/packages/core/src/WriteApi.ts
@@ -1,13 +1,10 @@
 import {Point, PointSettings} from './Point'
 
 /**
- * The asynchronous buffering API to Write time-series data into InfluxDB.
+ * Asynchronous API that writes time-series data into InfluxDB.
  * This API always buffers points/lines to create batches under the hood
  * to optimize data transfer to InfluxDB server, use `flush` to send
  * the buffered data to InfluxDB immediately.
- * <p>
- * The data are formatted in [Line Protocol](https://bit.ly/2QL99fu).
- * <p>
  */
 export default interface WriteApi extends PointSettings {
   /**

--- a/packages/core/src/impl/QueryApiImpl.ts
+++ b/packages/core/src/impl/QueryApiImpl.ts
@@ -128,7 +128,7 @@ export class QueryApiImpl implements QueryApi {
     if (typeof this.options.now === 'function') {
       request.now = this.options.now()
     }
-    // https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostQuery requires type
+    // https://docs.influxdata.com/influxdb/latest/api/#operation/PostQuery requires type
     request.type = this.options.type ?? 'flux'
     return request
   }

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -161,6 +161,6 @@ export interface ClientOptions extends ConnectionOptions {
 
 /**
  * Timestamp precision used in write operations.
- * See {@link https://docs.influxdata.com/influxdb/v2.1/api/#operation/PostWrite }
+ * See {@link https://docs.influxdata.com/influxdb/latest/api/#operation/PostWrite }
  */
 export type WritePrecisionType = 'ns' | 'us' | 'ms' | 's'

--- a/packages/core/src/query/flux.ts
+++ b/packages/core/src/query/flux.ts
@@ -39,7 +39,7 @@ function isFluxParameterLike(value: any): boolean {
 
 /**
  * Escapes content of the supplied string so it can be wrapped into double qoutes
- * to become a [flux string literal](https://docs.influxdata.com/flux/v0.65/language/lexical-elements/#string-literals).
+ * to become a [flux string literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#string-literals).
  * @param value - string value
  * @returns sanitized string
  */

--- a/packages/core/src/query/flux.ts
+++ b/packages/core/src/query/flux.ts
@@ -39,7 +39,7 @@ function isFluxParameterLike(value: any): boolean {
 
 /**
  * Escapes content of the supplied string so it can be wrapped into double qoutes
- * to become a [flux string literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#string-literals).
+ * to become a [flux string literal](https://docs.influxdata.com/flux/latest/spec/lexical-elements/#string-literals).
  * @param value - string value
  * @returns sanitized string
  */
@@ -120,7 +120,7 @@ export function sanitizeFloat(value: any): string {
     throw new Error(`not a flux float: ${value}`)
   }
   // try to return a flux float literal if possible
-  // https://docs.influxdata.com/flux/v0.x/data-types/basic/float/#float-syntax
+  // https://docs.influxdata.com/flux/latest/data-types/basic/float/#float-syntax
   const strVal = val.toString()
   let hasDot = false
   for (const c of strVal) {
@@ -147,7 +147,7 @@ export function fluxFloat(value: any): FluxParameterLike {
  * @throws Error if the the value cannot be sanitized
  */
 export function sanitizeInteger(value: any): string {
-  // https://docs.influxdata.com/flux/v0.x/data-types/basic/int/
+  // https://docs.influxdata.com/flux/latest/data-types/basic/int/
   // Min value: -9223372036854775808
   // Max value: 9223372036854775807
   // "9223372036854775807".length === 19
@@ -205,7 +205,7 @@ function sanitizeRegExp(value: any): string {
 
 /**
  * Creates flux regexp literal out of a regular expression. See
- * https://docs.influxdata.com/flux/v0.x/data-types/basic/regexp/#regular-expression-syntax
+ * https://docs.influxdata.com/flux/latest/data-types/basic/regexp/#regular-expression-syntax
  * for details.
  */
 export function fluxRegExp(value: any): FluxParameterLike {

--- a/packages/core/src/results/AnnotatedCSVResponse.ts
+++ b/packages/core/src/results/AnnotatedCSVResponse.ts
@@ -21,7 +21,7 @@ export interface AnnotatedCSVResponse {
   rows(): Observable<Row>
   /**
    * ConsumesLines consumes result lines (including empty and annotation lines)
-   * through the supplied consumer. See [annotated-csv](https://docs.influxdata.com/influxdb/v2.1/reference/syntax/annotated-csv/).
+   * through the supplied consumer. See [annotated-csv](https://docs.influxdata.com/influxdb/latest/reference/syntax/annotated-csv/).
    * @param consumer - csv result lines and error consumer
    */
   consumeLines(consumer: CommunicationObserver<string>): void

--- a/packages/core/src/results/FluxTableColumn.ts
+++ b/packages/core/src/results/FluxTableColumn.ts
@@ -1,5 +1,5 @@
 /**
- * Type of query result column, see {@link https://docs.influxdata.com/influxdb/v2.1/reference/syntax/annotated-csv/#data-types }
+ * Type of query result column, see {@link https://docs.influxdata.com/influxdb/latest/reference/syntax/annotated-csv/#data-types }
  */
 export type ColumnType =
   | 'boolean'
@@ -53,7 +53,7 @@ const identity = (x: string): any => x
 
 /**
  * A dictionary of serializers of particular types returned by a flux query.
- * See {@link https://docs.influxdata.com/influxdb/v2.1/reference/syntax/annotated-csv/#data-types }
+ * See {@link https://docs.influxdata.com/influxdb/latest/reference/syntax/annotated-csv/#data-types }
  */
 export const typeSerializers: Record<ColumnType, (val: string) => any> = {
   boolean: (x: string): any => x === 'true',

--- a/scripts/fix-extracted-api-files.js
+++ b/scripts/fix-extracted-api-files.js
@@ -3,10 +3,23 @@
 const path = require('path')
 const fs = require('fs')
 
+const markdownLinkRE = /\[([^\]]*)\]\(([^)]*)\)/g
+function changeMarkdownLinks(text) {
+  if (text) {
+    // changes markdown style [text](link) to tsdoc {@link URL | text }
+    return text.replace(markdownLinkRE, (match, text, link) => {
+      const retVal = `{@link ${link} | ${text} }`
+      console.log(` ${match} => ${retVal}`)
+      return retVal
+    })
+  }
+  return text
+}
+
 function replaceInExtractorFile(file) {
-  console.log(`correct references in: ${file}`)
   const data = fs.readFileSync(file, 'utf8')
   const json = JSON.parse(data)
+  console.log(`correct: ${file}`)
 
   function replaceObject(obj) {
     if (typeof obj === 'object') {
@@ -26,6 +39,10 @@ function replaceInExtractorFile(file) {
           }
         } else {
           for (const key in obj) {
+            if (key === 'docComment') {
+              obj.docComment = changeMarkdownLinks(obj.docComment)
+              continue
+            }
             replaceObject(obj[key])
           }
         }
@@ -38,7 +55,7 @@ function replaceInExtractorFile(file) {
 }
 
 const docsDir = path.resolve(__dirname, '..', 'docs')
-const files = fs.readdirSync(docsDir).filter(x => /\.api\.json$/.test(x))
-files.forEach(file => {
+const files = fs.readdirSync(docsDir).filter((x) => /\.api\.json$/.test(x))
+files.forEach((file) => {
   replaceInExtractorFile(path.resolve(docsDir, file))
 })


### PR DESCRIPTION
Fixes #513

## Proposed Changes
- doc reviewed and improved
- change generated API links to point to InfluxDB v2.3
- change unsupported markdown links to TSdoc links before generation of API docs

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `yarn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
