### PR TITLE
feat(core): improve write retry buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.29.0 [unreleased]
 
+### Features
+
+1. [#547](https://github.com/influxdata/influxdb-client-js/pull/547): Improve write retry buffer.
+
 ### Other
 
 1. [#511](https://github.com/influxdata/influxdb-client-js/pull/511): Replace rollup with tsup.

--- a/packages/core/src/impl/RetryBuffer.ts
+++ b/packages/core/src/impl/RetryBuffer.ts
@@ -43,7 +43,6 @@ export default class RetryBuffer {
     private onShrink: (entry: {
       lines: string[]
       retryCount: number
-      retryTime: number
       expires: number
     }) => void = () => undefined
   ) {}
@@ -72,6 +71,9 @@ export default class RetryBuffer {
           parent.next = found.next
         } else {
           this.first = found.next
+          if (this.first) {
+            this.scheduleRetry(this.first.retryTime - Date.now())
+          }
         }
         found.next = undefined
         this.onShrink(found)

--- a/packages/core/src/impl/RetryBuffer.ts
+++ b/packages/core/src/impl/RetryBuffer.ts
@@ -83,7 +83,7 @@ export default class RetryBuffer {
           origSize - this.size
         } oldest lines removed to keep buffer size under the limit of ${
           this.maxLines
-        } lines`
+        } lines.`
       )
     }
     const toAdd: RetryItem = {

--- a/packages/core/src/impl/RetryBuffer.ts
+++ b/packages/core/src/impl/RetryBuffer.ts
@@ -8,14 +8,14 @@ interface RetryItem {
   next?: RetryItem
 }
 
-type FindOldestExpiredResult = [found: RetryItem, parent?: RetryItem]
+type FindShrinkCandidateResult = [found: RetryItem, parent?: RetryItem]
 
-function findOldestExpires(first: RetryItem): FindOldestExpiredResult {
+function findShrinkCandidate(first: RetryItem): FindShrinkCandidateResult {
   let parent = undefined
   let found = first
   let currentParent = first
   while (currentParent.next) {
-    if (currentParent.next.expires > found.expires) {
+    if (currentParent.next.expires < found.expires) {
       parent = currentParent
       found = currentParent.next
     }
@@ -65,8 +65,8 @@ export default class RetryBuffer {
       const origSize = this.size
       const newSize = origSize * 0.7 // reduce to 70 %
       do {
-        // remove oldest item
-        const [found, parent] = findOldestExpires(this.first)
+        // remove "oldest" item
+        const [found, parent] = findShrinkCandidate(this.first)
         this.size -= found.lines.length
         if (parent) {
           parent.next = found.next

--- a/packages/core/src/impl/RetryBuffer.ts
+++ b/packages/core/src/impl/RetryBuffer.ts
@@ -1,13 +1,29 @@
 import {Log} from '../util/logger'
 
-/* interval between successful retries */
-const RETRY_INTERVAL = 1
-
 interface RetryItem {
   lines: string[]
   retryCount: number
+  retryTime: number
   expires: number
   next?: RetryItem
+}
+
+type FindOldestExpiredResult = [found: RetryItem, parent?: RetryItem]
+
+function findOldestExpires(first: RetryItem): FindOldestExpiredResult {
+  let oldestExpires = Number.MIN_SAFE_INTEGER
+  let parent = undefined
+  let found = first
+  let currentParent = first
+  while (currentParent.next) {
+    if (currentParent.next.expires > oldestExpires) {
+      oldestExpires = currentParent.next.expires
+      parent = currentParent
+      found = currentParent.next
+    }
+    currentParent = currentParent.next
+  }
+  return [found, parent]
 }
 
 /**
@@ -15,9 +31,7 @@ interface RetryItem {
  */
 export default class RetryBuffer {
   first?: RetryItem
-  last?: RetryItem
   size = 0
-  nextRetryTime = 0
   closed = false
   private _timeoutHandle: any = undefined
 
@@ -27,7 +41,13 @@ export default class RetryBuffer {
       lines: string[],
       retryCountdown: number,
       started: number
-    ) => Promise<void>
+    ) => Promise<void>,
+    private onShrink: (entry: {
+      lines: string[]
+      retryCount: number
+      retryTime: number
+      expires: number
+    }) => void = () => undefined
   ) {}
 
   addLines(
@@ -40,22 +60,23 @@ export default class RetryBuffer {
     if (!lines.length) return
     let retryTime = Date.now() + delay
     if (expires < retryTime) {
-      delay = expires - Date.now()
       retryTime = expires
     }
-    if (retryTime > this.nextRetryTime) this.nextRetryTime = retryTime
     // ensure at most maxLines are in the Buffer
     if (this.first && this.size + lines.length > this.maxLines) {
       const origSize = this.size
       const newSize = origSize * 0.7 // reduce to 70 %
       do {
-        const newFirst = this.first.next as RetryItem
-        this.size -= this.first.lines.length
-        this.first.next = undefined
-        this.first = newFirst
-        if (!this.first) {
-          this.last = undefined
+        // remove oldest item
+        const [found, parent] = findOldestExpires(this.first)
+        this.size -= found.lines.length
+        if (parent) {
+          parent.next = found.next
+        } else {
+          this.first = found.next
         }
+        found.next = undefined
+        this.onShrink(found)
       } while (this.first && this.size + lines.length > newSize)
       Log.error(
         `RetryBuffer: ${
@@ -68,15 +89,25 @@ export default class RetryBuffer {
     const toAdd: RetryItem = {
       lines,
       retryCount,
+      retryTime,
       expires,
     }
-    if (this.last) {
-      this.last.next = toAdd
-      this.last = toAdd
-    } else {
-      this.first = toAdd
-      this.last = toAdd
-      this.scheduleRetry(delay)
+    // insert sorted according to retryTime
+    let current: RetryItem | undefined = this.first
+    let parent = undefined
+    for (;;) {
+      if (!current || current.retryTime > retryTime) {
+        toAdd.next = current
+        if (parent) {
+          parent.next = toAdd
+        } else {
+          this.first = toAdd
+          this.scheduleRetry(retryTime - Date.now())
+        }
+        break
+      }
+      parent = current
+      current = current.next
     }
     this.size += lines.length
   }
@@ -87,25 +118,28 @@ export default class RetryBuffer {
       this.first = this.first.next
       toRetry.next = undefined
       this.size -= toRetry.lines.length
-      if (!this.first) this.last = undefined
       return toRetry
     }
     return undefined
   }
 
   scheduleRetry(delay: number): void {
+    if (this._timeoutHandle) {
+      clearTimeout(this._timeoutHandle)
+    }
     this._timeoutHandle = setTimeout(() => {
       const toRetry = this.removeLines()
       if (toRetry) {
-        this.retryLines(toRetry.lines, toRetry.retryCount, toRetry.expires)
-          .then(() => {
-            // continue with successfull retry
-            this.scheduleRetry(RETRY_INTERVAL)
-          })
-          .catch((_e) => {
-            // already logged
-            this.scheduleRetry(this.nextRetryTime - Date.now())
-          })
+        this.retryLines(
+          toRetry.lines,
+          toRetry.retryCount,
+          toRetry.expires
+        ).finally(() => {
+          // schedule next retry execution
+          if (this.first) {
+            this.scheduleRetry(this.first.retryTime - Date.now())
+          }
+        })
       } else {
         this._timeoutHandle = undefined
       }

--- a/packages/core/src/impl/RetryBuffer.ts
+++ b/packages/core/src/impl/RetryBuffer.ts
@@ -11,13 +11,11 @@ interface RetryItem {
 type FindOldestExpiredResult = [found: RetryItem, parent?: RetryItem]
 
 function findOldestExpires(first: RetryItem): FindOldestExpiredResult {
-  let oldestExpires = Number.MIN_SAFE_INTEGER
   let parent = undefined
   let found = first
   let currentParent = first
   while (currentParent.next) {
-    if (currentParent.next.expires > oldestExpires) {
-      oldestExpires = currentParent.next.expires
+    if (currentParent.next.expires > found.expires) {
       parent = currentParent
       found = currentParent.next
     }

--- a/packages/core/src/impl/WriteApiImpl.ts
+++ b/packages/core/src/impl/WriteApiImpl.ts
@@ -146,7 +146,8 @@ export default class WriteApiImpl implements WriteApi {
     this.retryStrategy = createRetryDelayStrategy(this.writeOptions)
     this.retryBuffer = new RetryBuffer(
       this.writeOptions.maxBufferLines,
-      this.sendBatch
+      this.sendBatch,
+      this.writeOptions.writeRetrySkipped
     )
   }
 

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -93,6 +93,13 @@ export interface WriteRetryOptions extends RetryDelayStrategyOptions {
    */
   writeSuccess(this: WriteApi, lines: Array<string>): void
 
+  /**
+   * WriteRetrySkipped is informed about lines that were removed from the retry buffer
+   * to keep the size of the retry buffer under the configured limit (maxBufferLines).
+   * @param entry - lines that were skipped
+   */
+  writeRetrySkipped(entry: {lines: Array<string>; expires: number}): void
+
   /** max count of retries after the first write fails */
   maxRetries: number
   /** max time (millis) that can be spent with retries */
@@ -137,6 +144,7 @@ export const DEFAULT_WriteOptions: WriteOptions = {
   flushInterval: 60000,
   writeFailed: function () {},
   writeSuccess: function () {},
+  writeRetrySkipped: function () {},
   maxRetries: 5,
   maxRetryTime: 180_000,
   maxBufferLines: 32_000,

--- a/packages/core/test/unit/impl/RetryBuffer.test.ts
+++ b/packages/core/test/unit/impl/RetryBuffer.test.ts
@@ -32,14 +32,12 @@ describe('RetryBuffer', () => {
     expect(input).deep.equals(output)
   })
   it('ignores lines on heavy load', async () => {
-    const input = [] as Array<[string[], number]>
     const output = [] as Array<[string[], number]>
     const subject = new RetryBuffer(5, (lines, countdown) => {
       output.push([lines, countdown])
       return Promise.resolve()
     })
     for (let i = 0; i < 10; i++) {
-      if (i >= 5) input.push([['a' + i], i])
       subject.addLines(['a' + i], i, 100, Date.now() + 1000)
     }
     await subject.flush()


### PR DESCRIPTION
This PR improves write retry buffer so that
- the calling code be informed about items that were removed in order to keep the size of the retry buffer under the configured limit (32_000 lines, maxBufferLines options) using a new optional `writeRetrySkipped` callback
- when the buffer becomes full, the oldest items (according to the time of the first failures) are always removed, previously oldest items according to the time they were added/re-added to the retry buffer were removed; the new strategy in this PR is fair
- the code now remembers scheduled retry time for each failed write, it always follows the order of retry execution regarding the scheduled retry time

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
