### PR TITLE
chore(deps-dev): revert @microsoft/api-extractor to 7.29.3

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1012,24 +1012,15 @@
     "@microsoft/tsdoc-config" "~0.16.1"
     "@rushstack/node-core-library" "3.50.2"
 
-"@microsoft/api-extractor-model@7.24.0":
-  version "7.24.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor-model/-/api-extractor-model-7.24.0.tgz#df71615f7c7d2c4f520c8b179d03a85efcdaf452"
-  integrity sha512-lFzF5h+quTyVB7eaKJkqrbQRDGSkrHzXyF8iMVvHdlaNrodGeyhtQeBFDuRVvBXTW2ILBiOV6ZWwUM1eGKcD+A==
-  dependencies:
-    "@microsoft/tsdoc" "0.14.1"
-    "@microsoft/tsdoc-config" "~0.16.1"
-    "@rushstack/node-core-library" "3.51.1"
-
 "@microsoft/api-extractor@^7.28.4":
-  version "7.30.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor/-/api-extractor-7.30.0.tgz#37a6f3ad4b6f9148bea2bcc8e3718903223c6ea6"
-  integrity sha512-XmtvrW74SzGvv59cjNC6+TE13XbIm4qrKKZtveoFRNbKdyTR4eIqnLmPvh1fgfolSF+iKfXlHHsQJpcgwdNztA==
+  version "7.29.3"
+  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor/-/api-extractor-7.29.3.tgz#f91ca61833c170c6c47a0fc064fa010460a11457"
+  integrity sha512-PHq+Oo8yiXhwi11VQ1Nz36s+aZwgFqjtkd41udWHtSpyMv2slJ74m1cHdpWbs2ovGUCfldayzdpGwnexZLd2bA==
   dependencies:
-    "@microsoft/api-extractor-model" "7.24.0"
+    "@microsoft/api-extractor-model" "7.23.1"
     "@microsoft/tsdoc" "0.14.1"
     "@microsoft/tsdoc-config" "~0.16.1"
-    "@rushstack/node-core-library" "3.51.1"
+    "@rushstack/node-core-library" "3.50.2"
     "@rushstack/rig-package" "0.3.14"
     "@rushstack/ts-command-line" "4.12.2"
     colors "~1.2.1"
@@ -1373,20 +1364,6 @@
     resolve "~1.17.0"
     semver "~7.3.0"
     timsort "~0.3.0"
-    z-schema "~5.0.2"
-
-"@rushstack/node-core-library@3.51.1":
-  version "3.51.1"
-  resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-3.51.1.tgz#e123053c4924722cc9614c0091fda5ed7bbc6c9d"
-  integrity sha512-xLoUztvGpaT5CphDexDPt2WbBx8D68VS5tYOkwfr98p90y0f/wepgXlTA/q5MUeZGGucASiXKp5ysdD+GPYf9A==
-  dependencies:
-    "@types/node" "12.20.24"
-    colors "~1.2.1"
-    fs-extra "~7.0.1"
-    import-lazy "~4.0.0"
-    jju "~1.4.0"
-    resolve "~1.17.0"
-    semver "~7.3.0"
     z-schema "~5.0.2"
 
 "@rushstack/rig-package@0.3.14":


### PR DESCRIPTION
This reverts commit e07173538ffc9571f31c7d73ebe2a2f940ad1e14, it fails in CI

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] `yarn test` completes successfully
- [ ] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
