### PR TITLE
fix: use node script in place of sed #568

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ publish:
 	git checkout master
 	git pull
 	yarn install --frozen-lockfile
-	sed -i '' -e "s/CLIENT_LIB_VERSION = '.*'/CLIENT_LIB_VERSION = '$(VERSION)'/" packages/core/src/impl/version.ts
+	node scripts/change-version.js
 	yarn run build
 	yarn run test
 	@echo "Publishing $(VERSION)..."

--- a/scripts/change-version.js
+++ b/scripts/change-version.js
@@ -1,0 +1,16 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const {readFileSync, writeFileSync} = require('fs')
+const VERSION = process.env.VERSION
+
+if (!VERSION) {
+  console.error('VERSION environment variable is not defined!')
+  process.exit(1)
+}
+
+const fileName = __dirname + '/../packages/core/src/impl/version.ts'
+const content = readFileSync(fileName, 'utf-8')
+const updatedVersion = content.replace(
+  /CLIENT_LIB_VERSION = '[^']*'/,
+  `CLIENT_LIB_VERSION = '${VERSION}'`
+)
+writeFileSync(fileName, updatedVersion, 'utf8')


### PR DESCRIPTION
Fixes #568

## Proposed Changes
Simple node script is used to do the same job that `sed` was intended to do, the code is now independent on platform (Unix, Mac).

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
