### PR TITLE
fix(docs): rename Headers to HttpHeaders to avoid clash with DOM's Headers type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 1. [#567](https://github.com/influxdata/influxdb-client-js/pull/567): Repair generated API documentation so that links between packages are rendered.
+1. [#570](https://github.com/influxdata/influxdb-client-js/pull/570): Rename Headers to HttpHeaders to avoid clash with DOM's Headers type.
 
 ## 1.29.0 [2022-08-25]
 

--- a/packages/core/src/results/CommunicationObserver.ts
+++ b/packages/core/src/results/CommunicationObserver.ts
@@ -2,14 +2,18 @@ import {Cancellable} from './Cancellable'
 /**
  * Type of HTTP headers.
  */
-export type Headers = {[header: string]: string | string[] | undefined}
+export type HttpHeaders = {[header: string]: string | string[] | undefined}
+export {HttpHeaders as Headers}
 
 /**
  * Informs about a start of response processing.
  * @param headers - response HTTP headers
  * @param statusCode - response status code
  */
-export type ResponseStartedFn = (headers: Headers, statusCode?: number) => void
+export type ResponseStartedFn = (
+  headers: HttpHeaders,
+  statusCode?: number
+) => void
 
 /**
  * Observes communication with the server.

--- a/scripts/fix-extracted-api-files.js
+++ b/scripts/fix-extracted-api-files.js
@@ -15,8 +15,6 @@ const mappedReferences = {
   // defect in api-extractor naming https://github.com/microsoft/rushstack/issues/3629
   '@influxdata/influxdb-client!FLUX_VALUE':
     '@influxdata/influxdb-client!FLUX_VALUE:var',
-  '@influxdata/influxdb-client!Headers:type':
-    '@influxdata/influxdb-client!Headers_2:type',
 }
 
 const markdownLinkRE = /\[([^\]]*)\]\(([^)]*)\)/g


### PR DESCRIPTION
This PR renames the client's `Headers` type to `HttpHeaders` in order to avoid clashing with a built-in DOM Headers type. `HttpHeaders` are also exported as `Headers`, so there is no backward-compatibility introduced herein.

This change also fixes the model of the generated API documentation (created by api-extractor), the client's HttpHeaders now has a unique canonical name that is referenceable.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `yarn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
