### PR TITLE
fix(core): repair deserialization of empty string to boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 1. [#567](https://github.com/influxdata/influxdb-client-js/pull/567): Repair generated API documentation so that links between packages are rendered.
 1. [#570](https://github.com/influxdata/influxdb-client-js/pull/570): Rename Headers to HttpHeaders to avoid clash with DOM's Headers type.
+1. [#578](https://github.com/influxdata/influxdb-client-js/pull/578): Repair deserialization of a missing boolean value.
 
 ## 1.29.0 [2022-08-25]
 

--- a/packages/core/src/results/FluxTableColumn.ts
+++ b/packages/core/src/results/FluxTableColumn.ts
@@ -56,7 +56,7 @@ const identity = (x: string): any => x
  * See {@link https://docs.influxdata.com/influxdb/latest/reference/syntax/annotated-csv/#data-types }
  */
 export const typeSerializers: Record<ColumnType, (val: string) => any> = {
-  boolean: (x: string): any => x === 'true',
+  boolean: (x: string): any => (x === '' ? null : x === 'true'),
   unsignedLong: (x: string): any => (x === '' ? null : +x),
   long: (x: string): any => (x === '' ? null : +x),
   double(x: string): any {

--- a/packages/core/test/unit/results/FluxTableMetaData.test.ts
+++ b/packages/core/test/unit/results/FluxTableMetaData.test.ts
@@ -115,6 +115,7 @@ describe('FluxTableMetaData', () => {
   const serializationTable: Array<[ColumnType | undefined, string, any]> = [
     ['boolean', 'false', false],
     ['boolean', 'true', true],
+    ['boolean', '', null],
     ['unsignedLong', '1', 1],
     ['unsignedLong', '', null],
     ['long', '1', 1],


### PR DESCRIPTION
Fixes #578


## Proposed Changes

Empty boolean value in a flux csv response is herein by default serialized to `null`, i.e. the same way as other types are.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
