### PR TITLE
chore(docs): repair doc links to point to latest API docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Other
 
 1. [#571](https://github.com/influxdata/influxdb-client-js/pull/571): Automate APIs generator, switch to @influxdata/oats.
+1. [#580](https://github.com/influxdata/influxdb-client-js/pull/580): Repair doc links to point to latest API docs.
 
 ## 1.29.0 [2022-08-25]
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository contains the reference JavaScript client for InfluxDB 2.x. This 
 
 This section contains links to the client library documentation.
 
-- [Product documentation](https://docs.influxdata.com/influxdb/v2.1/api-guide/client-libraries/nodejs/), [Getting Started](#usage)
+- [Product documentation](https://docs.influxdata.com/influxdb/latest/api-guide/client-libraries/nodejs/), [Getting Started](#usage)
 - [Examples](examples#influxdb-client-examples)
 - [API Reference](https://influxdata.github.io/influxdb-client-js/influxdb-client.html)
 - [Changelog](CHANGELOG.md)

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,9 +11,9 @@ This directory contains javascript and typescript examples for node.js, browser,
   - [write.mjs](./write.mjs)
     Write data points to InfluxDB.
   - [query.ts](./query.ts)
-    Query InfluxDB with [Flux](https://docs.influxdata.com/influxdb/v2.1/get-started/).
+    Query InfluxDB with [Flux](https://docs.influxdata.com/influxdb/latest/get-started/).
   - [queryWithParams.ts](./queryWithParams.ts)
-    Supply parameters to a [Flux](https://docs.influxdata.com/influxdb/v2.1/get-started/) query.
+    Supply parameters to a [Flux](https://docs.influxdata.com/influxdb/latest/get-started/) query.
   - [ping.mjs](./ping.mjs)
     Check status of InfluxDB server.
   - [createBucket.mjs](./createBucket.mjs)
@@ -23,7 +23,7 @@ This directory contains javascript and typescript examples for node.js, browser,
   - [influxdb-1.8.ts](./influxdb-1.8.ts)
     How to use forward compatibility APIs from InfluxDB 1.8.
   - [rxjs-query.ts](./rxjs-query.ts)
-    Use [RxJS](https://rxjs.dev/) to query InfluxDB with [Flux](https://docs.influxdata.com/influxdb/v2.1/get-started/).
+    Use [RxJS](https://rxjs.dev/) to query InfluxDB with [Flux](https://docs.influxdata.com/influxdb/latest/get-started/).
   - [writeAdvanced.mjs](./writeAdvanced.mjs)
     Shows how to control the way of how data points are written to InfluxDB.
   - [follow-redirects.mjs](./follow-redirects.mjs)
@@ -37,5 +37,5 @@ This directory contains javascript and typescript examples for node.js, browser,
     The local HTTP server serves all files from this git repository and also proxies requests
     to a configured influxDB database, see [scripts/server.js](./scripts/server.js) for details.
 - Deno examples
-  - [query.deno.ts](./query.deno.ts) shows how to query InfluxDB with [Flux](https://docs.influxdata.com/influxdb/v2.1/get-started/).
+  - [query.deno.ts](./query.deno.ts) shows how to query InfluxDB with [Flux](https://docs.influxdata.com/influxdb/latest/get-started/).
     It is almost the same as node's [query.ts](./query.ts) example, the difference is the import statement that works in [deno](https://deno.land) and built-in typescript support.

--- a/examples/ping.mjs
+++ b/examples/ping.mjs
@@ -3,7 +3,7 @@
 This example shows how to check state InfluxDB instance.
 InfluxDB OSS APIs are available through '@influxdata/influxdb-client-apis' package.
 
-See https://docs.influxdata.com/influxdb/v2.1/api/
+See https://docs.influxdata.com/influxdb/latest/api/
 */
 import {InfluxDB} from '@influxdata/influxdb-client'
 import {PingAPI} from '@influxdata/influxdb-client-apis'

--- a/packages/apis/DEVELOPMENT.md
+++ b/packages/apis/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # influxdb-client-apis
 
-Contains generated client APIs for InfluxDB v2.1. See https://github.com/influxdata/influxdb-client-js to know more.
+Contains generated client APIs for InfluxDB v2.x. See https://github.com/influxdata/influxdb-client-js to know more.
 
 ## Build
 

--- a/packages/apis/README.md
+++ b/packages/apis/README.md
@@ -1,3 +1,3 @@
 # @influxdata/influxdb-client-apis
 
-Contains client APIs for InfluxDB v2.1. See https://github.com/influxdata/influxdb-client-js to know more.
+Contains client APIs for InfluxDB v2.x. See https://github.com/influxdata/influxdb-client-js to know more.


### PR DESCRIPTION
This PR repairs doc links to point to the **latest** API docs, it was 2.1 before this PR. It is herein changed to `2.x` in texts and `latest` in URLs.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
