### PR TITLE
fix(core): fix unhandled promise rejection in write retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 1. [#588](https://github.com/influxdata/influxdb-client-js/pull/588): Allow to pause/resume flux query result communication observer.
 
+### Bug Fixes
+
+1. [#604](https://github.com/influxdata/influxdb-client-js/pull/604): Fix unhandled promise rejection in write retry.
+
 ## 1.30.0 [2022-09-29]
 
 ### Features

--- a/packages/core/src/impl/RetryBuffer.ts
+++ b/packages/core/src/impl/RetryBuffer.ts
@@ -132,7 +132,7 @@ export default class RetryBuffer {
       if (toRetry) {
         this.retryLines(toRetry.lines, toRetry.retryCount, toRetry.expires)
           .catch(() => {
-            /* error is already logged */
+            /* error is already logged, it must be caught */
           })
           .finally(() => {
             // schedule next retry execution

--- a/packages/core/src/impl/RetryBuffer.ts
+++ b/packages/core/src/impl/RetryBuffer.ts
@@ -130,16 +130,16 @@ export default class RetryBuffer {
     this._timeoutHandle = setTimeout(() => {
       const toRetry = this.removeLines()
       if (toRetry) {
-        this.retryLines(
-          toRetry.lines,
-          toRetry.retryCount,
-          toRetry.expires
-        ).finally(() => {
-          // schedule next retry execution
-          if (this.first) {
-            this.scheduleRetry(this.first.retryTime - Date.now())
-          }
-        })
+        this.retryLines(toRetry.lines, toRetry.retryCount, toRetry.expires)
+          .catch(() => {
+            /* error is already logged */
+          })
+          .finally(() => {
+            // schedule next retry execution
+            if (this.first) {
+              this.scheduleRetry(this.first.retryTime - Date.now())
+            }
+          })
       } else {
         this._timeoutHandle = undefined
       }

--- a/packages/core/test/unit/WriteApi.test.ts
+++ b/packages/core/test/unit/WriteApi.test.ts
@@ -11,7 +11,7 @@ import {
   DEFAULT_WriteOptions,
   PointSettings,
 } from '../../src'
-import {collectLogging, CollectedLogs} from '../util'
+import {collectLogging, CollectedLogs, unhandledRejections} from '../util'
 import {Log} from '../../src/util/logger'
 import {waitForCondition} from './util/waitForCondition'
 import zlib from 'zlib'
@@ -61,10 +61,12 @@ function createWriteCounters(): WriteListeners {
 describe('WriteApi', () => {
   beforeEach(() => {
     nock.disableNetConnect()
+    unhandledRejections.before()
   })
   afterEach(() => {
     nock.cleanAll()
     nock.enableNetConnect()
+    unhandledRejections.after()
   })
   describe('simple', () => {
     let subject: WriteApi

--- a/packages/core/test/unit/impl/RetryBuffer.test.ts
+++ b/packages/core/test/unit/impl/RetryBuffer.test.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai'
 import RetryBuffer from '../../../src/impl/RetryBuffer'
-import {CollectedLogs, collectLogging} from '../../util'
+import {CollectedLogs, collectLogging, unhandledRejections} from '../../util'
 import {waitForCondition} from '../util/waitForCondition'
 
 describe('RetryBuffer', () => {
@@ -8,9 +8,11 @@ describe('RetryBuffer', () => {
   beforeEach(() => {
     logs = collectLogging.decorate()
     // logs = collectLogging.replace()
+    unhandledRejections.before()
   })
   afterEach(async () => {
     collectLogging.after()
+    unhandledRejections.after()
   })
   it('stores lines for future retry', async () => {
     const input = [] as Array<[string[], number]>

--- a/packages/core/test/util.ts
+++ b/packages/core/test/util.ts
@@ -1,3 +1,4 @@
+import {expect} from 'chai'
 import {setLogger} from '../src/util/logger'
 
 let previous: any
@@ -54,7 +55,7 @@ function addRejection(e: any) {
 }
 
 /**
- * A simple guerd used by tests to check no unhandled promise rejection occurs.
+ * Used by unit tests to check that no unhandled promise rejection occurs.
  */
 export const unhandledRejections = {
   before(): void {
@@ -63,5 +64,6 @@ export const unhandledRejections = {
   },
   after(): void {
     process.off('unhandledRejection', addRejection)
+    expect(rejections, 'Unhandled Promise rejections detected').deep.equals([])
   },
 }

--- a/packages/core/test/util.ts
+++ b/packages/core/test/util.ts
@@ -47,3 +47,21 @@ export const collectLogging = {
     }
   },
 }
+
+let rejections: Array<any> = []
+function addRejection(e: any) {
+  rejections.push(e)
+}
+
+/**
+ * A simple guerd used by tests to check no unhandled promise rejection occurs.
+ */
+export const unhandledRejections = {
+  before(): void {
+    rejections = []
+    process.on('unhandledRejection', addRejection)
+  },
+  after(): void {
+    process.off('unhandledRejection', addRejection)
+  },
+}


### PR DESCRIPTION
Fixes #593

## Proposed Changes
- write API and write retry tests were enhanced to check for unhandled promise rejections, because the unit test framework (mocha) silently swallows promise rejections. Unhandled promise rejections normally terminate node.js process (unless '
- retry buffer was fixed to silently consume write failures before re-scheduling it, it was this way correctly in 1.29 and changed in 1.30 in #547, the following lines were causing it: in https://github.com/influxdata/influxdb-client-js/pull/547/files#diff-16970e3a239345f536ebc0fa851bf7d9732aa1f22160fe5667a9e1bf7de42a52L100-L108

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
