### PR TITLE
chore(ci): upgrade recommended node version to 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,12 +103,6 @@ workflows:
           filters:
             branches:
               ignore: gh-pages
-      - tests:
-          name: 'tests-node-19'
-          image: 'cimg/node:19.1'
-          filters:
-            branches:
-              ignore: gh-pages
       - coverage:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,25 @@ workflows:
   build:
     jobs:
       - tests:
+          name: 'tests-node-18'
+          filters:
+            branches:
+              ignore: gh-pages
+      - tests:
+          name: 'tests-node-14'
+          image: 'cimg/node:14.21'
+          filters:
+            branches:
+              ignore: gh-pages
+      - tests:
+          name: 'tests-node-16'
+          image: 'cimg/node:16.18'
+          filters:
+            branches:
+              ignore: gh-pages
+      - tests:
+          name: 'tests-node-19'
+          image: 'cimg/node:19.1'
           filters:
             branches:
               ignore: gh-pages
@@ -96,7 +115,7 @@ workflows:
               ignore: gh-pages
       - deploy-preview:
           requires:
-            - tests
+            - tests-node-18
             - coverage
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
     parameters:
       image:
         type: string
-        default: &default-image 'cimg/node:16.17'
+        default: &default-image 'cimg/node:18.11'
     docker:
       - image: << parameters.image >>
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 1. [#592](https://github.com/influxdata/influxdb-client-js/pull/592): Allow to receive query results using for-await loop.
 
+### Other
+
+1. [#624](https://github.com/influxdata/influxdb-client-js/pull/624): Upgrade to the latest node v18 LTS.
+
 ### Breaking Changes
 
 1. [#592](https://github.com/influxdata/influxdb-client-js/pull/592): The client packages newly require ES2018 runtime (was ES2015). The javascript code now needs [async generators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator#browser_compatibility) and [for-await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of#browser_compatibility) loop. At least the latest node 14 is required because of mature support for iterable http response. Deno and all current modern browsers support ES2018 for years back. This change shoudn't cause any harm in existing installations. In case of troubles, configure your project with babel ES2018 preset to produce ES2015 code.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ To contribute code, fork the repository, apply changes and submit a pull request
 
 Requirements:
 
-- Node.js v16 LTS
+- Node.js v18 LTS
   ```bash
   node --version
   ```

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ To contribute code, fork the repository, apply changes and submit a pull request
 
 Requirements:
 
-- Node.js v18 LTS
+- Node.js LTS version, v18 recommended
   ```bash
   node --version
   ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@ This directory contains javascript and typescript examples for node.js, browser,
 
 - Node.js examples
   - Prerequisites
-    - [node](https://nodejs.org/en/) installed, at least version 16 is recommended
+    - [node](https://nodejs.org/en/) installed, at least version 18 is recommended
     - Run `npm install` in this directory
     - Change variables in [./env.mjs](env.mjs) to configure connection to your InfluxDB instance. The file can be used as-is against a new [docker InfluxDB v2.3 OSS GA installation](https://docs.influxdata.com/influxdb/v2.3/get-started/)
   - Examples are executable. If it does not work for you, run `npm run esr EXAMPLE.ts`.


### PR DESCRIPTION
Fixes #623 

## Proposed Changes

The Node v18 is new LTS version. For more info https://github.com/nodejs/Release#release-schedule.

1. Upgraded recommended node version to 18 (LTS)
2. Test client on actual maintained version of nodejs - `14`, `16`, `18`

https://github.com/nodejs/Release#release-schedule

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `yarn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
