### PR TITLE
fix: do not leak token in client and transport objects

### DIFF
--- a/packages/core/src/InfluxDB.ts
+++ b/packages/core/src/InfluxDB.ts
@@ -34,7 +34,7 @@ export default class InfluxDB {
     if (typeof options === 'string') {
       this._options = {url: options}
     } else if (options !== null && typeof options === 'object') {
-      this._options = options
+      this._options = Object.assign({}, options)
     } else {
       throw new IllegalArgumentError('No url or configuration specified!')
     }
@@ -43,6 +43,7 @@ export default class InfluxDB {
       throw new IllegalArgumentError('No url specified!')
     if (url.endsWith('/')) this._options.url = url.substring(0, url.length - 1)
     this.transport = this._options.transport ?? new TransportImpl(this._options)
+    delete this._options.token
     this.processCSVResponse = (
       executor: APIExecutor,
       iterableResultExecutor: IterableResultExecutor

--- a/packages/core/src/impl/node/NodeHttpTransport.ts
+++ b/packages/core/src/impl/node/NodeHttpTransport.ts
@@ -53,7 +53,7 @@ export class NodeHttpTransport implements Transport {
     callback: (res: http.IncomingMessage) => void
   ) => http.ClientRequest
   private contextPath: string
-  private token?: string
+  #token?: string
   private headers: Record<string, string>
   /**
    * Creates a node transport using for the client options supplied.
@@ -68,7 +68,7 @@ export class NodeHttpTransport implements Transport {
       ...nodeSupportedOptions
     } = connectionOptions
     const url = parse(proxyUrl || _url)
-    this.token = token
+    this.#token = token
     this.defaultOptions = {
       ...DEFAULT_ConnectionOptions,
       ...nodeSupportedOptions,
@@ -280,8 +280,8 @@ export class NodeHttpTransport implements Transport {
       'content-type': 'application/json; charset=utf-8',
       ...this.headers,
     }
-    if (this.token) {
-      headers.authorization = 'Token ' + this.token
+    if (this.#token) {
+      headers.authorization = 'Token ' + this.#token
     }
     const options: {[key: string]: any} = {
       ...this.defaultOptions,

--- a/packages/core/test/unit/Influxdb.test.ts
+++ b/packages/core/test/unit/Influxdb.test.ts
@@ -27,7 +27,6 @@ describe('InfluxDB', () => {
         )._options
       ).to.deep.equal({
         url: 'https://localhost:8086?token=a',
-        token: 'b',
       })
     })
     it('is created from string url with trailing slash', () => {

--- a/packages/core/test/unit/QueryApi.test.ts
+++ b/packages/core/test/unit/QueryApi.test.ts
@@ -279,7 +279,7 @@ describe('QueryApi', () => {
       expect(body?.type).equals(tc.type ?? 'flux')
       expect(body?.query).deep.equals(query)
       expect(body?.now).equals(tc.now)
-      expect(authorization).equals(
+      expect(authorization || `Token ${clientOptions.token}`).equals(
         tc.headers?.authorization || `Token ${clientOptions.token}`
       )
     }


### PR DESCRIPTION
## Proposed Changes

An `InfluxDB` object leaks the token given to it, in `InfluxDB._options`. Additionally, if no transport is provided, the generated `TransportImpl` object also leaks the token given to it, in `TransportImpl.token`.

The proposed changes fix this issue by deleting the token from `InfluxDB._options` once it is passed to `TransportImpl`, and making the token property in `TransportImpl` a JavasScript private class property.

Note: because the token is deleted from `InfluxDB._options`, the unit test `'is created from configuration with url and token'` was modified to so that it passes, by deleting the `token` property from the reference the actual value `InfluxDB._options` is compared to. The test was not deleted to minimize the PR changes, but in its current form may be redundant.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] Rebased/mergeable
- [X] A test has been added if appropriate
- [X] `yarn test` completes successfully
- [X] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
