### PR TITLE
feat: add headers to http error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Features:
 
 1. [#1005](https://github.com/influxdata/influxdb-client-js/pull/1005): Token stored as a private class property.
-2. [1019](https://github.com/influxdata/influxdb-client-js/pull/1019/): Propagates headers from HTTP response when an error is returned from the server.
+2. [#1019](https://github.com/influxdata/influxdb-client-js/pull/1019): Propagates headers from HTTP response when an error is returned from the server.
 
 ### CI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Features:
 
 1. [#1005](https://github.com/influxdata/influxdb-client-js/pull/1005): Token stored as a private class property.
+2. [1019](https://github.com/influxdata/influxdb-client-js/pull/1019/): Propagates headers from HTTP response when an error is returned from the server.
 
 ### CI
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,3 +1,5 @@
+import {HttpHeaders} from './results'
+
 /**
  * Strategy for calculating retry delays.
  */
@@ -54,6 +56,8 @@ export class HttpError extends Error implements RetriableDecision {
   /** json error response */
   public json: any
 
+  public headers?: HttpHeaders | undefined
+
   /* istanbul ignore next because of super() not being covered*/
   constructor(
     readonly statusCode: number,
@@ -61,10 +65,14 @@ export class HttpError extends Error implements RetriableDecision {
     readonly body?: string,
     retryAfter?: string | undefined | null,
     readonly contentType?: string | undefined | null,
-    message?: string
+    message?: string,
+    headers?: HttpHeaders | undefined
   ) {
     super()
     Object.setPrototypeOf(this, HttpError.prototype)
+
+    this.headers = headers
+
     if (message) {
       this.message = message
     } else if (body) {

--- a/packages/core/src/impl/WriteApiImpl.ts
+++ b/packages/core/src/impl/WriteApiImpl.ts
@@ -180,9 +180,11 @@ export default class WriteApiImpl implements WriteApi {
       }
       return new Promise<void>((resolve, reject) => {
         let responseStatusCode: number | undefined
+        let headers: Headers | undefined
         const callbacks = {
           responseStarted(_headers: Headers, statusCode?: number): void {
             responseStatusCode = statusCode
+            headers = _headers
           },
           error(error: Error): void {
             // call the writeFailed listener and check if we can retry
@@ -245,7 +247,10 @@ export default class WriteApiImpl implements WriteApi {
                 responseStatusCode,
                 message,
                 undefined,
-                '0'
+                '0',
+                undefined,
+                undefined,
+                headers
               )
               error.message = message
               callbacks.error(error)

--- a/packages/core/src/impl/browser/FetchTransport.ts
+++ b/packages/core/src/impl/browser/FetchTransport.ts
@@ -153,12 +153,15 @@ export default class FetchTransport implements Transport {
         }
       } catch (e) {
         Log.warn('Unable to receive error body', e)
+
         throw new HttpError(
           response.status,
           response.statusText,
           undefined,
           response.headers.get('retry-after'),
-          response.headers.get('content-type')
+          response.headers.get('content-type'),
+          undefined,
+          getResponseHeaders(response)
         )
       }
       throw new HttpError(
@@ -166,7 +169,9 @@ export default class FetchTransport implements Transport {
         response.statusText,
         text,
         response.headers.get('retry-after'),
-        response.headers.get('content-type')
+        response.headers.get('content-type'),
+        undefined,
+        getResponseHeaders(response)
       )
     }
   }

--- a/packages/core/src/impl/node/NodeHttpTransport.ts
+++ b/packages/core/src/impl/node/NodeHttpTransport.ts
@@ -356,7 +356,9 @@ export class NodeHttpTransport implements Transport {
             res.statusMessage,
             body,
             res.headers['retry-after'],
-            res.headers['content-type']
+            res.headers['content-type'],
+            undefined,
+            res.headers
           )
         )
       })

--- a/packages/core/test/unit/errors.test.ts
+++ b/packages/core/test/unit/errors.test.ts
@@ -37,6 +37,13 @@ describe('errors', () => {
     expect(new RequestTimedOutError().message).is.not.empty
     expect(new AbortError().message).is.not.empty
   })
+  describe('HttpError Headers Property is defined', () => {
+    expect(
+      new HttpError(200, 'OK', 'body', '10', 'text/plain', 'message', {
+        header: 'value',
+      }).headers
+    ).is.deep.equal({header: 'value'})
+  })
   describe('retriable errors', () => {
     const testSetOK = [
       new HttpError(503, 'Service Unavailable'),


### PR DESCRIPTION
Fixes  https://github.com/influxdata/influxdb-client-js/issues/1018

## Proposed Changes

Adds headers to the HTTP error response.  

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
