### PR TITLE
docs: adds httpErrorHandled example and integration test for HttpError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 1. [#1005](https://github.com/influxdata/influxdb-client-js/pull/1005): Token stored as a private class property.
 2. [#1019](https://github.com/influxdata/influxdb-client-js/pull/1019): Propagates headers from HTTP response when an error is returned from the server.
+3. [#1020](https://github.com/influxdata/influxdb-client-js/pull/1020): Adds example of working with `HttpError` response.
 
 ### CI
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,6 +30,8 @@ This directory contains javascript and typescript examples for node.js, browser,
     Shows how to configure the client to follow HTTP redirects.
   - [delete.ts](./delete.ts)
     Shows how to delete data from a bucket.
+  - [httpErrorHandled.mjs](./httpErrorHandled.mjs)
+    Shows handling HTTP Error response. 
 - Browser examples
   - Change `token, org, bucket, username, password` variables in [./env_browser.mjs](env_browser.mjs) to match your InfluxDB instance
   - Run `npm run browser`

--- a/examples/httpErrorHandled.mjs
+++ b/examples/httpErrorHandled.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+///////////////////////////////////////////////////////////
+// Shows how to handle InfluxDB write API - HTTP Errors. //
+// To be run against cloud account                       //
+///////////////////////////////////////////////////////////
+
+import {InfluxDB} from '@influxdata/influxdb-client'
+import {url, token, org, bucket} from './env.mjs'
+
+console.log('*** FORCE AND HANDLE HTTP ERROR ***')
+
+const writeApi = new InfluxDB({url, token}).getWriteApi(org, bucket, 'ns')
+
+try {
+  await writeApi.writeRecord('asdf') //invalid lineprotocol
+  await writeApi.close()
+} catch (e) {
+  if (e.statusCode !== 400) {
+    throw new Error(`Expected HTTP 400 but received ${e.statusCode}`)
+  }
+  console.log()
+  console.log('Handle HTTP Error')
+  console.log(`Caught expected HTTP ${e.statusCode}`)
+  console.log(`     At:             ${e.headers.date}`)
+  console.log(`     During request: ${e.headers['x-influxdb-request-id']}`)
+  console.log(`     On build:       ${e.headers['x-influxdb-build']}`)
+  console.log(`     Traceable:      ${e.headers['trace-id']}`)
+  console.log(
+    `     Can retry:      ${e._retryAfter === 0 ? false : e._retryAfter}`
+  )
+}

--- a/examples/package.json
+++ b/examples/package.json
@@ -9,8 +9,8 @@
     "esr": "esr"
   },
   "dependencies": {
-    "@influxdata/influxdb-client": "*",
-    "@influxdata/influxdb-client-apis": "*"
+    "@influxdata/influxdb-client": "link:../packages/core",
+    "@influxdata/influxdb-client-apis": "link:../packages/apis"
   },
   "devDependencies": {
     "@types/express": "^4.17.2",


### PR DESCRIPTION
## Proposed Changes

- Add an example of using recently added `HttpError` type
- Add an extra integration test working with this type

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `yarn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
