### PR TITLE
fix: handle 201 response from write endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.35.0 [unreleased]
 
+### Bug Fixes
+
+1. [#1044](https://github.com/influxdata/influxdb-client-js/pull/1044): Allow 201 status code in a write response.
+
 ## 1.34.0 [2024-07-26]
 
 ### Breaking Changes

--- a/packages/core/src/impl/WriteApiImpl.ts
+++ b/packages/core/src/impl/WriteApiImpl.ts
@@ -236,8 +236,9 @@ export default class WriteApiImpl implements WriteApi {
             reject(error)
           },
           complete(): void {
+            // InfluxDB v3 returns 201 for partial success
             // older implementations of transport do not report status code
-            if (responseStatusCode == 204 || responseStatusCode == undefined) {
+            if (responseStatusCode == 204 || responseStatusCode == 201 || responseStatusCode == undefined) {
               self.writeOptions.writeSuccess.call(self, lines)
               self.retryStrategy.success()
               resolve()

--- a/packages/core/src/impl/WriteApiImpl.ts
+++ b/packages/core/src/impl/WriteApiImpl.ts
@@ -238,7 +238,11 @@ export default class WriteApiImpl implements WriteApi {
           complete(): void {
             // InfluxDB v3 returns 201 for partial success
             // older implementations of transport do not report status code
-            if (responseStatusCode == 204 || responseStatusCode == 201 || responseStatusCode == undefined) {
+            if (
+              responseStatusCode == 204 ||
+              responseStatusCode == 201 ||
+              responseStatusCode == undefined
+            ) {
               self.writeOptions.writeSuccess.call(self, lines)
               self.retryStrategy.success()
               resolve()


### PR DESCRIPTION
InfluxDB v3 returns 201 for partial write errors.

Helps internal issue https://github.com/influxdata/idpe/issues/18710

## Proposed Changes

_Briefly describe your proposed changes:_

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] `yarn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
